### PR TITLE
Remove first_parent from git log when handling pushes to central.

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -927,8 +927,7 @@ def gecko_push(git_gecko, git_wpt, repository_name, hg_rev, raise_on_error=False
 
     landing_sync = current(git_gecko, git_wpt)
     for commit in git_gecko.iter_commits(revish,
-                                         reverse=True,
-                                         first_parent=True):
+                                         reverse=True):
         commit = sync_commit.GeckoCommit(git_gecko, commit.hexsha)
         if landed_central and commit.is_landing:
             syncs = LandingSync.for_bug(git_gecko, git_wpt, commit.bug, flat=True)


### PR DESCRIPTION
Since all pushes to central are merge commits, using first_parent means that we don't
process any of the commits being merged in, and so don't notice landings being
completed.