### PR TITLE
Make three-way merge the default.

### DIFF
--- a/sync/commit.py
+++ b/sync/commit.py
@@ -139,7 +139,7 @@ class Commit(object):
                 if item.strip()]
 
     def move(self, dest_repo, skip_empty=True, msg_filter=None, metadata=None, src_prefix=None,
-             dest_prefix=None, amend=False, three_way=False):
+             dest_prefix=None, amend=False, three_way=True):
         if metadata is None:
             metadata = {}
 


### PR DESCRIPTION
I believe this provides the most useful behaviour in terms of conflict handling,
even if there isn't actually the right information to do a real three way merge.