### PR TITLE
Delete remote branch when upstream sync merges

### DIFF
--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -153,7 +153,8 @@ class UpstreamSync(base.SyncProcess):
 
     def update_wpt_refs(self):
         # Check if the remote was updated under us
-        if self.remote_branch is None:
+        if (self.remote_branch is None or
+            self.remote_branch not in self.git_wpt.remotes.origin.refs):
             return
 
         remote_head = self.git_wpt.refs["origin/%s" % self.remote_branch]
@@ -396,6 +397,9 @@ class UpstreamSync(base.SyncProcess):
             else:
                 self.merge_sha = merge_sha
                 self.finish()
+                # Delete the remote branch after a merge
+                self.git_wpt.remotes.origin.push(self.remote_branch, delete=True)
+                self.remote_branch = None
                 return True
         if msg is not None:
             logger.error(msg)

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -143,6 +143,7 @@ def test_land_pr(env, git_gecko, git_wpt, hg_gecko_upstream, upstream_gecko_comm
 
     sync = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
     env.gh_wpt.get_pull(sync.pr).mergeable = True
+    original_remote_branch = sync.remote_branch
 
     hg_gecko_upstream.bookmark("mozilla/central", "-r", rev)
 
@@ -152,6 +153,7 @@ def test_land_pr(env, git_gecko, git_wpt, hg_gecko_upstream, upstream_gecko_comm
     sync = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
     assert sync.gecko_landed()
     assert sync.status == "complete"
+    assert original_remote_branch not in git_wpt.remotes.origin.refs
     pr = env.gh_wpt.get_pull(sync.pr)
     assert pr.merged
 


### PR DESCRIPTION
Note that this must land after the changes to the way that remotes are stored in #32 