### PR TITLE
Support adding needinfo when upstream PR can't merge

### DIFF
--- a/sync/commit.py
+++ b/sync/commit.py
@@ -155,6 +155,11 @@ class Commit(object):
         return "%s <%s>" % (name, email)
 
     @property
+    def email(self):
+        author = self.pygit2_commit.author
+        return author.email
+
+    @property
     def metadata(self):
         return get_metadata(self.msg)
 

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -875,8 +875,12 @@ def commit_status_changed(git_gecko, git_wpt, sync, context, status, url, sha):
             details = "\n".join(details)
             msg = ("Can't merge web-platform-tests PR due to failing upstream checks:\n%s" %
                    details)
-            env.bz.comment(sync.bug, msg)
-            sync.error = "Travis failed"
+            with env.bz.bug_ctx(sync.bug) as bug:
+                bug["comment"] = msg
+                commit_author = sync.gecko_commits[0].author
+                if commit_author:
+                    bug.needinfo(commit_author)
+            sync.error = "Checks failed"
             sync.last_pr_check = check
         else:
             logger.info("Some upstream web-platform-tests status checks still pending.")


### PR DESCRIPTION
This encourages authors to investigate when their PRs fail to merge
which should avoid some of the problem where we have many PRs that are
not merged fo rtrivial failures or need to manually ping authors.

This adds the beginnings of a new API for working with bugs that
allows making multiple changes before updating bugzilla, so that the
needinfo request and the comment come from a single conceptual place.