### PR TITLE
Bail out if we keep trying to land, but the HEAD doesn't change after…

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -589,6 +589,7 @@ def push(landing):
 
     landing_tree = env.config["gecko"]["landing"]
 
+    old_head = None
     while not success:
         try:
             logger.info("Rebasing onto %s" % landing.gecko_integration_branch())
@@ -598,6 +599,13 @@ def push(landing):
             logger.error(err)
             landing.bz.comment(landing.bug, err)
             raise AbortError(err)
+
+        if old_head == landing.gecko_commits.head.sha1:
+            err = "Landing push failed and rebase didn't change head"
+            logger.error(err)
+            landing.bz.comment(landing.bug, err)
+            raise AbortError(err)
+        old_head = landing.gecko_commits.head.sha1
 
         if not tree.is_open(landing_tree):
             logger.info("%s is closed" % landing_tree)


### PR DESCRIPTION
… a rebase.

If we are trying to land and after a rebase we are trying to push the same thing again,
it typically means that something is broken and we should bail out (e.g. a hg hook failed).
Altough we should fix individual cases of this, this seems like a useful safety mechanism.