### PR TITLE
Remove empty, unused update_status method.

### DIFF
--- a/sync/base.py
+++ b/sync/base.py
@@ -876,10 +876,6 @@ class SyncProcess(object):
     def wpt_commit_filter(self):
         return CommitFilter()
 
-    def update_status(self, action, merged, wpt_base):
-        """Update the status of the sync for a PR change"""
-        pass
-
     @classmethod
     def new(cls, git_gecko, git_wpt, gecko_base, gecko_head,
             wpt_base="origin/master", wpt_head=None,

--- a/sync/update.py
+++ b/sync/update.py
@@ -133,7 +133,7 @@ def update_pr(git_gecko, git_wpt, pr):
         # a corresponding sync
         upstream_sync = upstream.UpstreamSync.from_pr(git_gecko, git_wpt, pr.number, pr.body)
         if upstream_sync is not None:
-            upstream_sync.update_status(pr.state, pr.merged)
+            upstream.update_pr(git_gecko, git_wpt, upstream_sync, pr.state, pr.merged)
         else:
             if pr.state != "open" and not pr.merged:
                 return
@@ -166,7 +166,7 @@ def update_pr(git_gecko, git_wpt, pr):
 
     elif isinstance(sync, upstream.UpstreamSync):
         merge_sha = pr.merge_commit_sha if pr.merged else None
-        sync.update_status(pr.state, merge_sha)
+        upstream.update_pr(git_gecko, git_wpt, sync, pr.state, merge_sha)
         sync.try_land_pr()
         if merge_sha:
             if git_wpt.is_ancestor(merge_sha, sync_point["upstream"]):


### PR DESCRIPTION
I think `update_status` should have probably been removed as part of this change: https://github.com/mozilla/wpt-sync/commit/98dd4953eeddddcf37f536adf9215edbd48a5376#diff-5de2e9e8eca6903bae6547b8990e75ff

I ran into a TypeError when running `wptsync update` as a result -- the empty base update_status method was being called:

```
[2018-05-22 19:55:13,606] ERROR:sync.tasks:update_status() takes exactly 4 arguments (3 given)
[2018-05-22 19:55:13,607] ERROR:sync.tasks:Traceback (most recent call last):
  File "/app/wpt-sync/sync/tasks.py", line 41, in inner
    return f(*args, **kwargs)
  File "/app/wpt-sync/sync/command.py", line 262, in do_update
    update.update_from_github(git_gecko, git_wpt, sync_classes, kwargs["status"])
  File "/app/wpt-sync/sync/update.py", line 217, in update_from_github
    update_pr(git_gecko, git_wpt, pr)
  File "/app/wpt-sync/sync/update.py", line 169, in update_pr
    sync.update_status(pr.state, merge_sha)
TypeError: update_status() takes exactly 4 arguments (3 given)

Traceback (most recent call last):
  File "/app/venv/bin/wptsync", line 11, in <module>
    load_entry_point('sync', 'console_scripts', 'wptsync')()
  File "/app/wpt-sync/sync/command.py", line 521, in main
    args.func(git_gecko, git_wpt, **vars(args))
  File "/app/wpt-sync/sync/tasks.py", line 41, in inner
    return f(*args, **kwargs)
  File "/app/wpt-sync/sync/command.py", line 262, in do_update
    update.update_from_github(git_gecko, git_wpt, sync_classes, kwargs["status"])
  File "/app/wpt-sync/sync/update.py", line 217, in update_from_github
    update_pr(git_gecko, git_wpt, pr)
  File "/app/wpt-sync/sync/update.py", line 169, in update_pr
    sync.update_status(pr.state, merge_sha)
TypeError: update_status() takes exactly 4 arguments (3 given)
```