### PR TITLE
Fix setting upstream syncs' PR status in update()

### DIFF
--- a/sync/base.py
+++ b/sync/base.py
@@ -797,10 +797,10 @@ class SyncProcess(object):
             try_pushes = sorted(try_pushes, key=lambda x: x._ref._process_name.seq_id)
             return try_pushes[-1]
 
-    def finish(self):
+    def finish(self, status="complete"):
         # TODO: cancel related try pushes &c.
         logger.info("Marking sync %s as complete" % (self._process_name))
-        self.status = "complete"
+        self.status = status
         for worktree in [self.gecko_worktree, self.wpt_worktree]:
             worktree.delete()
         for repo in [self.git_gecko, self.git_wpt]:

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -145,12 +145,14 @@ class UpstreamSync(base.SyncProcess):
         :param merge_sha boolean: SHA of the new head if the PR merged or None if it didn't
         """
         if action == "closed":
-            if not merge_sha:
+            if not merge_sha and self.pr_status != "closed":
                 env.bz.comment(self.bug, "Upstream PR was closed without merging")
                 self.pr_status = "closed"
             else:
                 self.merge_sha = merge_sha
-                env.bz.comment(self.bug, "Upstream PR merged")
+                if self.status != "complete":
+                    env.bz.comment(self.bug, "Upstream PR merged")
+                    self.finish("wpt-merged")
         elif action == "reopened" or action == "open":
             self.pr_status = "open"
 


### PR DESCRIPTION
Enable moving syncs from "complete" back to wpt-merged if they haven't
yet landed in gecko, and ensure that we don't over-comment on bugs.