### PR TITLE
Ignore status changes for prs relating to merged upstream syncs

### DIFF
--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -801,6 +801,9 @@ def gecko_push(git_gecko, git_wpt, repository_name, hg_rev, raise_on_error=False
 @base.entry_point("upstream")
 def commit_status_changed(git_gecko, git_wpt, sync, context, status, url, sha):
     landed = False
+    if sync.status != "open":
+        return True
+
     if status == "pending":
         # Never change anything for pending
         return landed


### PR DESCRIPTION
This was creating bugzilla noise when some optional jobs failed.