### PR TITLE
Add a skip attribute to downstream syncs

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -112,6 +112,14 @@ class DownstreamSync(base.SyncProcess):
         self.data["results-notified"] = value
 
     @property
+    def skip(self):
+        return self.data.get("skip", False)
+
+    @skip.setter
+    def skip(self, value):
+        self.data["skip"] = value
+
+    @property
     def wpt(self):
         git_work = self.wpt_worktree.get()
         return WPT(os.path.join(git_work.working_dir))

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -532,7 +532,7 @@ def landable_commits(git_gecko, git_wpt, prev_wpt_head, wpt_head=None):
                 # TODO: schedule a downstream sync for this pr
                 logger.info("PR %s has no corresponding sync" % pr)
                 last = True
-            elif not sync.metadata_ready:
+            elif not (sync.skip or sync.metadata_ready):
                 logger.info("Metadata pending for PR %s" % pr)
                 last = True
             if last:


### PR DESCRIPTION
This causes the sync to not be required to have metadata before
landing the correesponding PR. This can be useful if the sync puts the
repo into a broken state, or is low-value but happens to have an
error, or similar.