### PR TITLE
Fix handling of upstream sync that are backed out

### DIFF
--- a/sync/base.py
+++ b/sync/base.py
@@ -94,7 +94,7 @@ class ProcessName(object):
 
     @property
     def seq_id(self):
-        return int(self._seq_id)
+        return int(self._seq_id) if self._seq_id is not None else None
 
     @property
     def status(self):
@@ -576,7 +576,10 @@ class SyncProcess(object):
     def __eq__(self, other):
         if not hasattr(other, "_process_name"):
             return False
-        str(self._process_name) == str(other._process_name)
+        for attr in ["obj_type", "subtype", "obj_id", "seq_id"]:
+            if getattr(self._process_name, attr) != getattr(other._process_name, attr):
+                return False
+        return True
 
     def __ne__(self, other):
         return not self == other

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -99,7 +99,7 @@ def test_landing_reapply(env, git_gecko, git_wpt, git_wpt_upstream, pull_request
     hg_gecko_upstream.bookmark("mozilla/central", "-r", rev)
 
     # Merge the upstream change
-    remote_branch, _ = sync_1.remote_branch()
+    remote_branch = sync_1.remote_branch
     git_wpt_upstream.git.checkout(remote_branch)
     git_wpt_upstream.git.rebase("master")
     git_wpt_upstream.git.checkout("master")
@@ -117,7 +117,7 @@ def test_landing_reapply(env, git_gecko, git_wpt, git_wpt_upstream, pull_request
     hg_gecko_upstream.bookmark("mozilla/central", "-r", rev)
 
     # Merge the gecko change
-    remote_branch, _ = sync_2.remote_branch()
+    remote_branch = sync_2.remote_branch
     git_wpt_upstream.git.checkout(remote_branch)
     git_wpt_upstream.git.rebase("master")
     git_wpt_upstream.git.checkout("master")


### PR DESCRIPTION
We had a bug in out handling of backouts that meant we were creating a new sync for the backout, which wasn't expected. To fix this we have to ensure we look at the syncs for commits that were fully backed out, and also ensure we don't lose data when changing the sync status.