### PR TITLE
Mark syncs for PRs that are reverted, and the reverting sync as skip

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -394,6 +394,9 @@ Automatic update from web-platform-tests%s
         return False
 
     def add_metadata(self, sync):
+        if sync.skip:
+            return
+
         if self.has_metadata_for_sync(sync):
             return
 


### PR DESCRIPTION
PRs that are later reverted cause unnecessary work since the revert
won't apply until mozilla/central is updated with the original commit,
which is presumbably broken in some way. Instead of figuring all of
this out, it makes more sense to just skip both the original PR and
the reverting PR, assuming that they overall have no effect.

Putting this code at the start of  update_commits is not ideal, but it
must certainly run before that method since it will typically fail if
the revert doesn't apply to central.