### PR TITLE
When a landing reaches central mark as complete and trigger the next one

### DIFF
--- a/sync/command.py
+++ b/sync/command.py
@@ -81,10 +81,14 @@ def get_parser():
     parser_bug.add_argument("bug", default=None, nargs="?", help="Bug number")
     parser_bug.set_defaults(func=do_bug)
 
-    parser_upstream = subparsers.add_parser("upstream", help="Run the upstreaming code")
-    parser_upstream.add_argument("--base-rev", help="Base revision for upstreaming")
-    parser_upstream.add_argument("--rev", help="Revision to upstream to")
-    parser_upstream.set_defaults(func=do_upstream)
+    parser_push = subparsers.add_parser("push", help="Run the push handler")
+    parser_push.add_argument("--base-rev", help="Base revision for push or landing")
+    parser_push.add_argument("--rev", help="Revision pushed")
+    parser_push.add_argument("--process", dest="processes", action="append",
+                             choices=["landing", "upstream"],
+                             default=None,
+                             help="Select process to run on push (default: landing, upstream)")
+    parser_push.set_defaults(func=do_push)
 
     parser_delete = subparsers.add_parser("delete", help="Delete a sync by bug number or pr")
     parser_delete.add_argument("sync_type", help="Type of sync to delete")
@@ -269,14 +273,15 @@ def do_bug(git_gecko, git_wpt, bug, *args, **kwargs):
 
 
 @with_lock
-def do_upstream(git_gecko, git_wpt, *args, **kwargs):
+def do_push(git_gecko, git_wpt, *args, **kwargs):
     import update
     rev = kwargs["rev"]
     base_rev = kwargs["base_rev"]
+    processes = kwargs["processes"]
     if rev is None:
         rev = git_gecko.commit(env.config["gecko"]["refs"]["mozilla-inbound"]).hexsha
 
-    update.update_upstream(git_gecko, git_wpt, rev, base_rev=base_rev)
+    update.update_push(git_gecko, git_wpt, rev, base_rev=base_rev, processes=processes)
 
 
 @with_lock

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -73,18 +73,6 @@ class DownstreamSync(base.SyncProcess):
         return items[0] if items else None
 
     @classmethod
-    def for_bug(cls, git_gecko, git_wpt, bug, statuses=None):
-        if statuses is None:
-            statuses = "*"
-        for status in statuses:
-            syncs = cls.load_all(git_gecko, git_wpt, status=status, obj_id="*")
-            for item in syncs:
-                if item.bug == bug:
-                    return {item.status: [item]}
-
-        return {}
-
-    @classmethod
     def has_metadata(cls, message):
         required_keys = ["wpt-commits",
                          "wpt-pr"]

--- a/sync/update.py
+++ b/sync/update.py
@@ -88,7 +88,7 @@ def convert_rev(git_gecko, rev):
     return git_rev, hg_rev
 
 
-def update_upstream(git_gecko, git_wpt, rev, base_rev=None):
+def update_push(git_gecko, git_wpt, rev, base_rev=None, processes=None):
     git_rev, hg_rev = convert_rev(git_gecko, rev)
 
     if base_rev is not None:
@@ -103,10 +103,13 @@ def update_upstream(git_gecko, git_wpt, rev, base_rev=None):
     else:
         routing_key = "integration/autoland"
 
-    kwargs = {}
+    kwargs = {"_wptsync": {}}
 
     if hg_rev_base is not None:
