### PR TITLE
Don't try to upstream commits resulting from a landing.

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -83,6 +83,13 @@ class DownstreamSync(base.SyncProcess):
 
         return syncs[0]
 
+    @classmethod
+    def has_metadata(cls, message):
+        required_keys = ["wpt-commits",
+                         "wpt-pr"]
+        metadata = sync_commit.get_metadata(message)
+        return all(item in metadata for item in required_keys)
+
     @property
     def pr_head(self):
         return sync_commit.WptCommit(self.git_wpt, "origin/pr/%s" % self.pr)


### PR DESCRIPTION
The upstreaming code was accidentially trying to re-upstream stuff
that itself came from upstream. This patch checks if the commit has
metadata indicating that it came from upstream, and if it does we
filter it out of the commits considered for upstreaming.