### PR TITLE
Add clean-up to entrypoint script

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ docker build -t wptsync_dev --add-host=rabbitmq:127.0.0.1 --file wpt-sync/docker
 To start all the services in the container:
 
 ```
-docker run --init -it --add-host=rabbitmq:127.0.0.1 \
+docker run -it --add-host=rabbitmq:127.0.0.1 \
 --env WPTSYNC_CONFIG=/app/wpt-sync/devenv/sync.ini \
 --env WPTSYNC_CREDS=/app/wpt-sync/devenv/credentials.ini \
 --env WPTSYNC_SSH_CONFIG=/app/wpt-sync/devenv/ssh_config \

--- a/ansible/roles/wptsync_host/templates/run_docker.sh.j2
+++ b/ansible/roles/wptsync_host/templates/run_docker.sh.j2
@@ -14,7 +14,7 @@ if [[ $command == "build" ]]; then
 elif [[ $command == "test" ]]; then
     exec docker run -it $img --test
 elif [[ $command == "run" ]]; then
-    exec docker run --init -it --add-host=rabbitmq:127.0.0.1 \
+    exec docker run -it --add-host=rabbitmq:127.0.0.1 \
     --env WPTSYNC_CONFIG={{ wptsync_config | mandatory }} \
     --env WPTSYNC_CREDS={{ wptsync_credentials }} \
     --env WPTSYNC_GH_SSH_KEY={{ wptsync_github_key | mandatory }} \

--- a/bin/run_docker_dev.sh
+++ b/bin/run_docker_dev.sh
@@ -35,7 +35,7 @@ elif [[ $command == "clean" ]]; then
     rm -rf repos
     rm -rf devenv
 elif [[ $command == "run" ]]; then
-    exec docker run --init -it --add-host=rabbitmq:127.0.0.1 \
+    exec docker run -it --add-host=rabbitmq:127.0.0.1 \
     --env WPTSYNC_CONFIG=/app/wpt-sync/devenv/sync.ini \
     --env WPTSYNC_CREDS=/app/wpt-sync/devenv/credentials.ini \
     --env WPTSYNC_SSH_CONFIG=/app/wpt-sync/devenv/ssh_config \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 version: '3'
 services:
   sync:
-#   --init option of docker run not supported in docker-compose scheme v3
-#   init: true
     user: app
     build:
       context: .

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -17,6 +17,11 @@ RUN set -eux; \
     apt-get update; \
     apt-get install -y git sudo less emacs-nox wget gnupg apt-transport-https
 
+# install tini for process management so we can use its -g option
+ENV TINI_VERSION v0.17.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
 ### Install latest erlang
 # add buster sources.list
 RUN set -eux; \
@@ -160,5 +165,5 @@ WORKDIR /app/wpt-sync
 # /app/repos: bind mount to ebs volume for gecko and wpt repos (or local dev repos)
 VOLUME ["/app/wpt-sync", "/app/workspace", "/app/repos", "/app/data"]
 
-ENTRYPOINT ["/app/start_wptsync.sh"]
+ENTRYPOINT ["/tini", "-v", "-g", "--", "/app/start_wptsync.sh"]
 CMD ["--worker"]

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -5,6 +5,7 @@ RUN groupadd --gid 10001 app && \
 
 ENV RABBITMQ_CONFIG_FILE=/etc/rabbitmq/rabbitmq
 COPY ./docker/rabbitmq.conf /etc/rabbitmq/rabbitmq.conf
+RUN echo LOG_BASE=/app/workspace/logs > /etc/rabbitmq/rabbitmq-env.conf
 
 COPY ./docker/start_wptsync.sh /app/start_wptsync.sh
 RUN chmod +x /app/start_wptsync.sh

--- a/docker/rabbitmq.conf
+++ b/docker/rabbitmq.conf
@@ -26,8 +26,8 @@ log.file.level = debug
 
 ## File rotation config. No rotation by default.
 ## DO NOT SET rotation date to ''. Leave the value unset if "" is the desired value
-# log.file.rotation.date = $D0
-# log.file.rotation.size = 0
+log.file.rotation.date = $D0
+log.file.rotation.size = 0
 
 ## Logging to console (can be true or false)
 ##

--- a/docker/start_wptsync.sh
+++ b/docker/start_wptsync.sh
@@ -4,11 +4,54 @@ set -o errexit
 set -o pipefail
 set -o xtrace
 
-# USE the trap if you need to also do manual cleanup after the service is stopped,
-#     or need to start multiple services in the one container
-trap "echo TRAPed signal" HUP INT QUIT TERM
+# This script is meant to be run with tini -g, which forwards signals
+# child processes. This enables the use of `trap`
+# for cleanup. We don't want to use `exec` for any commands that
+# we might want to kill with TERM or clean up after.
 
-echo Args: $@
+trap cleanup HUP INT QUIT TERM
+
+CELERY_WORKER=syncworker1
+CELERY_PID_FILE=${WPTSYNC_ROOT}/%n.pid
+CELERY_LOG_FILE=${WPTSYNC_ROOT}/logs/%n%I.log
+CELERYBEAT_PID_FILE=${WPTSYNC_ROOT}/celerybeat.pid
+
+cleanup() {
+    echo "Stopping celery..."
+    /app/venv/bin/celery multi stopwait ${CELERY_WORKER} \
+        --pidfile=${CELERY_PID_FILE} \
+        --logfile=${CELERY_LOG_FILE}
+    echo -n "Stopping celery beat..."
+    if [ -f "$CELERYBEAT_PID_FILE" ]; then
+       kill -0 $(cat "$CELERYBEAT_PID_FILE") 1>/dev/null 2>&1
+       if [ $? -eq 1 ]; then
+            echo "Already stopped."
+            rm $CELERYBEAT_PID_FILE
+       else
+            kill -TERM $(cat "$CELERYBEAT_PID_FILE")
+       fi
+    else
+        echo "celery beat not running? (no pid file)"
+    fi
+    sudo service rabbitmq-server stop
+}
+
+clean_pid() {
+    pidfile=$1
+    if [ -f $pidfile ]; then
+        kill -0 $(cat "$pidfile") 1>/dev/null 2>&1
+        if [ $? -eq 1 ]; then
+            echo "Removing stale pid file: $pidfile"
+            rm $pidfile
+        else
+            echo "Process for $pidfile is running!"
+            exit 1
+        fi
+    fi
+}
+
+clean_pid "${WPTSYNC_ROOT}/${CELERY_WORKER}.pid"
+clean_pid "$CELERYBEAT_PID_FILE"
 
 cp -v ${WPTSYNC_CONFIG:-/app/wpt-sync/sync.ini} /app/workspace/sync.ini
 cp -v ${WPTSYNC_NEW_RELIC_CONFIG:-/app/wpt-sync/newrelic.ini} /app/workspace/newrelic.ini
@@ -49,27 +92,27 @@ elif [ "$1" == "--worker" ]; then
     newrelic-admin run-program \
                    /app/venv/bin/celery beat --detach --app sync.worker \
                    --schedule=${WPTSYNC_ROOT}/celerybeat-schedule \
-                   --pidfile=${WPTSYNC_ROOT}/celerybeat.pid \
+                   --pidfile=${CELERYBEAT_PID_FILE} \
                    --logfile=${WPTSYNC_ROOT}/logs/celerybeat.log --loglevel=DEBUG
 
     echo "Starting celery worker"
 
     newrelic-admin run-program \
-                   /app/venv/bin/celery multi start syncworker1 -A sync.worker \
+                   /app/venv/bin/celery multi start ${CELERY_WORKER} -A sync.worker \
                    --concurrency=1 \
-                   --pidfile=${WPTSYNC_ROOT}/%n.pid \
-                   --logfile=${WPTSYNC_ROOT}/logs/%n%I.log --loglevel=DEBUG
+                   --pidfile=${CELERY_PID_FILE} \
+                   --logfile=${CELERY_LOG_FILE} --loglevel=DEBUG
 
     echo "Starting pulse listener"
 
-    exec newrelic-admin run-program \
+    newrelic-admin run-program \
          /app/venv/bin/wptsync listen
 elif [ "$1" == "--test" ]; then
     command="test"
     if [ "$2" == "--no-flake8" ]; then
         command="$command --no-flake8"
     fi
-    exec /app/venv/bin/wptsync $command
+    /app/venv/bin/wptsync $command
 else
-    exec /app/venv/bin/wptsync "$@"
+    /app/venv/bin/wptsync "$@"
 fi

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -10,7 +10,7 @@ If something is very broken and you just want to stop everything:
 ```
 # list the container names
 docker ps
-docker stop -t 30 <container_name>...
+docker stop -t 60 <container_name>...
 ```
 
 ## Logs and inspecting the service


### PR DESCRIPTION
With these changes, `docker stop -t 60 <container>` will give celery and rabbitmq a chance to shutdown gracefully. The entrypoint script also attempts to clean up stale pid files when starting up. 