### PR TITLE
Ensure that try: doesn't appear in landing commit messages.

### DIFF
--- a/sync/commit.py
+++ b/sync/commit.py
@@ -34,6 +34,16 @@ def get_metadata(text):
     return data
 
 
+def try_filter(msg):
+    # It turns out that the string "try:" is forbidden anywhere in gecko commits,
+    # because we (mistakenly) think that this always means it's a try string. So we insert
+    # a ZWSP which means that the try syntax regexp doesn't match, but the printable
+    # representation of the commit message doesn't change
+    try_re = re.compile(r"(\b)try:")
+    msg, _ = try_re.subn(u"\\1try\u200B:", msg)
+    return msg
+
+
 class GitNotes(object):
     def __init__(self, commit):
         self.commit = commit

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -565,13 +565,7 @@ class DownstreamSync(base.SyncProcess):
         return commits
 
     def message_filter(self, msg):
-        # It turns out that the string "try:" is forbidden anywhere in gecko commits,
-        # because we (mistakenly) think that this always means it's a try string. So we insert
-        # a ZWSP which means that the try syntax regexp doesn't match, but the printable
-        # representation of the commit message doesn't change
-        try_re = re.compile(r"(\b)try:")
-        msg, _ = try_re.subn(u"\\1try\u200B:", msg)
-
+        msg = sync_commit.try_filter(msg)
         parts = msg.split("\n", 1)
         if len(parts) > 1:
             summary, body = parts

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -131,6 +131,8 @@ Automatic update from web-platform-tests%s
                              pr.title,
                              "\n--\n".join(item.msg for item in wpt_commits) + "\n--")
 
+        message = sync_commit.try_filter(message)
+
         upstream_changed = set()
         for commit in wpt_commits:
             stats = commit.commit.stats


### PR DESCRIPTION
Previously we fixed this for try push messages only. The string try: is not allowed
in hg.mozilla.org commits since it can be confused for a try message. But it's relatively
common in Chromium commits. We need to ensure it's removed when creating a landing commit.