### PR TITLE
Handle missing bug number in metadata commits.

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -344,6 +344,17 @@ Automatic update from web-platform-tests%s
                 else:
                     raise
 
+            metadata_commit = worktree.head.commit
+            if metadata_commit.message.startswith("Bug None"):
+                # If the metadata commit didn't get a valid bug number for some reason,
+                # we want to replace the placeholder bug number with the
+                # either the sync or landing bug number, otherwise the push will be
+                # rejected
+                bug_number = sync.bug or self.bug
+                new_message = "Bug %s%s" % (bug_number,
+                                            metadata_commit.message[len("Bug None"):])
+                worktree.git.commit(message=new_message, amend=True)
+
     def apply_prs(self, landable_commits):
         """Main entry point to setting the commits for landing.
 


### PR DESCRIPTION
Sometimes we are lacking a bug number when we make metadata commits
for whatever reason. Since we can't actually land anything with "Bug
None" at the start of the commit message, check for that case and add
a valid bug number from the sync or the landing.