### PR TITLE
Use combined PR status to determine success. (#16)

### DIFF
--- a/sync/base.py
+++ b/sync/base.py
@@ -702,6 +702,17 @@ class SyncProcess(object):
         self.data["pr"] = value
 
     @property
+    def last_pr_check(self):
+        return self.data.get("last-pr-check", {})
+
+    @last_pr_check.setter
+    def last_pr_check(self, value):
+        if value is not None:
+            self.data["last-pr-check"] = value
+        else:
+            del self.data["last-pr-check"]
+
+    @property
     def error(self):
         return self.data.get("error")
 

--- a/sync/update.py
+++ b/sync/update.py
@@ -58,10 +58,8 @@ def schedule_status_task(commit, status):
 def update_for_status(pr):
     commits = pr.get_commits()
     head = commits.reversed[0]
-    status = None
-    for status in head.get_combined_status():
+    for status in head.get_combined_status().statuses:
         if (status.context != "upstream/gecko"):
-            status = status
             schedule_status_task(head, status)
             return
 

--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -13,6 +13,8 @@ def test_new_wpt_pr(env, git_gecko, git_wpt, pull_request, set_pr_status, mock_m
 
     downstream.new_wpt_pr(git_gecko, git_wpt, pr)
     sync = load.get_pr_sync(git_gecko, git_wpt, pr["number"])
+    env.gh_wpt.set_status(pr["number"], "success", "http://test/", "description",
+                          "continuous-integration/travis-ci/pr")
     assert sync is not None
     assert sync.status == "open"
     assert len(sync.gecko_commits) == 1
@@ -33,6 +35,7 @@ def test_wpt_pr_status_success(git_gecko, git_wpt, pull_request, set_pr_status,
     downstream.new_wpt_pr(git_gecko, git_wpt, pr)
     sync = set_pr_status(pr, "success")
     try_push = sync.latest_try_push
+    assert sync.last_pr_check == {"state": "success", "sha": pr.head}
     assert try_push is not None
     assert try_push.status == "open"
     assert try_push.try_rev == hg_gecko_try.log("-l1", "--template={node}")

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -168,12 +168,12 @@ def test_land_pr_after_status_change(env, git_gecko, git_wpt, hg_gecko_upstream,
     sync = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
     env.gh_wpt.get_pull(sync.pr).mergeable = True
 
-    env.gh_wpt.set_status(sync.pr, "failed", "http://test/", "tests failed",
+    env.gh_wpt.set_status(sync.pr, "failure", "http://test/", "tests failed",
                           "continuous-integration/travis-ci/pr")
     upstream.status_changed(git_gecko, git_wpt, sync,
                             "continuous-integration/travis-ci/pr",
-                            "failed", "http://test/", sync.wpt_commits.head.sha1)
-
+                            "failure", "http://test/", sync.wpt_commits.head.sha1)
+    assert sync.last_pr_check == {"state": "failure", "sha": sync.wpt_commits.head.sha1}
     hg_gecko_upstream.bookmark("mozilla/central", "-r", rev)
 
     pushed, landed, failed = upstream.push(git_gecko, git_wpt, "central", rev,
@@ -185,6 +185,6 @@ def test_land_pr_after_status_change(env, git_gecko, git_wpt, hg_gecko_upstream,
     upstream.status_changed(git_gecko, git_wpt, sync,
                             "continuous-integration/travis-ci/pr",
                             "success", "http://test/", sync.wpt_commits.head.sha1)
-
+    assert sync.last_pr_check == {"state": "success", "sha": sync.wpt_commits.head.sha1}
     assert sync.gecko_landed()
     assert sync.status == "complete"


### PR DESCRIPTION
The sequence of GitHub status events that trigger handlers.handle_status
can sometimes include many "success" statuses. We don't want to
report success for each such event, only for the overall success of all
checks. We can do this by requesting combined status from the GitHub
API every time we see a non-"pending" status event.

Similarly, when downstreaming, we should only trigger a try
push once the combined status is "success".