### PR TITLE
Use wptreport.json files for metadata updates.

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -917,7 +917,13 @@ def record_too_many_failures(sync, try_push):
 
 
 def update_metadata(sync, try_push, intermittents=None):
-    log_files = try_push.download_raw_logs(exclude=intermittents)
+    wpt_tasks = try_push.download_logs(raw=False, report=True, exclude=intermittents)
+    log_files = []
+    for task in wpt_tasks:
+        for run in task.get("status", {}).get("runs", []):
+            log = run.get("_log_paths", {}).get("wptreport.json")
+            if log:
+                log_files.append(log)
     if not log_files:
         logger.warning("No log files found for try push %r" % try_push)
     sync.update_metadata(log_files)

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -82,7 +82,7 @@ def test_land_commit(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, se
 
     try_push = sync.latest_try_push
     try_push.taskgroup_id = "abcdef"
-    with patch.object(try_push, "download_raw_logs", Mock(return_value=[])):
+    with patch.object(try_push, "download_logs", Mock(return_value=[])):
         with patch.object(tc.TaskGroup, "tasks",
                           property(Mock(return_value=mock_tasks(completed=["foo"])))):
             landing.try_push_complete(git_gecko, git_wpt, try_push, sync)
@@ -146,10 +146,10 @@ def test_download_logs_after_retriggers_complete(git_gecko, git_wpt, try_push, m
     )
     with patch.object(tc.TaskGroup, "tasks", property(mock_tasks)):
         sync = landing.update_landing(git_gecko, git_wpt)
-        try_push.download_raw_logs = Mock(return_value=[])
+        try_push.download_logs = Mock(return_value=[])
         try_push["stability"] = True
         landing.try_push_complete(git_gecko, git_wpt, try_push, sync)
-        try_push.download_raw_logs.assert_called_with(exclude=["foo"])
+        try_push.download_logs.assert_called_with(raw=False, report=True, exclude=["foo"])
         assert sync.status == "open"
         assert try_push.status == "complete"
 
@@ -159,10 +159,10 @@ def test_no_download_logs_after_all_try_tasks_success(git_gecko, git_wpt, try_pu
     tasks = Mock(return_value=mock_tasks(completed=["bar", "baz", "boo"]))
     with patch.object(tc.TaskGroup, "tasks", property(tasks)):
         sync = landing.update_landing(git_gecko, git_wpt)
-        try_push.download_raw_logs = Mock(return_value=[])
+        try_push.download_logs = Mock(return_value=[])
         landing.try_push_complete(git_gecko, git_wpt, try_push, sync)
         # no intermittents in the try push
-        try_push.download_raw_logs.assert_not_called()
+        try_push.download_logs.assert_not_called()
         assert sync.status == "open"
         assert try_push.status == "complete"
 
@@ -258,7 +258,7 @@ def test_landing_reapply(env, git_gecko, git_wpt, git_wpt_upstream, pull_request
 
     try_push = sync.latest_try_push
     try_push.taskgroup_id = "abcde"
-    try_push.download_raw_logs = Mock(return_value=[])
+    try_push.download_logs = Mock(return_value=[])
     with patch.object(tc.TaskGroup, "tasks",
                       property(Mock(return_value=mock_tasks(completed=["foo"])))):
         landing.try_push_complete(git_gecko, git_wpt, try_push, sync)


### PR DESCRIPTION
These are smaller and can now be used as the basis of metadata updates.