### PR TITLE
Update to the latest git cinnabar

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -104,7 +104,7 @@ WORKDIR /app/git-cinnabar
 ENV PATH=/app/git-cinnabar:$PATH
 
 RUN git clone https://github.com/glandium/git-cinnabar.git . \
-    && git checkout bb45a922e9c7907ad6e101fbaa54cec5cb7b2434; \
+    && git checkout c5a4aa78d11426350ec880a54b944cc802116642; \
     pip install --user requests \
     && git cinnabar download
 


### PR DESCRIPTION
The regression we were avoiding has been fixed and the old version
stopped being avaiable to install, so this seems like a good time to
update.