### PR TITLE
Store sync associated with commit in upstream sync.

### DIFF
--- a/sync/base.py
+++ b/sync/base.py
@@ -873,6 +873,10 @@ class SyncProcess(object):
         self.data["pr"] = value
 
     @property
+    def seq_id(self):
+        return self._process_name.seq_id
+
+    @property
     def last_pr_check(self):
         return self.data.get("last-pr-check", {})
 

--- a/sync/commit.py
+++ b/sync/commit.py
@@ -325,6 +325,27 @@ class GeckoCommit(Commit):
                 commits.append(commit)
         return commits, set(bugs)
 
+    def upstream_sync(self, git_gecko, git_wpt):
+        import upstream
+        if "upstream-sync" in self.notes:
+            bug, seq_id = self.notes["upstream-sync"].split(":", 1)
+            if seq_id == "":
+                seq_id = None
+            syncs = upstream.UpstreamSync.load_all(git_gecko, git_wpt, status="*",
+                                                   obj_id=bug, seq_id=seq_id)
+            assert len(syncs) <= 1
+            if syncs:
+                return syncs[0]
+
+    def set_upstream_sync(self, sync):
+        import upstream
+        if not isinstance(sync, upstream.UpstreamSync):
+            raise ValueError
+        seq_id = sync.seq_id
+        if seq_id is None:
+            seq_id = ""
+        self.notes["upstream-sync"] = "%s:%s" % (sync.bug, seq_id)
+
 
 class WptCommit(Commit):
     def pr(self):

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -65,6 +65,13 @@ class UpstreamSync(base.SyncProcess):
         self._upstreamed_gecko_head = None
 
     @classmethod
+    def new(cls, *args, **kwargs):
+        self = super(UpstreamSync, cls).new(*args, **kwargs)
+        for commit in self.gecko_commits:
+            commit.set_upstream_sync(self)
+        return self
+
+    @classmethod
     def load(cls, git_gecko, git_wpt, branch_name):
         sync = super(UpstreamSync, cls).load(git_gecko, git_wpt, branch_name)
         sync.update_wpt_refs()
@@ -594,6 +601,9 @@ def updated_syncs_for_push(git_gecko, git_wpt, first_commit, head_commit):
     update_syncs = {}
 
     for commit in commits:
+        if commit.upstream_sync(git_gecko, git_wpt) is not None:
+            # This commit was already processed e.g. by a manual invocation, so skip
+            continue
         if commit.is_backout:
             create, update = updates_for_backout(git_gecko, git_wpt, commit)
             create_syncs.update(create)
@@ -661,6 +671,8 @@ def update_sync_heads(syncs_by_bug):
             raise ValueError("Tried to modify a closed sync for bug %s with commit %s" %
                              (bug, commit.canonical_rev))
         sync.gecko_commits.head = commit
+        for commit in sync.gecko_commits:
+            commit.set_upstream_sync(sync)
         rv.append(sync)
     return rv
 


### PR DESCRIPTION
This allows us to avoid reprocessing commits that have already been
processed, which can happen e.g. with manual intervention. The sync
data is stored in a git note associated with the gecko commit.