### PR TITLE
Account for infra failures when creating or using try pushes.

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -817,19 +817,10 @@ def land_to_gecko(git_gecko, git_wpt, prev_wpt_head=None, new_wpt_head=None,
 
 @base.entry_point("landing")
 def try_push_complete(git_gecko, git_wpt, try_push, sync, allow_push=True):
-    # min rate of job success to proceed with metadata update
-    target_rate = 0.7
     retriggered = try_push.retriggered_wpt_states(force_update=True)
     intermittents = []
     if not try_push.success() and not retriggered:
-        if try_push.success_rate() < target_rate:
-            message = (
-                "Latest try push for bug %s has too many failures.\n"
-                "See %s"
-            ) % (sync.bug, try_push.treeherder_url(try_push.try_rev))
-            sync.error = message
-            env.bz.comment(sync.bug, message)
-            try_push.status = "complete"
+        if try_push.failure_limit_exceeded(sync):
             return
         num_new_jobs = try_push.retrigger_failures()
         logger.info("%s new tasks scheduled on try for %s" % (num_new_jobs, sync.bug))
@@ -841,10 +832,12 @@ def try_push_complete(git_gecko, git_wpt, try_push, sync, allow_push=True):
     for name, data in retriggered.iteritems():
         total = float(sum(data["states"].itervalues()))
         # assuming that only failures cause metadata updates
-        if data["states"][tc.SUCCESS] / total >= target_rate:
+        if data["states"][tc.SUCCESS] / total >= try_push._min_success:
             intermittents.append(name)
 
     log_files = try_push.download_raw_logs(exclude=intermittents)
+    if not log_files:
+        logger.debug("No log files found for try push %r" % try_push)
     sync.update_metadata(log_files)
 
     try_push.status = "complete"


### PR DESCRIPTION
This is a tentative PR. I don't have a full picture of the impact on landing code, so would like some initial feedback on whether the overall approach makes sense. 

The rough idea is to mark a sync with "error" if we try to get metadata from an empty try push (no wpt tasks) -- this can happen if tasks expire from taskcluster, which they do after 28 days, or if the decision task failed.

The other piece is to create a try push again during downstreaming if we know the previous one was an infra failure. 

Also note to self before I run out the door: todo - check wpt_tasks in next_try_push, force True.