### PR TITLE
Ensure we actually move metadata over during landings.

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -230,7 +230,7 @@ Automatic update from web-platform-tests%s
 
         already_applied = landing_commit.metadata.get("reapplied-commits")
         if already_applied:
-            already_applied = already_applied.split(",")
+            already_applied = [item.strip() for item in already_applied.split(",")]
         else:
             already_applied = []
         already_applied_set = set(already_applied)
@@ -272,7 +272,7 @@ Automatic update from web-platform-tests%s
             git_work.git.commit(amend=True, no_edit=True)
 
     def add_metadata(self, sync):
-        for item in sync.gecko_commits:
+        for item in self.gecko_commits:
             if (item.metadata.get("wpt-pr") == sync.pr and
                 item.metadata.get("wpt-type") == "metadata"):
                 return

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -72,6 +72,10 @@ class TryCommit(object):
         raise NotImplementedError
 
     def read_treeherder(self, status, output):
+        if status != 0:
+            logger.error("Failed to push to try.")
+            # TODO retry
+            raise AbortError("Failed to push to try")
         rev_match = rev_re.search(output)
         if not rev_match:
             logger.warning("No revision found in string:\n\n{}\n".format(output))
@@ -84,10 +88,6 @@ class TryCommit(object):
                 return None
         else:
             try_rev = rev_match.group('rev')
-        if status != 0:
-            logger.error("Failed to push to try.")
-            # TODO retry
-            raise AbortError("Failed to push to try")
         return try_rev
 
 


### PR DESCRIPTION
This wasn't happening because we were accidentially checking if the
metadata already existed on the sync rather than on the landing, which
of course it did.

Also bundle in a few other minor fixes for landing issues.