-        kwargs["_wptsync"] = {"base_rev": hg_rev_base}
+        kwargs["_wptsync"]["base_rev"] = hg_rev_base
+
+    if processes is not None:
+        kwargs["_wptsync"]["processes"] = processes
 
     event = construct_event("push", {"data": {"heads": [hg_rev]}},
                             _meta={"routing_key": routing_key},

--- a/sync/worker.py
+++ b/sync/worker.py
@@ -1,11 +1,6 @@
 import celery
-from celery.schedules import crontab
 
 beat_schedule = {
-    'attempt-landing': {
-        "task": "sync.tasks.land",
-        "schedule": crontab(hour=10, minute=30),
-    },
     # Try to cleanup once an hour
     'cleanup': {
         "task": "sync.tasks.cleanup",

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -9,8 +9,8 @@ def test_create_pr(env, git_gecko, git_wpt, upstream_gecko_commit):
                                 message="Change README")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
-    pushed, landed, failed = upstream.push(git_gecko, git_wpt, "inbound", rev,
-                                           raise_on_error=True)
+    pushed, landed, failed = upstream.gecko_push(git_gecko, git_wpt, "inbound", rev,
+                                                 raise_on_error=True)
     assert len(pushed) == 1
     assert len(landed) == 0
     assert len(failed) == 0
@@ -48,8 +48,8 @@ def test_create_pr_backout(git_gecko, git_wpt, upstream_gecko_commit,
                                 message="Change README")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
-    upstream.push(git_gecko, git_wpt, "inbound", rev,
-                  raise_on_error=True)
+    upstream.gecko_push(git_gecko, git_wpt, "inbound", rev,
+                        raise_on_error=True)
 
     syncs = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
     assert syncs.keys() == ["open"]
@@ -64,7 +64,7 @@ def test_create_pr_backout(git_gecko, git_wpt, upstream_gecko_commit,
     backout_rev = upstream_gecko_backout(rev, bug)
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=backout_rev)
-    upstream.push(git_gecko, git_wpt, "inbound", backout_rev, raise_on_error=True)
+    upstream.gecko_push(git_gecko, git_wpt, "inbound", backout_rev, raise_on_error=True)
     syncs = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
     assert syncs.keys() == ["incomplete"]
     assert len(syncs["incomplete"]) == 1
@@ -85,13 +85,13 @@ def test_create_pr_backout_reland(git_gecko, git_wpt, upstream_gecko_commit,
                                 message="Change README")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
-    upstream.push(git_gecko, git_wpt, "inbound", rev,
-                  raise_on_error=True)
+    upstream.gecko_push(git_gecko, git_wpt, "inbound", rev,
+                        raise_on_error=True)
 
     backout_rev = upstream_gecko_backout(rev, bug)
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
-    upstream.push(git_gecko, git_wpt, "inbound", backout_rev, raise_on_error=True)
+    upstream.gecko_push(git_gecko, git_wpt, "inbound", backout_rev, raise_on_error=True)
 
     syncs = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
     assert syncs.keys() == ["incomplete"]
@@ -109,7 +109,7 @@ def test_create_pr_backout_reland(git_gecko, git_wpt, upstream_gecko_commit,
                                           message="Reland: Change README")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
-    upstream.push(git_gecko, git_wpt, "inbound", relanding_rev, raise_on_error=True)
+    upstream.gecko_push(git_gecko, git_wpt, "inbound", relanding_rev, raise_on_error=True)
 
     syncs = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
     assert syncs.keys() == ["open"]
@@ -133,8 +133,7 @@ def test_create_partial_backout_reland(git_gecko, git_wpt, upstream_gecko_commit
                                  message="Change README again")
 
     update_repositories(git_gecko, git_wpt)
-    upstream.push(git_gecko, git_wpt, "inbound", rev1,
-                  raise_on_error=True)
+    upstream.gecko_push(git_gecko, git_wpt, "inbound", rev1, raise_on_error=True)
 
     upstream_gecko_backout(rev1, bug)
 
@@ -147,7 +146,7 @@ def test_create_partial_backout_reland(git_gecko, git_wpt, upstream_gecko_commit
                                           message="Change README once more")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=relanding_rev)
-    upstream.push(git_gecko, git_wpt, "inbound", relanding_rev, raise_on_error=True)
+    upstream.gecko_push(git_gecko, git_wpt, "inbound", relanding_rev, raise_on_error=True)
 
     syncs = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
     assert syncs.keys() == ["open"]
@@ -168,8 +167,8 @@ def test_land_pr(env, git_gecko, git_wpt, hg_gecko_upstream, upstream_gecko_comm
                                 message="Change README")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
-    pushed, landed, failed = upstream.push(git_gecko, git_wpt, "inbound", rev,
-                                           raise_on_error=True)
+    pushed, landed, failed = upstream.gecko_push(git_gecko, git_wpt, "inbound", rev,
+                                                 raise_on_error=True)
 
     syncs = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
     assert syncs.keys() == ["open"]
@@ -181,8 +180,8 @@ def test_land_pr(env, git_gecko, git_wpt, hg_gecko_upstream, upstream_gecko_comm
     hg_gecko_upstream.bookmark("mozilla/central", "-r", rev)
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
-    pushed, landed, failed = upstream.push(git_gecko, git_wpt, "central", rev,
-                                           raise_on_error=True)
+    pushed, landed, failed = upstream.gecko_push(git_gecko, git_wpt, "central", rev,
+                                                 raise_on_error=True)
 
     syncs = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
     assert syncs == {"wpt-merged": [sync]}
@@ -201,8 +200,8 @@ def test_land_pr_after_status_change(env, git_gecko, git_wpt, hg_gecko_upstream,
                                 message="Change README")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
-    pushed, landed, failed = upstream.push(git_gecko, git_wpt, "inbound", rev,
-                                           raise_on_error=True)
+    pushed, landed, failed = upstream.gecko_push(git_gecko, git_wpt, "inbound", rev,
+                                                 raise_on_error=True)
     syncs = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
     assert syncs.keys() == ["open"]
     assert len(syncs["open"]) == 1
@@ -218,8 +217,8 @@ def test_land_pr_after_status_change(env, git_gecko, git_wpt, hg_gecko_upstream,
     hg_gecko_upstream.bookmark("mozilla/central", "-r", rev)
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
-    pushed, landed, failed = upstream.push(git_gecko, git_wpt, "central", rev,
-                                           raise_on_error=True)
+    pushed, landed, failed = upstream.gecko_push(git_gecko, git_wpt, "central", rev,
+                                                 raise_on_error=True)
 
     env.gh_wpt.set_status(sync.pr, "success", "http://test/", "tests failed",
                           "continuous-integration/travis-ci/pr")
@@ -240,15 +239,15 @@ def test_no_upstream_downstream(env, git_gecko, git_wpt, upstream_gecko_commit,
 wpt-pr: 1
 wpt-commits: 0000000000000000000000000000000000000000""")
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=hg_rev)
-    pushed, landed, failed = upstream.push(git_gecko, git_wpt, "mozilla-inbound",
-                                           hg_rev, raise_on_error=True)
+    pushed, landed, failed = upstream.gecko_push(git_gecko, git_wpt, "mozilla-inbound",
+                                                 hg_rev, raise_on_error=True)
     assert not pushed
     assert not landed
     assert not failed
     backout_rev = upstream_gecko_backout(hg_rev, "1234")
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=backout_rev)
-    pushed, landed, failed = upstream.push(git_gecko, git_wpt, "mozilla-inbound",
-                                           backout_rev, raise_on_error=True)
+    pushed, landed, failed = upstream.gecko_push(git_gecko, git_wpt, "mozilla-inbound",
+                                                 backout_rev, raise_on_error=True)
     assert not pushed
     assert not landed
     assert not failed
@@ -265,8 +264,8 @@ def test_upstream_existing(env, git_gecko, git_wpt, upstream_gecko_commit, upstr
 
     upstream_wpt_commit(file_data=test_changes_1)
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=gecko_rev_2)
-    pushed, landed, failed = upstream.push(git_gecko, git_wpt, "inbound", gecko_rev_2,
-                                           raise_on_error=True)
+    pushed, landed, failed = upstream.gecko_push(git_gecko, git_wpt, "inbound", gecko_rev_2,
+                                                 raise_on_error=True)
     assert len(pushed) == 1
     assert len(landed) == 0
     assert len(failed) == 0
@@ -296,8 +295,8 @@ def test_upstream_existing(env, git_gecko, git_wpt, upstream_gecko_commit, upstr
     gecko_rev_3 = upstream_gecko_commit(test_changes=test_changes_3, bug=bug,
                                         message="Add more")
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=gecko_rev_3)
-    pushed, landed, failed = upstream.push(git_gecko, git_wpt, "inbound", gecko_rev_3,
-                                           raise_on_error=True)
+    pushed, landed, failed = upstream.gecko_push(git_gecko, git_wpt, "inbound", gecko_rev_3,
+                                                 raise_on_error=True)
     assert len(sync.gecko_commits) == 3
     assert len(sync.wpt_commits) == 2
     assert ([item.metadata.get("gecko-commit") for item in sync.wpt_commits] ==
@@ -311,8 +310,8 @@ def test_upstream_multi(env, git_gecko, git_wpt, upstream_gecko_commit):
                                   message="Add README")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev_0)
-    pushed, landed, failed = upstream.push(git_gecko, git_wpt, "inbound", rev_0,
-                                           raise_on_error=True)
+    pushed, landed, failed = upstream.gecko_push(git_gecko, git_wpt, "inbound", rev_0,
+                                                 raise_on_error=True)
     assert len(pushed) == 1
     sync_0 = pushed.pop()
 
@@ -321,8 +320,8 @@ def test_upstream_multi(env, git_gecko, git_wpt, upstream_gecko_commit):
                                   message="Add README1")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev_1)
-    pushed, landed, failed = upstream.push(git_gecko, git_wpt, "inbound", rev_1,
-                                           raise_on_error=True)
+    pushed, landed, failed = upstream.gecko_push(git_gecko, git_wpt, "inbound", rev_1,
+                                                 raise_on_error=True)
     assert len(pushed) == 1
     assert pushed == {sync_0}
     assert len(sync_0.upstreamed_gecko_commits) == 2
@@ -339,8 +338,8 @@ def test_upstream_multi(env, git_gecko, git_wpt, upstream_gecko_commit):
                                   message="Add README2")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev_2)
-    pushed, landed, failed = upstream.push(git_gecko, git_wpt, "inbound", rev_2,
-                                           raise_on_error=True)
+    pushed, landed, failed = upstream.gecko_push(git_gecko, git_wpt, "inbound", rev_2,
+                                                 raise_on_error=True)
 
     assert len(pushed) == 1
     sync_1 = pushed.pop()
@@ -360,8 +359,8 @@ def test_upstream_multi(env, git_gecko, git_wpt, upstream_gecko_commit):
                                   message="Add README3")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev_3)
-    pushed, landed, failed = upstream.push(git_gecko, git_wpt, "inbound", rev_3,
-                                           raise_on_error=True)
+    pushed, landed, failed = upstream.gecko_push(git_gecko, git_wpt, "inbound", rev_3,
+                                                 raise_on_error=True)
     assert len(pushed) == 1
     sync_2 = pushed.pop()
     assert sync_2._process_name not in (sync_1._process_name, sync_0._process_name)
@@ -381,20 +380,20 @@ def test_upstream_reprocess_commits(git_gecko, git_wpt, upstream_gecko_commit,
                                 message="Change README")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
-    pushed, _, _ = upstream.push(git_gecko, git_wpt, "inbound", rev,
-                                 raise_on_error=True)
+    pushed, _, _ = upstream.gecko_push(git_gecko, git_wpt, "inbound", rev,
+                                       raise_on_error=True)
     sync = pushed.pop()
     assert sync.gecko_commits[0].upstream_sync(git_gecko, git_wpt) == sync
 
     backout_rev = upstream_gecko_backout(rev, bug)
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=backout_rev)
-    upstream.push(git_gecko, git_wpt, "inbound", backout_rev, raise_on_error=True)
+    upstream.gecko_push(git_gecko, git_wpt, "inbound", backout_rev, raise_on_error=True)
 
     sync_point = git_gecko.refs["sync/upstream/inbound"]
     sync_point.commit = (sync_commit.GeckoCommit(git_gecko, git_gecko.cinnabar.hg2git(rev))
                          .commit.parents[0])
 
-    pushed, landed, failed = upstream.push(git_gecko, git_wpt, "inbound", backout_rev,
-                                           raise_on_error=True)
+    pushed, landed, failed = upstream.gecko_push(git_gecko, git_wpt, "inbound", backout_rev,
+                                                 raise_on_error=True)
     assert len(pushed) == len(landed) == len(failed) == 0


### PR DESCRIPTION
Also, handle backouts of landings by ensuring that the relevant
landing is set to "open" and marked as having an error. Togehter this
means that we can't start a new landing until the present
one reaches central and any backout that happens before that will
prevent a new landing from starting.