### PR TITLE
Allow the sync to support multiple processes

### DIFF
--- a/bin/run_docker_dev.sh
+++ b/bin/run_docker_dev.sh
@@ -24,8 +24,8 @@ if [[ $command == "build" ]]; then
       && ssh-keygen -f workspace/ssh/id_github -t rsa -b 4096 \
       && echo "Creating development credentials for hg.m.o" \
       && ssh-keygen -f workspace/ssh/id_hgmo -t rsa -b 4096 -C wptsync@mozilla.com \
-      && echo "Creating repos directory"
-      mkdir repos
+      && echo "Creating repos directory" \
+      && mkdir repos
     }
     docker build -t wptsync_dev --file docker/Dockerfile.dev .
 elif [[ $command == "test" ]]; then

--- a/sync.ini
+++ b/sync.ini
@@ -5,6 +5,7 @@ repos = .
 worktrees = work
 logs = logs
 try_logs = data
+locks = locks
 
 [pulse]
 username = %SECRET%

--- a/sync/commit.py
+++ b/sync/commit.py
@@ -13,7 +13,7 @@ from errors import AbortError
 env = Environment()
 logger = log.get_logger(__name__)
 
-METADATA_RE = re.compile("([^\:]*): (.*)")
+METADATA_RE = re.compile("\s*([^\:]*): (.*)")
 
 
 class ShowError(Exception):

--- a/sync/gitutils.py
+++ b/sync/gitutils.py
@@ -5,6 +5,7 @@ import git
 import log
 from env import Environment
 from errors import RetryableError
+from lock import RepoLock
 
 env = Environment()
 
@@ -47,19 +48,21 @@ def until(func, cond, max_tries=5):
 
 
 def _update_gecko(git_gecko, include_autoland):
-    logger.info("Fetching mozilla-unified")
-    # Not using the built in fetch() function since that tries to parse the output
-    # and sometimes fails
-    git_gecko.git.fetch("mozilla")
+    with RepoLock(git_gecko):
+        logger.info("Fetching mozilla-unified")
+        # Not using the built in fetch() function since that tries to parse the output
+        # and sometimes fails
+        git_gecko.git.fetch("mozilla")
 
-    if include_autoland and "autoland" in [item.name for item in git_gecko.remotes]:
-        logger.info("Fetching autoland")
-        git_gecko.git.fetch("autoland")
+        if include_autoland and "autoland" in [item.name for item in git_gecko.remotes]:
+            logger.info("Fetching autoland")
+            git_gecko.git.fetch("autoland")
 
 
 def _update_wpt(git_wpt):
-    logger.info("Fetching web-platform-tests")
-    git_wpt.git.fetch("origin")
+    with RepoLock(git_wpt):
+        logger.info("Fetching web-platform-tests")
+        git_wpt.git.fetch("origin")
 
 
 def refs(git, prefix=None):

