### PR TITLE
Update sync point before landing to try.

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -801,6 +801,8 @@ def land_to_gecko(git_gecko, git_wpt, prev_wpt_head=None, new_wpt_head=None,
 
     landing.update_bug_components()
 
+    landing.update_sync_point(sync_point)
+
     if landing.latest_try_push is None:
         trypush.TryPush.create(landing, hacks=False,
                                try_cls=trypush.TryFuzzyCommit, exclude=["pgo", "ccov"])
@@ -855,9 +857,6 @@ def try_push_complete(git_gecko, git_wpt, try_push, sync, allow_push=True):
                                          git_wpt,
                                          sync.wpt_commits.base.sha1,
                                          sync.wpt_commits.head.sha1)
-
-    sync_point = load_sync_point(git_gecko, git_wpt)
-    sync.update_sync_point(sync_point)
 
     if not allow_push:
         logger.info("Landing in bug %s is ready for push.\n"

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -283,7 +283,8 @@ def test_landing_metadata(env, git_gecko, git_wpt, git_wpt_upstream, pull_reques
     tree.is_open = lambda x: True
     landing_sync = landing.land_to_gecko(git_gecko, git_wpt)
 
-    assert len(landing_sync.gecko_commits) == 2
-    assert landing_sync.gecko_commits[-1].metadata["wpt-type"] == "metadata"
+    assert len(landing_sync.gecko_commits) == 3
+    assert landing_sync.gecko_commits[-1].metadata["wpt-type"] == "landing"
+    assert landing_sync.gecko_commits[-2].metadata["wpt-type"] == "metadata"
     for item in file_data:
-        assert item in landing_sync.gecko_commits[-1].commit.stats.files
+        assert item in landing_sync.gecko_commits[-2].commit.stats.files


### PR DESCRIPTION
Otherwise we forget to do it in cases where we do the try run manually.