### PR TITLE
Enable retries for specified exceptions.

### DIFF
--- a/sync/commit.py
+++ b/sync/commit.py
@@ -6,7 +6,7 @@ from mozautomation import commitparser
 
 import log
 from env import Environment
-from pipeline import AbortError
+from errors import AbortError
 
 
 env = Environment()

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -23,7 +23,7 @@ import trypush
 import commit as sync_commit
 from env import Environment
 from gitutils import update_repositories
-from pipeline import AbortError
+from errors import AbortError
 from projectutil import Mach, WPT
 from trypush import TryPush
 

--- a/sync/errors.py
+++ b/sync/errors.py
@@ -9,3 +9,11 @@ class AbortError(Exception):
         self.message = msg
         self.cleanup = cleanup
         self.set_flag = set_flag
+
+
+class RetryableError(Exception):
+    def __init__(self, wrapped):
+        self.wrapped = wrapped
+
+    def __getattr__(self, name):
+        return getattr(self.wrapped, name)

--- a/sync/gitutils.py
+++ b/sync/gitutils.py
@@ -4,6 +4,7 @@ import git
 
 import log
 from env import Environment
+from errors import RetryableError
 
 env = Environment()
 
@@ -25,7 +26,8 @@ def update_repositories(git_gecko, git_wpt, include_autoland=False, wait_gecko_c
             success = until(lambda: _update_gecko(git_gecko, include_autoland),
                             lambda: have_gecko_hg_commit(git_gecko, wait_gecko_commit))
             if not success:
-                raise ValueError("Failed to fetch gecko commit %s" % wait_gecko_commit)
+                raise RetryableError(
+                    ValueError("Failed to fetch gecko commit %s" % wait_gecko_commit))
         else:
             _update_gecko(git_gecko, include_autoland)
 

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -23,7 +23,7 @@ import upstream
 from env import Environment
 from gitutils import update_repositories
 from projectutil import Mach
-from pipeline import AbortError
+from errors import AbortError, RetryableError
 
 
 env = Environment()
@@ -601,8 +601,7 @@ def push(landing):
 
         if not tree.is_open(landing_tree):
             logger.info("%s is closed" % landing_tree)
-            # TODO make this auto-retry
-            raise AbortError("Tree is closed")
+            raise RetryableError(AbortError("Tree is closed"))
 
         try:
             logger.info("Pushing landing")

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -14,7 +14,7 @@ import tc
 import tree
 from env import Environment
 from load import get_syncs
-from pipeline import AbortError
+from errors import AbortError, RetryableError
 from projectutil import Mach
 
 logger = log.get_logger(__name__)
@@ -79,8 +79,7 @@ class TryCommit(object):
     def read_treeherder(self, status, output):
         if status != 0:
             logger.error("Failed to push to try.")
-            # TODO retry
-            raise AbortError("Failed to push to try")
+            raise RetryableError(AbortError("Failed to push to try"))
         rev_match = rev_re.search(output)
         if not rev_match:
             logger.warning("No revision found in string:\n\n{}\n".format(output))
@@ -248,8 +247,7 @@ class TryPush(base.ProcessData):
         logger.info("Creating try push for PR %s" % sync.pr)
         if not tree.is_open("try"):
             logger.info("try is closed")
-            # TODO make this auto-retry
-            raise AbortError("Try is closed")
+            raise RetryableError(AbortError("Try is closed"))
 
         git_work = sync.gecko_worktree.get()
 

--- a/sync/update.py
+++ b/sync/update.py
@@ -6,7 +6,7 @@ import upstream
 from env import Environment
 from load import get_bug_sync, get_pr_sync
 from gitutils import update_repositories
-from pipeline import AbortError
+from errors import AbortError
 
 env = Environment()
 logger = log.get_logger(__name__)

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -12,7 +12,7 @@ import log
 import commit as sync_commit
 from downstream import DownstreamSync
 from gitutils import update_repositories, gecko_repo
-from pipeline import AbortError
+from errors import AbortError
 from env import Environment
 
 env = Environment()


### PR DESCRIPTION
Introduce a RetryableError class which is used to wrap exceptions
which can be retried automatically. Enable automatic retries for
selected exceptions, notably:

* Failing to fetch a given commit when updating repositoires
* Tree closures