### PR TITLE
Wait for PR approval before scheduling a stability run.

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -475,13 +475,16 @@ def try_push_complete(git_gecko, git_wpt, try_push, sync):
     else:
         disabled = []
 
-    if sync.affected_tests() and not try_push.stability:
+    pr = env.gh_wpt.get_pull(sync.pr)
+    if (sync.affected_tests() and
+        (pr.merged or env.gh_wpt.is_approved(sync.pr)) and
+        not try_push.stability):
         logger.info("Creating a stability try push for PR %s" % sync.pr)
         # TODO check if tonnes of tests are failing -- don't want to update the
         # expectation data in that case
         # TODO decide whether to do another narrow push on mac
         TryPush.create(sync, sync.affected_tests(), stability=True)
-    else:
+    elif try_push.stability:
         if disabled:
             logger.info("The following tests were disabled:\n%s" % "\n".join(disabled))
             # TODO notify relevant people about test expectation changes, stability
@@ -494,3 +497,13 @@ def try_push_complete(git_gecko, git_wpt, try_push, sync):
     pr = env.gh_wpt.get_pull(sync.pr)
     if pr.merged:
         sync.try_notify()
+
+
+@base.entry_point("downstream")
+def pull_request_approved(git_gecko, git_wpt, sync):
+    pr = env.gh_wpt.get_pull(sync.pr)
+    if env.gh_wpt.is_approved(pr.number):
+        latest_try_push = sync.latest_try_push
+        if (latest_try_push and latest_try_push.status == "complete" and
+            not latest_try_push.stability):
+            TryPush.create(sync, sync.affected_tests(), stability=True)

--- a/sync/gh.py
+++ b/sync/gh.py
@@ -117,6 +117,17 @@ class GitHub(object):
         # issue.add_to_labels("mozilla:backed-out")
         pr.edit(state="closed")
 
+    def is_approved(self, pr_id):
+        pr = self.get_pull(pr_id)
+        reviews = pr.get_reviews()
+        # We get a chronological list of all reviews, so we want to
+        # check if the last review by any reviewer was in the approved
+        # state
+        review_by_reviewer = {}
+        for review in reviews:
+            review_by_reviewer[review.user.login] = review.state
+        return "APPROVED" in review_by_reviewer.values()
+
     def is_mergeable(self, pr_id):
         pr = self.get_pull(pr_id)
         return pr.mergeable
@@ -215,7 +226,7 @@ class MockGitHub(GitHub):
             "merged": False,
             "state": "open",
             "mergeable": True,
-            "approved": True,
+            "_approved": True,
             "_commits": _commits,
             "user": {
                 "login": _user
@@ -285,6 +296,10 @@ class MockGitHub(GitHub):
             # TODO: raise the right kind of error here
             raise ValueError
         self._log("Merged PR with id %s" % pr_id)
+
+    def is_approved(self, pr_id):
+        pr = self.get_pull(pr_id)
+        return pr._approved
 
     def approve_pull(self, pr_id):
         pr = self.get_pull(pr_id)

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -297,6 +297,14 @@ class TryPush(base.ProcessData):
     def treeherder_url(try_rev):
         return "https://treeherder.mozilla.org/#/jobs?repo=try&revision=%s" % try_rev
 
+    def __eq__(self, other):
+        if not (hasattr(other, "_ref") and hasattr(other._ref, "_process_name")):
+            return False
+        for attr in ["obj_type", "subtype", "obj_id", "seq_id"]:
+            if getattr(self._ref._process_name, attr) != getattr(other._ref._process_name, attr):
+                return False
+        return True
+
     @property
     def try_rev(self):
         return self.get("try-rev")


### PR DESCRIPTION
There's no point in doing all the work of a stability run if the PR is
undergoing active changes. It will save resources at the possible cost
of some latency to only schedule this once it's marked as approved.