### PR TITLE
Don't generate results notifications for PRs with no affected tests.

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -369,7 +369,13 @@ class DownstreamSync(base.SyncProcess):
             return
 
         if not self.bug:
-            logger.error("Sync has no associated bug")
+            logger.error("Sync for PR %s has no associated bug" % self.pr)
+            return
+
+        if not self.affected_tests():
+            logger.debug("PR %s doesn't have affected tests so skipping results notification" %
+                         self.pr)
+            return
 
         logger.info("Trying to generate results notification for PR %s" % self.pr)
 


### PR DESCRIPTION
Otherwise we end up warning about the results for tests that probably
weren't actually affected by the PR. In the future we may want to
notify in some other way for these things.