### PR TITLE
Fix up the handling of non-synced files.

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -110,7 +110,8 @@ def initial_wpt_content(env):
 test(() => assert_true(true), "Passing test");
 test(() => assert_true(false), "Failing test");
 </script>
-"""}
+""",
+            "LICENSE": "Initial license\n"}
 
 
 @pytest.fixture

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -39,9 +39,10 @@ def test_land_try(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_p
     assert not os.path.exists(os.path.join(worktree.working_dir,
                                            env.config["gecko"]["path"]["wpt"],
                                            ".git"))
-    assert not os.path.exists(os.path.join(worktree.working_dir,
-                                           env.config["gecko"]["path"]["wpt"],
-                                           "LICENSE"))
+    with open(os.path.join(worktree.working_dir,
+                           env.config["gecko"]["path"]["wpt"],
+                           "LICENSE")) as f:
+        assert f.read() == "Initial license\n"
 
     try_push = sync.latest_try_push
     assert try_push is not None


### PR DESCRIPTION
The previous approach to non-synced files didn't actually work because
the patterns were only matched against the filename and not the full
path. Also the files were deleted because we didn't restore the copy
from the current gecko tree.

In this new approach we match the full path for all the files with a
custom ignore function, and use git checkout_index on the gecko side
to ensure that the files are later restored.