### PR TITLE
Don't update the last sync point if it would make it earlier.

### DIFF
--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -703,7 +703,8 @@ def push(git_gecko, git_wpt, repository_name, hg_rev, raise_on_error=False,
     else:
         landed_syncs = set()
 
-    last_sync_point.commit = rev
+    if not git_gecko.is_ancestor(rev, last_sync_point.commit.sha1):
+        last_sync_point.commit = rev
 
     return pushed_syncs, landed_syncs, failed_syncs
 


### PR DESCRIPTION
If we override the last sync point for wptsync upstream it's possible
to end up in a situation where the revision we sync to is earlier than
the current last sync point. In this case we don't want to update the
stored last sync point or we will accidentally redo work.