### PR TITLE
Add facility to wait for a specific gecko hg rev to appear when updating repos.

### DIFF
--- a/sync/handlers.py
+++ b/sync/handlers.py
@@ -137,15 +137,11 @@ class PushHandler(Handler):
         # matters for us
         rev = body["payload"]["data"]["heads"][0]
         logger.info("Handling commit %s to repo %s" % (rev, repo))
-        update_repositories(git_gecko, None)
-        try:
-            git_rev = git_gecko.cinnabar.hg2git(rev)
-        except ValueError:
-            pass
-        else:
-            if gecko_repo(git_gecko, git_rev) is None:
-                logger.info("Skipping commit as it isn't in a branch we track")
-                return
+        update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
+        git_rev = git_gecko.cinnabar.hg2git(rev)
+        if gecko_repo(git_gecko, git_rev) is None:
+            logger.info("Skipping commit as it isn't in a branch we track")
+            return
         upstream.push(git_gecko, git_wpt, repo_name, rev, base_rev=base_rev)
 
 

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -645,21 +645,7 @@ def update_sync(git_gecko, git_wpt, sync, raise_on_error=True):
 @base.entry_point("upstream")
 def push(git_gecko, git_wpt, repository_name, hg_rev, raise_on_error=False,
          base_rev=None):
-    i = 0
-    while True:
-        update_repositories(git_gecko, git_wpt, repository_name == "autoland")
-
-        try:
-            rev = git_gecko.cinnabar.hg2git(hg_rev)
-        except ValueError:
-            if i == 4:
-                raise
-            else:
-                i += 1
-                time.sleep(1 * (i + 1))
-        else:
-            break
-
+    rev = git_gecko.cinnabar.hg2git(hg_rev)
     last_sync_point = UpstreamSync.last_sync_point(git_gecko, repository_name)
     if last_sync_point.commit is None:
         # If we are just starting, default to the current mozilla central

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -2,6 +2,7 @@ import os
 
 from sync import landing, downstream, tree, trypush, upstream
 from sync import commit as sync_commit
+from sync.gitutils import update_repositories
 
 
 def test_upstream_commit(env, git_gecko, git_wpt, git_wpt_upstream, pull_request):
