### PR TITLE
Fix metadata update handing.

### DIFF
--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -7,3 +7,66 @@ def test_wpt_empty(git_gecko, local_gecko_commit):
     gecko_commit = sync_commit.GeckoCommit(git_gecko, commit)
     assert not gecko_commit.is_empty()
     assert not gecko_commit.has_wpt_changes()
+
+
+def test_metadata_update():
+    msg = """Bug 1443987 [wpt PR 9909] - [css-typed-om] Clean up parsing tests., a=testonly
+
+This patch:
+- Deletes unused interface.html
+- Fixes <div> tag in tests.
+- Adds case-sensitivity tests.
+
+
+Bug: 774887
+Change-Id: I194ec7549991bfcd7708e640458246b40fc3ab03
+Reviewed-on: https://chromium-review.googlesource.com/952509
+Reviewed-by: nainar <nainar@chromium.org>
+Commit-Queue: Darren Shen <shend@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#541592}
+
+wpt-commits: ab1fd254ca0a97ca7cbca5c9fca853596cd22cfd
+wpt-pr: 9909"""
+
+    expected = """Bug 1443987 [wpt PR 9909] - [css-typed-om] Clean up parsing tests., a=testonly
+
+This patch:
+- Deletes unused interface.html
+- Fixes <div> tag in tests.
+- Adds case-sensitivity tests.
+
+Bug: 774887
+Change-Id: I194ec7549991bfcd7708e640458246b40fc3ab03
+Reviewed-on: https://chromium-review.googlesource.com/952509
+Reviewed-by: nainar <nainar@chromium.org>
+Commit-Queue: Darren Shen <shend@chromium.org>
+Cr-Commit-Position: refs/heads/master@{#541592}
+wpt-commits: ab1fd254ca0a97ca7cbca5c9fca853596cd22cfd
+wpt-pr: 9910
+new: value
+"""
+
+    metadata = sync_commit.get_metadata(msg)
+    assert metadata["wpt-commits"] == "ab1fd254ca0a97ca7cbca5c9fca853596cd22cfd"
+    assert metadata["wpt-pr"] == "9909"
+    assert metadata["Change-Id"] == "I194ec7549991bfcd7708e640458246b40fc3ab03"
+
+    metadata["wpt-pr"] = "9910"
+    metadata["new"] = "value"
+
+    assert expected == sync_commit.Commit.make_commit_msg(msg, metadata)
+
+    # Should replace metadata not in the metadata set
+    metadata = {"wpt-pr": "9910",
+                "new": "value"}
+    expected = """Bug 1443987 [wpt PR 9909] - [css-typed-om] Clean up parsing tests., a=testonly
+
+This patch:
+- Deletes unused interface.html
+- Fixes <div> tag in tests.
+- Adds case-sensitivity tests.
+
+wpt-pr: 9910
+new: value
+"""
+    assert expected == sync_commit.Commit.make_commit_msg(msg, metadata)


### PR DESCRIPTION
Before we would always append metadata to commit messages, resulting
in duplicate metadata in some cases. Instead we want to read the
existing metadata and update it. To make this work we solidify the
definition of metadata:

* It is a line of the form 'foo: bar' i.e. containing a colon followed
  by a space.
* Metadata lines appear at the end of a commit message possibly
  interspersed with blank lines.

This means that any line which happens to look like metadata, but
which appears above a line that does not look like metadata and is not
blank will not be considered metadata.