### PR TITLE
Enable creating a bug as part of the sync pr command.

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -39,14 +39,7 @@ class DownstreamSync(base.SyncProcess):
                                               wpt_base=wpt_base,
                                               wpt_head="origin/pr/%s" % pr_id)
 
-        comment = sync.make_bug_comment(git_wpt, pr_id, pr_title, pr_body)
-        bug = env.bz.new(summary="[wpt-sync] Sync PR %s - %s" % (pr_id, pr_title),
-                         comment=comment,
-                         product="Testing",
-                         component="web-platform-tests",
-                         whiteboard="[wptsync downstream]",
-                         priority="P3")
-        sync.bug = bug
+        sync.create_bug(git_wpt, pr_id, pr_title, pr_body)
         return sync
 
     def make_bug_comment(self, git_wpt, pr_id, pr_title, pr_body):
@@ -115,6 +108,18 @@ class DownstreamSync(base.SyncProcess):
     def wpt(self):
         git_work = self.wpt_worktree.get()
         return WPT(os.path.join(git_work.working_dir))
+
+    def create_bug(self, git_wpt, pr_id, pr_title, pr_body):
+        if self.bug is not None:
+            return
+        comment = self.make_bug_comment(git_wpt, pr_id, pr_title, pr_body)
+        bug = env.bz.new(summary="[wpt-sync] Sync PR %s - %s" % (pr_id, pr_title),
+                         comment=comment,
+                         product="Testing",
+                         component="web-platform-tests",
+                         whiteboard="[wptsync downstream]",
+                         priority="P3")
+        self.bug = bug
 
     def update_status(self, action, merge_sha=None, wpt_base=None):
         if action == "closed" and not merge_sha:

--- a/sync/update.py
+++ b/sync/update.py
@@ -121,6 +121,8 @@ def update_pr(git_gecko, git_wpt, pr):
             schedule_pr_task("opened", pr)
             update_for_status(pr)
     elif isinstance(sync, downstream.DownstreamSync):
+        if not sync.bug and not (pr.state == "closed" and not pr.merged):
+            sync.create_bug(git_wpt, pr.number, pr.title, pr.body)
         if pr.state == "open":
             if pr.head.sha != sync.wpt_commits.head:
                 # Upstream has different commits, so run a push handler


### PR DESCRIPTION
If for some reason we happen to crash out after creating a PR but
before creating a bug, we can end up with a bug that has no PR. In
that case we want to allow creating such a bug when running the
wptsync pr command (assuming that the PR didn't get closed in the
meantime).