--- a/sync/lock.py
+++ b/sync/lock.py
@@ -1,0 +1,306 @@
+import inspect
+import os
+
+import filelock
+
+import log
+from env import Environment
+
+env = Environment()
+
+logger = log.get_logger(__name__)
+
+
+"""
+Locking system for the wpt sync.
+
+There are two principal kinds of lock defined here; the RepoLock that's
+used to protect against concurrent writes to the underlying storage, and
+the SyncLock, which is used to ensure that multiples processes don't try
+to update the same sync at the same time.
+
+Since the sync is run from multiple processes without shared memory,
+and each process is single threaded, the locks must be based on files.
+
+A RepoLock is pretty straightforward; only one process is allowed to
+acquire the RepoLock at a time. Like all locks it's intended to be used
+as a context manager, and there's a repo_lock decoration for functions
+and methods that must acquire the lock for their entire body.
+
+For the SyncLock, things are more complex. Processes are put into the
+following groups:
+* All upstream syncs
+* All landing syncs
+* Downstream syncs for each pr
+
+Within each group operations that update data must be sequenced i.e.
+there is a lock that must be obtained for each group when writing.
+That lock is represented by the SyncLock object and it has an
+associated "subtype" which is the kind of sync (upstream, downstream,
+or landing) and object id which is the PR id for downstream syncs
+or None otherwise.
+
+In order to allow for read-only access to sync objects and to ensure
+that we don't have data races, functions and methods that cause mutation
+to the underlying data are annotated with the @mut() decorator. When
+applied to a class method this does the following
+
+* Ensures that the instance has a property called _lock
+* Ensures that the _lock property is a acquired SyncLock with the
+  right attributes for mutation of this class.
+
+In order to set the properties, classes with mutable state must provide
+an as_mut() method that takes the current lock as an argument. This returns
+a context manager object that ensures mutation methods are accessible for
+the defined context. This is clearer with an example:
+
+# Ensure we have the lock for upstream syns
+with SyncLock("upstream", None) as lock:
+   sync = UpstreamSync.for_bug(git_gecko, git_wpt, bug)
+
+   # Reading the sync is possible here
+   print sync.status
+
+   # But writing will fail unless we are in a mut block
+   with sync.as_mut(lock):
+       sync.update_wpt_commits()
+
+The @mut decorator can also be used on functions to check that arguments
+passed into those functions are available for mutation; in this case the
+decorator takes the names of the arguments to check e.g.
+
+@mut("sync")
+def some_update_fn(git_gecko, git_wpt, sync):
+    # Sync must be mutable here or we would fail
+    sync.update_wpt_commits()
+
+Constructing new objects is also a form of mutation, but because an object
+doesn't exist yet a slightly different approach is required. The
+@constructor decorator marks a classmethod that creates new instances and
+can only be called with an appropriate lock. But in this case the lock is
+passed as the first argument to the function, and the lock checking is done
+by providing a function argument to the decorator that takes the arguments
+to the constructor and returns a (subtype, obj_id) pair used to check for
+lock validity e.g.
+
+@classmethod
+@constructor(lambda kwargs: (kwargs["process_name"].subtype,
+                             kwargs["process_name"].obj_id))
+def create(cls, lock, git_gecko, git_wpt, process_name):
+    pass
+
+All objects that can cause mutation of the underlying sync data must
+implement this locking system. In order to do so, the object must
+provide the following methods and properties:
+
+property _lock - None or a SyncLock representing the currenly held lock
+method lock_key - Returns the (subtype, obj_id) pair for the current
+                  instance, used to ensure the lock is valid
+method as_mut - Used to make the object mutable. Returns a MutGuard
+                wrapping the current object.
+
+"""
+
+
+def repo_lock(f):
+    def inner(repo, *args, **kwargs):
+        with RepoLock(repo):
+            return f(repo, *args, **kwargs)
+    inner.__name__ = f.__name__
+    inner.__doc__ = f.__doc__
+    return inner
+
+
+class LockError(Exception):
+    pass
+
+
+class Lock(object):
+    locks = {}
+
+    def __init__(self, *args):
+        self.path = self.lock_path(*args)
+        self.lock = filelock.FileLock(self.path)
+
+    def __enter__(self):
+        if self.path in self.locks:
+            raise LockError("Tried to reacquire lock for %s in same process")
+        self.locks[self.path] = self
+        self.lock.acquire()
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        assert self.locks[self.path] is self
+        del self.locks[self.path]
+        self.lock.release()
+
+    @staticmethod
+    def lock_path(*args):
+        """Return a path to the file representing the current lock"""
+        raise NotImplementedError
+
+
+class RepoLock(Lock):
+    def __init__(self, repo):
+        super(RepoLock, self).__init__(repo)
+
+    @staticmethod
+    def lock_path(repo):
+        return os.path.join(
+            env.config["root"],
+            env.config["paths"]["locks"],
+            "%s.lock" % (repo.working_dir.replace(os.path.sep, "_"),))
+
+
+class SyncLock(Lock):
+    lock_per_type = {"landing", "upstream"}
+    lock_per_obj = {"downstream"}
+
+    locks = {}
+
+    def __init__(self, sync_type, obj_id):
+        assert sync_type in self.lock_per_obj | self.lock_per_type
+
+        if sync_type in self.lock_per_type:
+            if obj_id is not None:
+                raise ValueError("%s must be locked over all objects" % sync_type)
+        elif obj_id is None:
+            raise ValueError("%s must be locked over each object" % sync_type)
+        self.sync_type = sync_type
+        self.obj_id = obj_id
+        super(SyncLock, self).__init__(sync_type, obj_id)
+
+    @classmethod
+    def for_process(cls, process_name):
+        """Get the SyncLock for the provided ProcessName."""
+        sync_type = process_name.subtype
+        obj_id = process_name.obj_id if sync_type in cls.lock_per_obj else None
+        return cls(sync_type, obj_id)
+
+    def check(self, sync_type, obj_id):
+        """Check that the current lock is valid for the provided sync_type and obj_id"""
+        if sync_type in self.lock_per_type:
+            obj_id = None
+        if not (sync_type == self.sync_type and
+                obj_id == self.obj_id and
+                self.lock.is_locked):
+            raise ValueError("""Got wrong lock, expected sync_type:%s obj_id:%s locked:True,
+                got: sync_type:%s obj_id:%s locked:%s""" %
+                             (sync_type,
+                              obj_id,
+                              self.sync_type,
+                              self.obj_id,
+                              self.lock.is_locked))
+
+    @staticmethod
+    def lock_path(sync_type, obj_id):
+        if obj_id is None:
+            filename = "%s.lock" % sync_type
+        else:
+            filename = "%s_%s.lock" % (sync_type, obj_id)
+        return os.path.join(
+            env.config["root"],
+            env.config["paths"]["locks"],
+            filename)
+
+
+class MutGuard(object):
+    def __init__(self, lock, instance, props=None):
+        """Context Manager wrapping an object that is to be accessed for mutation.
+
+        Mutability is re-entrant in the sense that if we already have a certain object
+        in a mutable state, an attempt to make the same object mutable using the same
+        lock will succeed.
+        """
+        self.instance = instance
+        self.lock = lock
+        self.props = props or []
+        self.owned_guards = []
+        lock.check(*instance.lock_key)
+        self.took_lock = None
+
+    def __enter__(self):
+        logger.debug("Making object mutable %r" % self.instance)
+        if self.instance._lock is not None:
+            if self.instance._lock is not self.lock:
+                raise ValueError("Tried to re-lock %s with a different lock" % self.instance)
+            self.took_lock = False
+            return
+
+        self.took_lock = True
+        self.instance._lock = self.lock
+
+        for prop in self.props:
+            if prop._lock is None:
+                self.owned_guards.append(prop.as_mut(self.lock))
+                self.owned_guards[-1].__enter__()
+
+        return self.instance
+
+    def __exit__(self, *args, **kwargs):
+        try:
+            if not self.took_lock:
+                return
+            while self.owned_guards:
+                guard = self.owned_guards.pop()
+                guard.__exit__(*args, **kwargs)
+            self.instance._lock = None
+        finally:
+            self.took_lock = None
+
+
+class mut(object):
+    def __init__(self, *args):
+        """Mark a function as requiring given arguments are mutable.
+
+        When entering the function the decorator checks that the specified
+        arguments are locked for mutation with an appropriate lock.
+
+        When no arguments are specified, self is used as a default,
+        appropriate for marking instance methods that require the
+        object to be locked for mutation."""
+        if not args:
+            args = ("self",)
+        self.args = args
+
+    def __call__(self, f):
+        def inner(*args, **kwargs):
+            arg_values = inspect.getcallargs(f, *args, **kwargs)
+
+            for arg in self.args:
+                arg_value = arg_values[arg]
+                if arg_value._lock is None:
+                    raise ValueError("Tried to use %r as mutable without locking" % arg_value)
+                arg_value._lock.check(*arg_value.lock_key)
+
+            return f(*args, **kwargs)
+        inner.__name__ = f.__name__
+        inner.__doc__ = f.__doc__
+        return inner
+
+
+class constructor(object):
+    def __init__(self, arg_func):
+        """Mark a classmethod as a constructor for an object which uses the
+        mutation system.
+
+        The decorator takes a single function as an argument. This function
+        is run against the arguments provided to the decorator and returns a
+        tuple of (subtype, obj_id) representing the kind of lock that needs
+        to be held to construct the object."""
+
+        self.arg_func = arg_func
+
+    def __call__(self, f):
+        def inner(cls, lock, *args, **kwargs):
+            if lock is None:
+                raise ValueError("Tried to access constructor %s without locking")
+
+            arg_values = inspect.getcallargs(f, cls, lock, *args, **kwargs)
+            sync_type, obj_id = self.arg_func(arg_values)
+
+            lock.check(sync_type, obj_id)
+            return f(cls, lock, *args, **kwargs)
+        inner.__name__ = f.__name__
+        inner.__doc__ = f.__doc__
+        return inner

