### PR TITLE
Go thorugh update landing code when the landing appears ready.

### DIFF
--- a/sync/command.py
+++ b/sync/command.py
@@ -268,10 +268,7 @@ def do_landing(git_gecko, git_wpt, *args, **kwargs):
                                           allow_push=kwargs["push"],
                                           accept_failures=accept_failures)
         elif try_push.status == "complete" and not try_push.infra_fail:
-            landing.push_to_gecko(git_gecko,
-                                  git_wpt,
-                                  current_landing,
-                                  allow_push=kwargs["push"])
+            update_landing()
         elif try_push.status == "complete":
             if kwargs["retry"]:
                 update_landing()


### PR DESCRIPTION
This ensures that we have a single entry point and run any logic about retriggering etc.