### PR TITLE
By default preserve author when moving commits.

### DIFF
--- a/sync/commit.py
+++ b/sync/commit.py
@@ -194,7 +194,7 @@ class Commit(object):
          %s""" % (e.command, e.status, patch_path, message_path, e.stderr)
                     raise AbortError(err_msg)
 
-                return Commit.create(dest_repo, msg, None, amend=amend)
+                return Commit.create(dest_repo, msg, None, amend=amend, author=self.author)
 
 
 class GeckoCommit(Commit):


### PR DESCRIPTION
This should ensure that the author is preserved when upstreaming.