### PR TITLE
Add a push url to the mozilla repo config.

### DIFF
--- a/docker/gecko_config
+++ b/docker/gecko_config
@@ -13,6 +13,7 @@
 [remote "mozilla"]
     url = hg::https://hg.mozilla.org/mozilla-unified
     fetch = +refs/heads/bookmarks/*:refs/remotes/mozilla/*
+    pushurl = hg::ssh://hg.mozilla.org/integration/mozilla-inbound
 [remote "autoland"]
     url = hg::https://hg.mozilla.org/integration/autoland
     fetch = +refs/heads/*:refs/remotes/autoland/*


### PR DESCRIPTION
This enables landings to actually push to inbound.