### PR TITLE
Make GitHub check subject to a config setting

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -318,6 +318,8 @@ class DownstreamSync(SyncProcess):
 
     @mut()
     def update_github_check(self):
+        if not env.config["web-platform-tests"]["github"]["checks"]["enabled"]:
+            return
         title = "gecko/sync"
         head_sha = self.wpt_commits.head.sha1
 

--- a/test/config/sync.ini
+++ b/test/config/sync.ini
@@ -35,6 +35,7 @@ github.token = blah
 github.user = moz-wptsync-bot
 # for testing only
 path = %ROOT%/remotes/web-platform-tests
+github.checks.enabled=1
 
 [bugzilla]
 url = https://bugzilla-dev.allizom.org/rest


### PR DESCRIPTION
We can't use the checks API until we migrate to use a GitHub app, so
allow it to be disabled in the settings to prevent the log spam from
it always failing.