### PR TITLE
When landing only reapply parts of patch that touched wpt.

### DIFF
--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -105,6 +105,8 @@ def test_landing_reapply(env, git_gecko, git_wpt, git_wpt_upstream, pull_request
     git_wpt_upstream.git.checkout("master")
     git_wpt_upstream.git.merge(remote_branch, ff_only=True)
 
+    sync_1.finish()
+
     # Add second gecko change
     test_changes = {"change2": "CHANGE2\n"}
     rev = upstream_gecko_commit(test_changes=test_changes, bug="1112",


### PR DESCRIPTION
When reapplying commits that we upstreamed but won't be involved in
the landing, only apply the parts that touch web-platform-tests,
ignoring other gecko changes.

Unfortunately git-cherry-pick doesn't provide a mechanism to pick a
partial commit, so instead we reuse the same show/apply machinery as
for moving commits between different trees, with the difference that
we amend the previous commit and use a three-way merge since the
history is meaningful.

The patch also makes resuming in the middle of a landing work better;
if there's an error during apply one fixes it up in the normal way
then runs git commit --amend -F <sha1>.message and reinvokes the
landing code to continue.