### PR TITLE
Apply all landing commits by diff rather than copy

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -500,8 +500,14 @@ Automatic update from web-platform-tests%s
             logger.info("Applying PR %i of %i" % (i + 1, len(landable_commits)))
             update_gecko_landed(sync, commits)
 
-            # If this is the first commit, do a full copy from upstream
-            copy = i == 0
+            # If copy is set then we copy the commits and reapply in-progress upstream
+            # syncs. This is currently always disabled, but the intent was to do this for
+            # the first commit to ensure that the possible drift from upstream was limited.
+            # However there were some difficulties reapplying all the right commits, so it's
+            # disabled until this is worked out.
+            # To reenable it change the below line to
+            # copy = i == 0
+            copy = False
             commit = None
             if not meta_only:
                 # If we haven't applied it before then create the initial commit

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -240,7 +240,8 @@ Automatic update from web-platform-tests%s
                                         amend=False,
                                         metadata=metadata,
                                         rev_name="pr-%s" % pr.number,
-                                        author=wpt_commits[0].author)
+                                        author=wpt_commits[0].author,
+                                        exclude={"LICENSE", "resources/testdriver_vendor.js"})
 
     def unlanded_gecko_commits(self):
         """Get a list of gecko commits that correspond to commits which have


### PR DESCRIPTION
The copy-and-reapply approach was running into some bugs, so in order
to expediate getting landings working disable this for now. In theory
it's a good idea because if limits the possible drift from upstream,
but in practice we have had difficulties ensuring that we always
reapply the correct commits.