### PR TITLE
Use multiple statuses to handle intermittents where possible

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -772,12 +772,19 @@ class DownstreamSync(SyncProcess):
     @mut()
     def update_metadata(self, log_files, stability=False):
         meta_path = env.config["gecko"]["path"]["meta"]
-        args = log_files
-        if stability:
-            args.extend(["--stability", "wpt-sync Bug %s" % self.bug])
-
         gecko_work = self.gecko_worktree.get()
+
         mach = Mach(gecko_work.working_dir)
+        args = []
+
+        if stability:
+            help_text = mach.wpt_update("--help")
+            if "--stability " in help_text:
+                args.extend(["--stability", "wpt-sync Bug %s" % self.bug])
+            else:
+                args.append("--update-intermittent")
+        args.extend(log_files)
+
         logger.debug("Updating metadata")
         output = mach.wpt_update(*args)
         prefix = "disabled:"

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -569,7 +569,7 @@ Automatic update from web-platform-tests\n%s
             self.update_landing_commit()
 
     @mut()
-    def update_metadata(self, log_files):
+    def update_metadata(self, log_files, update_intermittents=False):
         """Update the web-platform-tests metadata based on the logs
         generated in a try run.
 
@@ -581,8 +581,15 @@ Automatic update from web-platform-tests\n%s
         gecko_work = self.gecko_worktree.get()
         mach = Mach(gecko_work.working_dir)
         logger.info("Updating metadata from %s logs" % len(log_files))
-        mach.wpt_manifest_update()
-        mach.wpt_update(*log_files)
+        args = []
+        if update_intermittents:
+            help_text = mach.wpt_update("--help")
+            if "--update-intermittent " in help_text:
+                args.append("--update-intermittent")
+            # We didn't use --stability here since it's unclear which
+            # bug it will be associated with
+        args.extend(log_files)
+        mach.wpt_update(*args)
 
         if gecko_work.is_dirty(untracked_files=True, path=meta_path):
             gecko_work.git.add(meta_path, all=True)
@@ -1019,7 +1026,7 @@ def update_metadata(sync, try_push, tasks=None, intermittents=None):
                 log_files.append(log)
     if not log_files:
         logger.warning("No log files found for try push %r" % try_push)
-    sync.update_metadata(log_files)
+    sync.update_metadata(log_files, update_intermittents=True)
 
 
 def push_to_gecko(git_gecko, git_wpt, sync, allow_push=True):


### PR DESCRIPTION
We run --update-intermittents with stability try pushes so that things
which have multiple runs with differing results end up marked as
intermittent with multiple statuses in the metadata. In order to handle
the possibility of old base commits with the previous --stability option
we look in the help output for the required options before using them.