### PR TITLE
Handle try: in downstream commit message.

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -558,12 +558,20 @@ class DownstreamSync(base.SyncProcess):
         return commits
 
     def message_filter(self, msg):
+        # It turns out that the string "try:" is forbidden anywhere in gecko commits,
+        # because we (mistakenly) think that this always means it's a try string. So we insert
+        # a ZWSP which means that the try syntax regexp doesn't match, but the printable
+        # representation of the commit message doesn't change
+        try_re = re.compile(r"(\b)try:")
+        msg, _ = try_re.subn(u"\\1try\u200B:", msg)
+
         parts = msg.split("\n", 1)
         if len(parts) > 1:
             summary, body = parts
         else:
             summary = parts[0]
             body = ""
+
         new_msg = "Bug %s [wpt PR %s] - %s, a=testonly\n%s" % (self.bug,
                                                                self.pr,
                                                                summary,

--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -292,3 +292,29 @@ wpt-type: metadata
     assert sync.gecko_commits[-1].metadata.get("wpt-type") == "metadata"
     assert sync.gecko_commits[-1].msg == metadata_commit.msg
     assert sync.gecko_commits[-2].metadata.get("wpt-commit") == head_sha
+
+
+def test_message_filter():
+    sync = Mock()
+    sync.configure_mock(bug=1234, pr=7)
+    msg, _ = downstream.DownstreamSync.message_filter.__func__(
+        sync,
+        """Upstream summary
+
+Upstream message
+
+Cq-Include-Trybots: luci.chromium.try:android_optional_gpu_tests_rel;"""
+        "luci.chromium.try:mac_optional_gpu_tests_rel;"
+        "master.tryserver.chromium.linux:linux_mojo;"
+        "master.tryserver.chromium.mac:ios-simulator-cronet;"
+        "master.tryserver.chromium.mac:ios-simulator-full-configs")
+
+    assert msg == (u"""Bug 1234 [wpt PR 7] - Upstream summary, a=testonly
+
+Upstream message
+
+Cq-Include-Trybots: luci.chromium.try\u200B:android_optional_gpu_tests_rel;"""
+                   u"luci.chromium.try\u200B:mac_optional_gpu_tests_rel;"
+                   u"master.tryserver.chromium.linux:linux_mojo;"
+                   u"master.tryserver.chromium.mac:ios-simulator-cronet;"
+                   u"master.tryserver.chromium.mac:ios-simulator-full-configs")


### PR DESCRIPTION
Gecko's hg hooks reject commit messages with try: in them. It turns out that Chrome uses
similar syntax but allows it in commits, so we end up with this case being hit
semi-regularly.