--- a/sync/lock.py
+++ b/sync/lock.py
@@ -244,6 +244,8 @@ class MutGuard(object):
             while self.owned_guards:
                 guard = self.owned_guards.pop()
                 guard.__exit__(*args, **kwargs)
+            if hasattr(self.instance, "exit_mut"):
+                self.instance.exit_mut()
             self.instance._lock = None
         finally:
             self.took_lock = None

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -3,52 +3,58 @@ import gc
 import pytest
 
 from sync import base
+from sync.lock import SyncLock
 
 
 def test_processname_update(git_gecko):
     commit = git_gecko.commit("FETCH_HEAD")
 
-    p = base.ProcessName("test", "subtype", "open", "1")
-    assert str(p) == "test/subtype/open/1"
-    assert p.name_filter() == "test/subtype/*/1"
+    p = base.ProcessName("test", "upstream", "open", "1")
+    assert str(p) == "test/upstream/open/1"
+    assert p.name_filter() == "test/upstream/*/1"
     assert p.obj_type == "test"
-    assert p.subtype == "subtype"
+    assert p.subtype == "upstream"
     assert p.status == "open"
     assert p.obj_id == "1"
 
-    ref = base.DataRefObject.create(git_gecko, p, commit)
-    assert p._refs == set([ref])
+    with SyncLock("upstream", None) as lock:
+        ref = base.DataRefObject.create(lock, git_gecko, p, commit)
+        assert p._refs == set([ref])
 
