### PR TITLE
Add a command line option to allow rebases from wptsync pr.

### DIFF
--- a/sync/command.py
+++ b/sync/command.py
@@ -80,6 +80,8 @@ def get_parser():
 
     parser_pr = subparsers.add_parser("pr", help="Update the downstreaming for a specific PR")
     parser_pr.add_argument("pr_id", default=None, nargs="?", help="PR number")
+    parser_pr.add_argument("--rebase", default=False, action="store_true",
+                           help="Force the PR to be rebase onto the integration branch")
     parser_pr.set_defaults(func=do_pr)
 
     parser_bug = subparsers.add_parser("bug", help="Update the upstreaming for a specific bug")
@@ -310,7 +312,7 @@ def do_pr(git_gecko, git_wpt, pr_id, *args, **kwargs):
         pr_id = sync_from_path(git_gecko, git_wpt).pr
     pr = env.gh_wpt.get_pull(int(pr_id))
     update_repositories(git_gecko, git_wpt, True)
-    update.update_pr(git_gecko, git_wpt, pr)
+    update.update_pr(git_gecko, git_wpt, pr, kwargs["rebase"])
 
 
 @with_lock

--- a/sync/update.py
+++ b/sync/update.py
@@ -120,7 +120,7 @@ def update_push(git_gecko, git_wpt, rev, base_rev=None, processes=None):
     handle_sync(*args)
 
 
-def update_pr(git_gecko, git_wpt, pr):
+def update_pr(git_gecko, git_wpt, pr, force_rebase=False):
     sync = get_pr_sync(git_gecko, git_wpt, pr.number)
 
     if sync and sync.status == "complete":
@@ -142,6 +142,9 @@ def update_pr(git_gecko, git_wpt, pr):
             schedule_pr_task("opened", pr)
             update_for_status(pr)
     elif isinstance(sync, downstream.DownstreamSync):
+        if force_rebase:
+            sync.gecko_rebase(sync.gecko_integration_branch())
+
         if len(sync.wpt_commits) == 0:
             sync.update_wpt_commits()
 


### PR DESCRIPTION
By default we don't rebase when updating PRs, but we may want to do so
where it will fix a conflict (in the future we may wan to make this the default)