### PR TITLE
Reset sync status to open before trying to update commits.

### DIFF
--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -673,6 +673,7 @@ def update_modified_sync(git_gecko, git_wpt, sync):
             logger.info("Sync was already fully applied upstream, not creating a PR")
             return
     else:
+        sync.status = "open"
         try:
             sync.update_wpt_commits()
         except AbortError:
@@ -691,7 +692,6 @@ def update_modified_sync(git_gecko, git_wpt, sync):
                     # Reset the base to origin/master
                     sync.set_wpt_base("origin/master")
                     raise
-        sync.status = "open"
 
     sync.update_github()
 


### PR DESCRIPTION
Otherwise we can lose stuff that should be upstreamed but was bsacked out if the post-backout
commits end up with a merge conflict (because we won't typically look for errors in incomplete
upstream syncs, but will in open ones).