@@ -91,6 +92,7 @@ def test_landing_reapply(env, git_gecko, git_wpt, git_wpt_upstream, pull_request
     rev = upstream_gecko_commit(test_changes=test_changes, bug="1111",
                                 message="Add change1 file")
 
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
     pushed, _, _ = upstream.push(git_gecko, git_wpt, "inbound", rev,
                                  raise_on_error=True)
     sync_1 = pushed.pop()
@@ -110,6 +112,7 @@ def test_landing_reapply(env, git_gecko, git_wpt, git_wpt_upstream, pull_request
     rev = upstream_gecko_commit(test_changes=test_changes, bug="1112",
                                 message="Add change2 file")
 
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
     pushed, _, _ = upstream.push(git_gecko, git_wpt, "inbound", rev,
                                  raise_on_error=True)
     sync_2 = pushed.pop()
@@ -148,6 +151,8 @@ def test_landing_reapply(env, git_gecko, git_wpt, git_wpt_upstream, pull_request
     test_changes = {"change3": "CHANGE3\n"}
     rev = upstream_gecko_commit(test_changes=test_changes, bug="1113",
                                 message="Add change3 file")
+
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
     pushed, _, _ = upstream.push(git_gecko, git_wpt, "inbound", rev,
                                  raise_on_error=True)
 

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -1,4 +1,5 @@
 from sync import upstream
+from sync.gitutils import update_repositories
 
 
 def test_create_pr(env, git_gecko, git_wpt, upstream_gecko_commit):
@@ -7,6 +8,7 @@ def test_create_pr(env, git_gecko, git_wpt, upstream_gecko_commit):
     rev = upstream_gecko_commit(test_changes=test_changes, bug=bug,
                                 message="Change README")
 
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
     pushed, landed, failed = upstream.push(git_gecko, git_wpt, "inbound", rev,
                                            raise_on_error=True)
     assert len(pushed) == 1
@@ -42,6 +44,7 @@ def test_create_pr_backout(git_gecko, git_wpt, upstream_gecko_commit,
     rev = upstream_gecko_commit(test_changes=test_changes, bug=bug,
                                 message="Change README")
 
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
     upstream.push(git_gecko, git_wpt, "inbound", rev,
                   raise_on_error=True)
 
@@ -54,6 +57,7 @@ def test_create_pr_backout(git_gecko, git_wpt, upstream_gecko_commit,
 
     backout_rev = upstream_gecko_backout(rev, bug)
 
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
     upstream.push(git_gecko, git_wpt, "inbound", backout_rev, raise_on_error=True)
     sync = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
     assert sync.bug == "1234"
@@ -69,11 +73,13 @@ def test_create_pr_backout_reland(git_gecko, git_wpt, upstream_gecko_commit,
     rev = upstream_gecko_commit(test_changes=test_changes, bug=bug,
                                 message="Change README")
 
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
     upstream.push(git_gecko, git_wpt, "inbound", rev,
                   raise_on_error=True)
 
     backout_rev = upstream_gecko_backout(rev, bug)
 
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
     upstream.push(git_gecko, git_wpt, "inbound", backout_rev, raise_on_error=True)
 
     # Make some unrelated commit in the root
@@ -83,6 +89,7 @@ def test_create_pr_backout_reland(git_gecko, git_wpt, upstream_gecko_commit,
     relanding_rev = upstream_gecko_commit(test_changes=test_changes, bug=bug,
                                           message="Reland: Change README")
 
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
     upstream.push(git_gecko, git_wpt, "inbound", relanding_rev, raise_on_error=True)
 
     sync = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
@@ -102,6 +109,7 @@ def test_create_partial_backout_reland(git_gecko, git_wpt, upstream_gecko_commit
     rev1 = upstream_gecko_commit(test_changes={"README": "Change README again\n"}, bug=bug,
                                  message="Change README again")
 
+    update_repositories(git_gecko, git_wpt)
     upstream.push(git_gecko, git_wpt, "inbound", rev1,
                   raise_on_error=True)
 
@@ -115,6 +123,7 @@ def test_create_partial_backout_reland(git_gecko, git_wpt, upstream_gecko_commit
                                           bug=bug,
                                           message="Change README once more")
 
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=relanding_rev)
     upstream.push(git_gecko, git_wpt, "inbound", relanding_rev, raise_on_error=True)
 
     sync = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
@@ -132,6 +141,7 @@ def test_land_pr(env, git_gecko, git_wpt, hg_gecko_upstream, upstream_gecko_comm
     rev = upstream_gecko_commit(test_changes=test_changes, bug=bug,
                                 message="Change README")
 
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
     pushed, landed, failed = upstream.push(git_gecko, git_wpt, "inbound", rev,
                                            raise_on_error=True)
 
@@ -140,6 +150,7 @@ def test_land_pr(env, git_gecko, git_wpt, hg_gecko_upstream, upstream_gecko_comm
 
     hg_gecko_upstream.bookmark("mozilla/central", "-r", rev)
 
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
     pushed, landed, failed = upstream.push(git_gecko, git_wpt, "central", rev,
                                            raise_on_error=True)
 
@@ -157,6 +168,7 @@ def test_land_pr_after_status_change(env, git_gecko, git_wpt, hg_gecko_upstream,
     rev = upstream_gecko_commit(test_changes=test_changes, bug=bug,
                                 message="Change README")
 
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
     pushed, landed, failed = upstream.push(git_gecko, git_wpt, "inbound", rev,
                                            raise_on_error=True)
     sync = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
@@ -170,6 +182,7 @@ def test_land_pr_after_status_change(env, git_gecko, git_wpt, hg_gecko_upstream,
 
     hg_gecko_upstream.bookmark("mozilla/central", "-r", rev)
 
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
     pushed, landed, failed = upstream.push(git_gecko, git_wpt, "central", rev,
                                            raise_on_error=True)
 


### PR DESCRIPTION
I think this is required because there's a synchronisation delay between mozilla-unified and
the source repos. We want to deal with unified, but the events we are getting are based on the
source repos, so the commits haven't necessarily appeared when we run the handlers.