### PR TITLE
Use git add --all for updating metadata.

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -359,7 +359,7 @@ class DownstreamSync(base.SyncProcess):
 
         if gecko_work.is_dirty(untracked_files=True, path=meta_path):
             self.ensure_metadata_commit()
-            gecko_work.index.add([meta_path])
+            gecko_work.git.add(meta_path, all=True)
             self._commit_metadata()
 
         return disabled

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -379,11 +379,11 @@ Automatic update from web-platform-tests%s
 
         gecko_work = self.gecko_worktree.get()
         mach = Mach(gecko_work.working_dir)
-        logger.debug("Updating metadata")
+        logger.info("Updating metadata")
         mach.wpt_update(*log_files)
 
         if gecko_work.is_dirty(untracked_files=True, path=meta_path):
-            gecko_work.index.add([meta_path])
+            gecko_work.git.add(meta_path, all=True)
             self.update_metadata_commit()
 
     def update_sync_point(self, sync_point):


### PR DESCRIPTION
This ensures that the worktree exactly matches the index, including
for removals. Using the underlying git command is recommended by the
gitpython author.