### PR TITLE
Ensure that the metadata commit is the tip of downstream sync

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -404,6 +404,7 @@ def pull_request_commit(env, git_wpt_upstream, pull_request):
         git_wpt_upstream.git.update_ref("refs/pull/%s/head" % pr_id, "refs/heads/temp_pr")
         git_wpt_upstream.heads.master.checkout()
         git_wpt_upstream.delete_head(pr_branch, force=True)
+        return rev.hexsha
 
     return inner
 


### PR DESCRIPTION
If we have a downstream sync and new commits are added, we currently
just add those commits after any existing metadata update commit. This
means we can break later invariants that there is only a single such
commit, or simply not apply the metadata during landing. Instead we
remove the metadata commit before updates, and reapply it later. Since
applying the upstream commits may fail, we need to store this pointer
in the sync data.