### PR TITLE
Only commit testing/web-platform/meta/MANIFEST.json when updating man…

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -175,7 +175,9 @@ class DownstreamSync(base.SyncProcess):
         mach = Mach(gecko_work.working_dir)
         mach.wpt_manifest_update()
         if gecko_work.is_dirty():
-            gecko_work.index.add(["testing/web-platform/meta/MANIFEST.json"])
+            manifest_path = os.path.join(env.config["gecko"]["path"]["meta"],
+                                         "MANIFEST.json")
+            gecko_work.index.add([manifest_path])
             metadata = {
                 "wpt-pr": self.pr,
                 "wpt-type": "manifest"
@@ -183,6 +185,9 @@ class DownstreamSync(base.SyncProcess):
             msg = sync_commit.Commit.make_commit_msg("Bug %s [wpt PR %s] - Update wpt manifest" %
                                                      (self.bug, self.pr), metadata)
             gecko_work.index.commit(message=msg)
+        if gecko_work.is_dirty():
+            # This can happen if the mozilla/meta/MANIFEST.json is updated
+            gecko_work.git.reset(hard=True)
 
     @property
     def metadata_commit(self):

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -312,8 +312,13 @@ Automatic update from web-platform-tests%s
         mach = Mach(git_work.working_dir)
         mach.wpt_manifest_update()
         if git_work.is_dirty():
-            git_work.git.add("testing/web-platform/meta")
+            manifest_path = os.path.join(env.config["gecko"]["path"]["meta"],
+                                         "MANIFEST.json")
+            git_work.git.add(manifest_path)
             git_work.git.commit(amend=True, no_edit=True)
+        if git_work.is_dirty():
+            # This can happen if the mozilla/meta/MANIFEST.json is updated
+            git_work.git.reset(hard=True)
 
     def has_metadata(self, sync):
         for item in self.gecko_commits:


### PR DESCRIPTION
…ifest

In particular we don't have write access to update the
Mozilla-specific manifest, so if that's changed we want to reset the
changes and not update it otherwise it won't be possible to push the
commit.