### PR TITLE
 When rerunning a landing, only reprocess prs that are at HEAD.

### DIFF
--- a/sync/bug.py
+++ b/sync/bug.py
@@ -14,12 +14,16 @@ logger = log.get_logger(__name__)
 
 
 def bz_url_from_api_url(api_url):
+    if api_url is None:
+        return None
     parts = urlparse.urlparse(api_url)
     bz_url = (parts.scheme, parts.netloc, "", "", "", "")
     return urlparse.urlunparse(bz_url)
 
 
 def bug_number_from_url(url):
+    if url is None:
+        return None
     return urlparse.parse_qs(urlparse.urlsplit(url).query).get("id")
 
 

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -54,9 +54,11 @@ def test_land_try(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_p
 
 
 def test_land_commit(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_pr_status,
-                     hg_gecko_try):
+                     hg_gecko_try, mock_mach):
     pr = pull_request([("Test commit", {"README": "example_change"})])
     head_rev = pr._commits[0]["sha"]
+
+    trypush.Mach = mock_mach
 
     downstream.new_wpt_pr(git_gecko, git_wpt, pr)
     downstream_sync = set_pr_status(pr, "success")


### PR DESCRIPTION
If we are reappling upstreamed commits to a landing and we get some
kind of git error, we need to fix it by hand and then reinvoke the
landing code. When we do this, we *only* want to reinvoke applying
upstreamed commits for the HEAD of the repository, otherwise we end up
trying to reapply patches to whatever does happen to be the HEAD
irrespective of which PR it is or whether it's a metadata commit.

This also contains a small optimisation so that we only recompute the
set of unlanded commits if we are actually going to use them. It
should also be possible to store that in the process data, but we
would need to ensure that the data is invalidated by a rebase.