-    assert ref.path == "refs/syncs/test/subtype/open/1"
-    assert ref.ref is not None
-    assert ref.commit.sha1 == commit.hexsha
+        assert ref.path == "refs/syncs/test/upstream/open/1"
+        assert ref.ref is not None
+        assert ref.commit.sha1 == commit.hexsha
 
-    p.status = "complete"
-    assert str(p) == "test/subtype/complete/1"
-    assert ref.path == "refs/syncs/test/subtype/complete/1"
-    assert p._refs == set([ref])
+        with p.as_mut(lock):
+            p.status = "complete"
+        assert str(p) == "test/upstream/complete/1"
+        assert ref.path == "refs/syncs/test/upstream/complete/1"
+        assert p._refs == set([ref])
 
 
 def test_ref_duplicate(git_gecko):
     commit = git_gecko.commit("FETCH_HEAD")
 
     def create_initial():
-        p = base.ProcessName("test", "subtype", "open", "1")
-        base.DataRefObject.create(git_gecko, p, commit)
+        p = base.ProcessName("test", "upstream", "open", "1")
+        with SyncLock("upstream", None) as lock:
+            base.DataRefObject.create(lock, git_gecko, p, commit)
     create_initial()
     # Ensure that the p object has been gc'd
     gc.collect()
 
-    q = base.ProcessName("test", "subtype", "closed", "1")
+    q = base.ProcessName("test", "upstream", "closed", "1")
     assert q._refs == set()
     with pytest.raises(ValueError):
-        base.DataRefObject.create(git_gecko, q, commit)
+        with SyncLock("upstream", None) as lock:
+            base.DataRefObject.create(lock, git_gecko, q, commit)
 
 
 def test_process_name(git_gecko, local_gecko_commit):
     commit = local_gecko_commit(test_changes={"README": "Example change"})
     process_name_no_seq_id = base.ProcessName("sync", "upstream", "open", "1234")
-    base.DataRefObject.create(git_gecko, process_name_no_seq_id, commit)
+    with SyncLock("upstream", None) as lock:
+        base.DataRefObject.create(lock, git_gecko, process_name_no_seq_id, commit)
 
     process_name_seq_id = base.ProcessName.with_seq_id(git_gecko, "syncs", "sync",
                                                        "upstream", "open", "1234")

--- a/test/test_try.py
+++ b/test/test_try.py
@@ -1,6 +1,7 @@
 from mock import Mock, patch
 
 from sync import tc, trypush
+from sync.lock import SyncLock
 
 
 def test_try_message_no_tests():
@@ -27,26 +28,30 @@ def test_try_task_states(mock_tasks, try_push):
     tasks = Mock(return_value=mock_tasks(
         completed=["foo", "bar"] * 5, failed=["foo", "foo", "bar", "baz"]
     ))
-    with patch.object(tc.TaskGroup, "tasks", property(tasks)):
-        states = try_push.wpt_states()
-    assert not try_push.success()
-    assert set(states.keys()) == {"baz", "foo", "bar"}
-    assert states["foo"]["states"][tc.SUCCESS] == 5
-    assert states["foo"]["states"][tc.FAIL] == 2
-    assert states["bar"]["states"][tc.SUCCESS] == 5
-    assert states["bar"]["states"][tc.FAIL] == 1
-    assert states["baz"]["states"][tc.FAIL] == 1
-    retriggered_states = try_push.retriggered_wpt_states()
-    assert try_push.success_rate() == float(10) / len(tasks())
-    # baz is not retriggered, only occurs once
-    assert retriggered_states.keys() == ["foo", "bar"]
+    with SyncLock.for_process(try_push.process_name) as lock:
+        with try_push.as_mut(lock):
+            with patch.object(tc.TaskGroup, "tasks", property(tasks)):
+                states = try_push.wpt_states()
+            assert not try_push.success()
+            assert set(states.keys()) == {"baz", "foo", "bar"}
+            assert states["foo"]["states"][tc.SUCCESS] == 5
+            assert states["foo"]["states"][tc.FAIL] == 2
+            assert states["bar"]["states"][tc.SUCCESS] == 5
+            assert states["bar"]["states"][tc.FAIL] == 1
+            assert states["baz"]["states"][tc.FAIL] == 1
+            retriggered_states = try_push.retriggered_wpt_states()
+            assert try_push.success_rate() == float(10) / len(tasks())
+            # baz is not retriggered, only occurs once
+            assert retriggered_states.keys() == ["foo", "bar"]
 
 
 def test_try_task_states_all_success(mock_tasks, try_push):
     tasks = Mock(return_value=mock_tasks(completed=["foo", "bar"] * 5))
