### PR TITLE
Add ability to automatically restart incomplete syncs

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -165,6 +165,8 @@ class DownstreamSync(base.SyncProcess):
 
     @property
     def metadata_commit(self):
+        if len(self.gecko_commits) == 0:
+            return
         if self.gecko_commits[-1].metadata.get("wpt-type") == "metadata":
             return self.gecko_commits[-1]
 


### PR DESCRIPTION
If we have a backlog of PRs it can be helpful to do a landing and then retrigger all the unlanded ones because some will be blocked on something that is now fixed (e.g. some intermittent error or a merge conflict that's now resolved). This adds a --retrigger option to `wptsync landable` that attempts to do this.