### PR TITLE
Specify “task” bug type when filing a new bug

### DIFF
--- a/sync/bug.py
+++ b/sync/bug.py
@@ -97,6 +97,7 @@ class Bugzilla(object):
     def new(self, summary, comment, product, component, whiteboard=None, priority=None,
             url=None):
         bug = bugsy.Bug(self.bugzilla,
+                        type="task",
                         summary=summary,
                         product=product,
                         component=component)


### PR DESCRIPTION
Hi there! I have just realized that the Sync Bot suddenly started to file bugs on Bugzilla [without a bug type specified](https://bugzilla.mozilla.org/buglist.cgi?bug_type=--&reporter=wptsync%40mozilla.bugs). The `type` field is currently optional, but we’ll soon [make it required](https://bugzilla.mozilla.org/show_bug.cgi?id=1562364). Let’s use the “task” type for all new bugs.