### PR TITLE
Fix logging of reference rename and add safety check.

### DIFF
--- a/sync/base.py
+++ b/sync/base.py
@@ -227,15 +227,20 @@ class VcsRefObject(object):
         ref.set_object(commit)
 
     def rename(self):
+        path = self.path
         ref = self.ref
         if not ref:
             return
-        logger.debug("Renaming ref %s to %s" % (ref, self.path))
-        # Pretty sure there is an easier way to do this
+        # This implicitly updates self.path
         self._ref = str(self._process_name)
+        if self.path == path:
+            return
+        logger.debug("Renaming ref %s to %s" % (path, self.path))
         new_ref = git.Reference(self.repo, self.path)
         new_ref.set_object(ref.commit.hexsha)
-        logger.debug("Deleting ref %s" % (ref.path))
+        logger.debug("Deleting ref %s pointing at %s.\n"
+                     "To recreate this ref run `git update-ref %s %s`" %
+                     (ref.path, ref.commit.hexsha, ref.path, ref.commit.hexsha))
         ref.delete(self.repo, ref.path)
 
     @classmethod


### PR DESCRIPTION
Previously we were logging too early so it looked like we were always
renaming the ref to the same name. We also want a safety check that
we don't do that since we could end up deleting a valid reference.