### PR TITLE
Make a new try push whenever we get new commits and PR status is success (#74)

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -472,7 +472,6 @@ def new_wpt_pr(git_gecko, git_wpt, pr_data, raise_on_error=True):
 def status_changed(git_gecko, git_wpt, sync, context, status, url, head_sha,
                    raise_on_error=False):
     update_repositories(git_gecko, git_wpt)
-    previous_check = sync.last_pr_check
     try:
         logger.debug("Got status %s for PR %s" % (status, sync.pr))
         if status == "pending":
@@ -482,7 +481,7 @@ def status_changed(git_gecko, git_wpt, sync, context, status, url, head_sha,
             return
         check_state, _ = env.gh_wpt.get_combined_status(sync.pr)
         sync.last_pr_check = {"state": check_state, "sha": head_sha}
-        if check_state == "success" and previous_check != sync.last_pr_check:
+        if check_state == "success":
             head_changed = sync.update_commits()
             if sync.latest_try_push and not head_changed:
                 logger.info("Commits on PR %s didn't change" % sync.pr)


### PR DESCRIPTION
This is basically reverting back to a looser check before making  a try push.

Initially the comparison with last_pr_check was added to prevent
unnecessary bug updates on repeated "success" status, but in
retrospect I don't think this is necessary for downstream syncs:
the only way we update the bug in case of "success" is to flip
the whiteboard error field if it's not already None, and we don't make try pushes
unless the PR commits change.