### PR TITLE
Skip merge commits in some cases

### DIFF
--- a/sync/commit.py
+++ b/sync/commit.py
@@ -45,6 +45,12 @@ def try_filter(msg):
     return msg
 
 
+def first_non_merge(commits):
+    for item in commits:
+        if not item.is_merge:
+            return item
+
+
 class GitNotes(object):
     def __init__(self, commit):
         self.commit = commit

--- a/sync/gh.py
+++ b/sync/gh.py
@@ -134,6 +134,12 @@ class GitHub(object):
             review_by_reviewer[review.user.login] = review.state
         return "APPROVED" in review_by_reviewer.values()
 
+    def merge_sha(self, pr_id):
+        pr = self.get_pull(pr_id)
+        if pr.merged:
+            return pr.merge_commit_sha
+        return None
+
     def is_mergeable(self, pr_id):
         pr = self.get_pull(pr_id)
         return pr.mergeable
@@ -230,6 +236,7 @@ class MockGitHub(GitHub):
             "base": {"ref": base},
             "head": head,
             "merged": False,
+            "merge_commit_sha": "%040x" % random.getrandbits(160),
             "state": "open",
             "mergeable": True,
             "_approved": True,
@@ -294,6 +301,12 @@ class MockGitHub(GitHub):
             raise ValueError
         pr["state"] = "closed"
 
+    def merge_sha(self, pr_id):
+        pr = self.get_pull(pr_id)
+        if pr.merged:
+            return pr.merge_commit_sha
+        return None
+
     def merge_pull(self, pr_id):
         pr = self.get_pull(pr_id)
         if self.is_mergeable:
@@ -302,6 +315,7 @@ class MockGitHub(GitHub):
             # TODO: raise the right kind of error here
             raise ValueError
         self._log("Merged PR with id %s" % pr_id)
+        return pr.merge_commit_sha
 
     def is_approved(self, pr_id):
         pr = self.get_pull(pr_id)

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -395,6 +395,13 @@ class UpstreamSync(base.SyncProcess):
             logger.info("No upstream PR created")
             return False
 
+        merge_sha = env.gh_wpt.merge_sha(self.pr)
+        if merge_sha:
+            logger.info("PR already merged")
+            self.merge_sha = merge_sha
+            self.finish("wpt-merged")
+            return
+
         logger.info("Commit are landable; trying to land %s" % self.pr)
 
         msg = None


### PR DESCRIPTION
We were hitting a problem when a PR we upstreamed was manually merged with a merge
commit. In this case different codepaths disagreed about whether the commit was actually
an upstream commit since the merge commit itself didn't have the expected metadata.
So this change skips those merge commits where possible and fixes some diff generation
to not consider the merge commit because a diff including a merge shows changes
from both sides when we only want changes on one side of the merge. The approach
here is not ideal, but since there is a plan to forbid merge commits upstream it's
probably good enough.