### PR TITLE
Don't allow downstreaming when the moz-wptsync-bot created a PR.

### DIFF
--- a/sync.ini
+++ b/sync.ini
@@ -51,6 +51,7 @@ path.meta = testing/web-platform/meta
 # See also wpt_config file
 repo.url = https://github.com/w3c/web-platform-tests
 github.token = %SECRET%
+github.user = moz-wptsync-bot
 landing = master
 
 [bugzilla]

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -400,6 +400,8 @@ class DownstreamSync(base.SyncProcess):
 @base.entry_point("downstream")
 def new_wpt_pr(git_gecko, git_wpt, pr_data, raise_on_error=True):
     """ Start a new downstream sync """
+    if pr_data["user"]["login"] == env.config["web-platform-tests"]["github"]["user"]:
+        raise ValueError("Tried to create a downstram sync for a PR created by the wpt bot")
     update_repositories(git_gecko, git_wpt)
     pr_id = pr_data["number"]
     if DownstreamSync.for_pr(git_gecko, git_wpt, pr_id):

--- a/sync/gh.py
+++ b/sync/gh.py
@@ -193,12 +193,15 @@ class MockGitHub(GitHub):
         self._log("Getting PR %s" % id)
         return self.prs.get(int(id))
 
-    def create_pull(self, title, body, base, head, _commits=None, _id=None):
+    def create_pull(self, title, body, base, head, _commits=None, _id=None,
+                    _user=None):
         if _id is None:
             id = self._id.next()
         else:
             id = int(_id)
         assert id not in self.prs
+        if _user is None:
+            _user = env.config["web-platform-tests"]["github"]["user"]
         if _commits is None:
             _commits = [AttrDict(**{"sha": "%040x" % random.getrandbits(160),
                                     "message": "Test commit",
@@ -214,6 +217,9 @@ class MockGitHub(GitHub):
             "mergeable": True,
             "approved": True,
             "_commits": _commits,
+            "user": {
+                "login": _user
+            },
             "labels": []
         })
         self.prs[id] = data

--- a/sync_prod.ini
+++ b/sync_prod.ini
@@ -53,6 +53,7 @@ path.meta = testing/web-platform/meta
 # See also wpt_config file
 repo.url = https://github.com/w3c/web-platform-tests
 github.token = %SECRET%
+github.user = moz-wptsync-bot
 landing = master
 
 [bugzilla]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -336,7 +336,8 @@ def pull_request(env, git_wpt_upstream):
                                        body,
                                        "master",
                                        gh_commits[-1]["sha"],
-                                       _commits=gh_commits)
+                                       _commits=gh_commits,
+                                       _user="test")
         pr = env.gh_wpt.get_pull(pr_id)
 
         git_wpt_upstream.git.update_ref("refs/pull/%s/head" % pr_id, "refs/heads/temp_pr")

--- a/test/testdata/sync.ini
+++ b/test/testdata/sync.ini
@@ -30,6 +30,7 @@ path.meta = testing/web-platform/meta
 repo.url = %ROOT%/remotes/web-platform-tests
 repo.remote.origin = %ROOT%/remotes/web-platform-tests
 github.token = blah
+github.user = moz-wptsync-bot
 # for testing only
 path = %ROOT%/remotes/web-platform-tests
 


### PR DESCRIPTION
This isn't supposed to happen, but it's a belt-and-braces approach to fixing an observed
problem. The idea is that by throwing an error we can figure out how to stop the code getting
this far.