### PR TITLE
Allow setting the initial commit for the wptsync upstream command.

### DIFF
--- a/sync/command.py
+++ b/sync/command.py
@@ -72,7 +72,8 @@ def get_parser():
     parser_bug.set_defaults(func=do_bug)
 
     parser_upstream = subparsers.add_parser("upstream", help="Run the upstreaming code")
-    parser_upstream.add_argument("rev", nargs="?", help="Revision to upstream to")
+    parser_upstream.add_argument("--base-rev", help="Base revision for upstreaming")
+    parser_upstream.add_argument("--rev", help="Revision to upstream to")
     parser_upstream.set_defaults(func=do_upstream)
 
     parser_delete = subparsers.add_parser("delete", help="Delete a sync by bug number or pr")
@@ -219,11 +220,11 @@ def do_bug(git_gecko, git_wpt, bug, *args, **kwargs):
 def do_upstream(git_gecko, git_wpt, *args, **kwargs):
     import update
     rev = kwargs["rev"]
-
+    base_rev = kwargs["base_rev"]
     if rev is None:
         rev = git_gecko.commit(env.config["gecko"]["refs"]["mozilla-inbound"]).hexsha
 
-    update.update_upstream(git_gecko, git_wpt, rev)
+    update.update_upstream(git_gecko, git_wpt, rev, base_rev=base_rev)
 
 
 @with_lock

--- a/sync/handlers.py
+++ b/sync/handlers.py
@@ -130,6 +130,9 @@ class PushHandler(Handler):
             repo_name = repo.rsplit("/", 1)[1]
         else:
             repo_name = repo
+        # Commands can override the base rev
+        base_rev = body.get("_wptsync", {}).get("base_rev")
+
         # Not sure if it's ever possible to get multiple heads here in a way that
         # matters for us
         rev = body["payload"]["data"]["heads"][0]
@@ -143,7 +146,7 @@ class PushHandler(Handler):
             if gecko_repo(git_gecko, git_rev) is None:
                 logger.info("Skipping commit as it isn't in a branch we track")
                 return
-        upstream.push(git_gecko, git_wpt, repo_name, rev)
+        upstream.push(git_gecko, git_wpt, repo_name, rev, base_rev=base_rev)
 
 
 class TaskHandler(Handler):


### PR DESCRIPTION
This is mostly for the transient initial case where we assume that we are up to date with
upstream on central. But we probably actually aren't so in this case we want to allow
running upstreaming over some larger range of commits. Because the base commit isn't
in the normal pulse message we get, we smuggle the base commit though a _wptsync field
when invoking the handler from a command.