### PR TITLE
Use combined upstream status checks when checking if we can merge a PR.

### DIFF
--- a/sync/update.py
+++ b/sync/update.py
@@ -59,9 +59,8 @@ def update_for_status(pr):
     commits = pr.get_commits()
     head = commits.reversed[0]
     status = None
-    for status in head.get_statuses():
-        if (status.context == "continuous-integration/travis-ci/pr" and
-            status.state != "pending"):
+    for status in head.get_combined_status():
+        if (status.context != "upstream/gecko"):
             status = status
             schedule_status_task(head, status)
             return


### PR DESCRIPTION
This avoids the problem where we misuse the status API and think that
something has failed when it hasn't. We also add better logging for
the failing case.