### PR TITLE
Clean up commits created during landing.

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -165,6 +165,10 @@ class LandingSync(base.SyncProcess):
             logger.info("PR %s didn't add any changes" % pr_id)
             return None
 
+        if not git_work_gecko.is_dirty(untracked_files=True):
+            logger.info("PR %s didn't add any changes" % pr_id)
+            return None
+
         git_work_gecko.git.add(env.config["gecko"]["path"]["wpt"],
                                no_ignore_removal=True)
 

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -182,7 +182,7 @@ def test_landing_reapply(env, git_gecko, git_wpt, git_wpt_upstream, pull_request
     assert (hg_gecko_upstream
             .log("-l1", "--template={desc|firstline}")
             .strip()
-            .endswith("[wpt-sync] Update web-platform-tests to %s" % landing_rev))
+            .endswith("[wpt-sync] Update web-platform-tests to %s, a=testonly" % landing_rev))
     for file in ["change1", "change2", "change3", "upstream1"]:
         path = os.path.join(gecko_root,
                             env.config["gecko"]["path"]["wpt"],


### PR DESCRIPTION
Ensure we create only a single commit inclusingn any additional
metadatta updates and the change in the in-tree sync point.