### PR TITLE
Update wpt commits correctly after a merge

### DIFF
--- a/sync/base.py
+++ b/sync/base.py
@@ -425,8 +425,13 @@ class CommitRange(object):
     def base(self):
         return self._base
 
-    # Base doesn't have a setter here because we don't have a good way to update
-    # the ref where it's stored
+    @base.setter
+    def base(self, value):
+        # Note that this doesn't actually update the stored value of the base
+        # anywhere, unlike the head setter which will update the associated ref
+        self._commits = None
+        self._base_sha = value
+        self._base = self.commit_cls(self.repo, value)
 
     @property
     def head(self):

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -141,9 +141,22 @@ class DownstreamSync(base.SyncProcess):
             self.status = "open"
             self.pr_status = "open"
 
-    def update_wpt_head(self):
+    def update_wpt_commits(self):
         if not self.wpt_commits.head or self.wpt_commits.head.sha1 != self.pr_head.sha1:
             self.wpt_commits.head = self.pr_head
+        if len(self.wpt_commits) == 0 and self.git_wpt.is_ancestor(self.wpt_commits.head.sha1,
+                                                                   "origin/master"):
+            # The commits landed on master so we need to change the commit
+            # range to not use origin/master as a base
+            base_commit = None
+            assert self.wpt_commits.head.pr() == self.pr
+            for commit in self.git_wpt.iter_commits(self.wpt_commits.head.sha1):
+                wpt_commit = sync_commit.WptCommit(self.git_wpt, commit)
+                if wpt_commit.pr() != self.pr:
+                    base_commit = wpt_commit
+                    break
+
+            self.wpt_commits.base = self.data["wpt-base"] = base_commit.sha1
 
     def files_changed(self):
         # TODO: Would be nice to do this from mach with a gecko worktree
@@ -262,7 +275,7 @@ class DownstreamSync(base.SyncProcess):
             gecko_work.git.commit(amend=True, no_edit=True)
 
     def update_commits(self):
-        self.update_wpt_head()
+        self.update_wpt_commits()
         old_gecko_head = self.gecko_commits.head.sha1
         logger.debug("PR %s gecko HEAD was %s" % (self.pr, old_gecko_head))
         self.wpt_to_gecko_commits()

--- a/sync/update.py
+++ b/sync/update.py
@@ -122,6 +122,8 @@ def update_pr(git_gecko, git_wpt, pr):
             schedule_pr_task("opened", pr)
             update_for_status(pr)
     elif isinstance(sync, downstream.DownstreamSync):
+        if len(sync.wpt_commits) == 0:
+            sync.update_wpt_commits()
         if not sync.bug and not (pr.state == "closed" and not pr.merged):
             sync.create_bug(git_wpt, pr.number, pr.title, pr.body)
         if sync.latest_try_push and not sync.latest_try_push.taskgroup_id:


### PR DESCRIPTION
After wpt commits are either merged or fast-forwarded onto master the
range origin/master..origin/pr/<id> is empty since the endpoint is an
ancestor of the master branch. Instead we should take the commits that
actually landed onto the master branch explicitly, setting the base
commit to whatever the commit prior to landing was.

The way we handle updating the base commit is non-ideal since it has
to be set in the sync data and then updated in the CommitRange
object. However this should be enough to fix the problem we currently have.