### PR TITLE
On landing, do a try push with metadata updates but without retrggering.

### DIFF
--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -244,7 +244,7 @@ class TryPush(base.ProcessData):
 
     @classmethod
     def create(cls, sync, affected_tests=None, stability=False, hacks=True,
-               try_cls=TrySyntaxCommit, **kwargs):
+               try_cls=TrySyntaxCommit, rebuild_count=None, **kwargs):
         logger.info("Creating try push for PR %s" % sync.pr)
         if not tree.is_open("try"):
             logger.info("try is closed")
@@ -252,7 +252,8 @@ class TryPush(base.ProcessData):
 
         git_work = sync.gecko_worktree.get()
 
-        rebuild_count = 0 if not stability else 10
+        if rebuild_count is None:
+            rebuild_count = 0 if not stability else 10
         with try_cls(sync.git_gecko, git_work, affected_tests, rebuild_count, hacks=hacks,
                      **kwargs) as c:
             try_rev = c.push()


### PR DESCRIPTION
The current design was predicated on the idea that metadata from PR
try runs would usually be accurate enough that metadata updates
wouldn't be required on landing. But in practice this doesn't seem to
be the case. Given that, the disadvantage of the previous approach is
that end up retriggering many hundreds of jobs on each push, and the
resulting metadata update causes problems like poor performance and
OOM due to the number of logs being consumed.

A simple switcharound implemented here is, assuming the first try push
fails, to do a metadata update without any retriggers and perform a
new try push. If that try push also fails, we fall back to the current
approach of retriggering failed jobs to check for intermittents.