### PR TITLE
Fix the handling of decision tasks.

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -765,7 +765,15 @@ def try_push_complete(git_gecko, git_wpt, try_push, sync):
                 sync.error = message
                 env.bz.comment(sync.bug, message)
                 try_push.status = "complete"
+                try_push.infra_fail = True
                 raise AbortError(message)
+        elif len(try_push.failed_builds()):
+            message = ("Try push had build failures")
+            sync.error = message
+            env.bz.comment(sync.bug, message)
+            try_push.status = "complete"
+            try_push.infra_fail = True
+            raise AbortError(message)
         else:
             logger.info("Try push %r for PR %s complete" % (try_push, sync.pr))
             disabled = []

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -846,7 +846,14 @@ def try_push_complete(git_gecko, git_wpt, try_push, sync, allow_push=True,
     intermittents = []
 
     if not try_push.success() and not retriggered:
-        if not accept_failures and try_push.failure_limit_exceeded():
+        if not accept_failures and len(try_push.failed_builds()):
+            message = ("Try push had build failures")
+            sync.error = message
+            env.bz.comment(sync.bug, message)
+            try_push.status = "complete"
+            try_push.infra_fail = True
+            raise AbortError(message)
+        elif not accept_failures and try_push.failure_limit_exceeded():
             message = (
                 "Latest try push for bug %s has too many failures.\n"
                 "See %s"

--- a/sync/listen.py
+++ b/sync/listen.py
@@ -8,7 +8,6 @@ from kombu.mixins import ConsumerMixin
 import log
 import handlers
 import tasks
-import tc
 
 here = os.path.dirname(__file__)
 
@@ -191,4 +190,4 @@ class TaskFilter(Filter):
 
     def accept(self, body):
         return (body["display"]["jobName"] == "Gecko Decision Task" and
-                body["state"] == tc.SUCCESS)
+                body["state"] == "completed")

--- a/sync/notify.py
+++ b/sync/notify.py
@@ -79,13 +79,13 @@ def get_central_tasks(git_gecko, sync):
         git_gecko,
         git_gecko.merge_base(sync.gecko_commits.head.sha1,
                              env.config["gecko"]["refs"]["central"])[0])
-    taskgroup_id, status = tc.get_taskgroup_id("mozilla-central",
-                                               central_commit.canonical_rev)
-    if taskgroup_id is None:
+    taskgroup_id, state, result = tc.get_taskgroup_id("mozilla-central",
+                                                      central_commit.canonical_rev)
+    if taskgroup_id is None or state != "completed":
         return None
 
-    if status != "success":
-        logger.info("mozilla-central decision task has status %s" % status)
+    if result != "success":
+        logger.info("mozilla-central decision task has status %s" % result)
         return None
 
     taskgroup_id = tc.normalize_task_id(taskgroup_id)

--- a/sync/tc.py
+++ b/sync/tc.py
@@ -347,7 +347,9 @@ def get_taskgroup_id(project, revision):
                                (project, job_id))
     job_data = fetch_json(job_url)
 
-    return normalize_task_id(job_data["taskcluster_metadata"]["task_id"]), job_data["result"]
+    return (normalize_task_id(job_data["taskcluster_metadata"]["task_id"]),
+            job_data["state"],
+            job_data["result"])
 
 
 def cleanup():

--- a/sync/update.py
+++ b/sync/update.py
@@ -225,10 +225,11 @@ def update_taskgroup_ids(git_gecko, git_wpt):
             continue
 
         if not try_push.taskgroup_id:
-            taskgroup_id, status = tc.get_taskgroup_id("try", try_push.try_rev)
+            taskgroup_id, state, result = tc.get_taskgroup_id("try", try_push.try_rev)
             handle_sync("task", {"origin": {"revision": try_push.try_rev},
                                  "taskId": taskgroup_id,
-                                 "result": status})
+                                 "state": state,
+                                 "result": result})
 
 
 def update_tasks(git_gecko, git_wpt, pr_id=None, sync=None):


### PR DESCRIPTION
The handling of decision tasks previously contained a few bugs,
notably that we were assuming the statuses were in the
taskcluster-queue set, but actually the pulse message we are using
here is from treeherder, which has two different kinds of status,
"state" which is just about whether the job is complete and "result"
which is about whether it succeeded, and a different set of
corresponding strings.

In addition the handling of failed decision tasks was lacking; we were
immediately failing and complaining in the bug, but not retriggering
anything. Now we attempt 5 retriggers before giving up.