### PR TITLE
Fix handling of PR status updates.

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -629,8 +629,8 @@ def pull_request_approved(git_gecko, git_wpt, sync):
 
 
 @base.entry_point("downstream")
-def update_pr(git_gecko, git_wpt, sync, action, merged, base_sha):
-    if action == "closed" and not merged:
+def update_pr(git_gecko, git_wpt, sync, action, merge_sha, base_sha):
+    if action == "closed" and not merge_sha:
         sync.pr_status = "closed"
         sync.finish()
     elif action == "closed":

--- a/sync/handlers.py
+++ b/sync/handlers.py
@@ -53,12 +53,21 @@ def handle_pr(git_gecko, git_wpt, event):
         if event["action"] == "opened":
             downstream.new_wpt_pr(git_gecko, git_wpt, event["pull_request"])
     else:
-        downstream.update_pr(git_gecko,
-                             git_wpt,
-                             sync,
-                             event["action"],
-                             event["pull_request"]["merged"],
-                             event["pull_request"]["base"]["sha"])
+        if isinstance(sync, downstream.DownstreamSync):
+            update_func = downstream.update_pr
+        elif isinstance(sync, upstream.UpstreamSync):
+            update_func = upstream.update_pr
+        else:
+            return
+
+        merge_sha = (event["pull_request"]["merge_commit_sha"]
+                     if event["pull_request"]["merged"] else None)
+        update_func(git_gecko,
+                    git_wpt,
+                    sync,
+                    event["action"],
+                    merge_sha,
+                    event["pull_request"]["base"]["sha"])
 
 
 def handle_status(git_gecko, git_wpt, event):


### PR DESCRIPTION
The previous change introduced a regression so that we didn't handle
status updates to PRs we created. This fixes that and ensures that the
merge sha is actually passed into the handler.