-    with patch.object(tc.TaskGroup, "tasks", property(tasks)):
-        assert try_push.success()
-        assert try_push.success_rate() == 1.0
+    with SyncLock.for_process(try_push.process_name) as lock:
+        with try_push.as_mut(lock):
+            with patch.object(tc.TaskGroup, "tasks", property(tasks)):
+                assert try_push.success()
+                assert try_push.success_rate() == 1.0
 
 
 def test_retrigger_failures(mock_tasks, try_push):
@@ -56,9 +61,12 @@ def test_retrigger_failures(mock_tasks, try_push):
         completed=["foo", "bar"] * 5, failed=failed, exception=ex
     ))
     retrigger_count = 5
-    with patch.object(tc.TaskGroup, "tasks", property(tasks)):
-        with patch('sync.trypush.auth_tc.retrigger', return_value=["job"] * retrigger_count):
-            jobs = try_push.retrigger_failures(count=retrigger_count)
+    with SyncLock.for_process(try_push.process_name) as lock:
+        with try_push.as_mut(lock):
+            with patch.object(tc.TaskGroup, "tasks", property(tasks)):
+                with patch('sync.trypush.auth_tc.retrigger',
+                           return_value=["job"] * retrigger_count):
+                    jobs = try_push.retrigger_failures(count=retrigger_count)
     assert jobs == retrigger_count * len(set(failed + ex))
 
 
@@ -68,14 +76,16 @@ def test_download_logs_excluded(mock_tasks, try_push):
     tasks = Mock(return_value=mock_tasks(
         completed=["foo", "bar", "woo"] * 5, failed=failed, exception=ex
     ))
-    with patch.object(tc.TaskGroup, "tasks", property(tasks)):
-        with patch.object(tc.TaskGroupView, "download_logs", Mock()):
-            download_tasks = try_push.download_logs(exclude=["foo"])
-            task_names = [t["task"]["metadata"]["name"] for t in download_tasks]
-            assert task_names.count("foo") == 5
-            assert task_names.count("bar") == 7
-            assert task_names.count("woo") == 5
-            assert task_names.count("boo") == 1
-            assert task_names.count("baz") == 1
-            assert len(task_names) == 19
-            assert task_names.count("foo") == 5
+    with SyncLock.for_process(try_push.process_name) as lock:
+        with try_push.as_mut(lock):
+            with patch.object(tc.TaskGroup, "tasks", property(tasks)):
+                with patch.object(tc.TaskGroupView, "download_logs", Mock()):
+                    download_tasks = try_push.download_logs(exclude=["foo"])
+                    task_names = [t["task"]["metadata"]["name"] for t in download_tasks]
+                    assert task_names.count("foo") == 5
+                    assert task_names.count("bar") == 7
+                    assert task_names.count("woo") == 5
+                    assert task_names.count("boo") == 1
+                    assert task_names.count("baz") == 1
+                    assert len(task_names) == 19
+                    assert task_names.count("foo") == 5

--- a/test/testdata/sync.ini
+++ b/test/testdata/sync.ini
@@ -2,6 +2,7 @@
 repos = repos
 worktrees = work
 logs = logs
+locks = locks
 # testing only
 remotes = remotes
 try_logs = try_logs


### PR DESCRIPTION
This replaces the current global lock with locks around the following
processes:
* All upstreaming
* All landing
* Each PR being downstreamed

Separately locked processes are able to run concurrently, which should
allow the sync to be used interactively more easily and reduce the
latency of many operations.

In order to prove that you have the necessary write lock before
modifying data, the lock object is used as a token that must be passed
down into methods (and functions) with the @mut decorator. An
@constructor decorator is used for initial object creation.

Full details of the locking scheme are given in the sync/lock.py file.