### PR TITLE
Don't try to reland upstream PRs if the commits didn't change.

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -236,9 +236,9 @@ Automatic update from web-platform-tests\n%s
         # If this is originally an UpstreamSync and no new changes were introduced to the GH PR
         # then we can safely skip and not need to re-apply these changes. Compare the hash of
         # the upstreamed gecko commits against the final hash in the PR.
-        last_gecko_rev = wpt_commits[-1].metadata.get('gecko-commit', None)
-        if isinstance(sync, upstream.UpstreamSync) and \
-                sync.upstreamed_gecko_commits[-1].canonical_rev == last_gecko_rev:
+        pr_ref = 'origin/pr/{}'.format(pr_id)
+        if (isinstance(sync, upstream.UpstreamSync) and
+                sync.wpt_commits.head.sha1 == sync.git_wpt.refs[pr_ref].commit.hexsha):
 
             logger.info("Upstream sync doesn't introduce any gecko changes")
             return

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -236,10 +236,8 @@ Automatic update from web-platform-tests\n%s
         # If this is originally an UpstreamSync and no new changes were introduced to the GH PR
         # then we can safely skip and not need to re-apply these changes. Compare the hash of
         # the upstreamed gecko commits against the final hash in the PR.
-        pr_ref = 'origin/pr/{}'.format(pr_id)
         if (isinstance(sync, upstream.UpstreamSync) and
-                sync.wpt_commits.head.sha1 == sync.git_wpt.refs[pr_ref].commit.hexsha):
-
+            sync.wpt_commits.head.sha1 == sync.pr_head):
             logger.info("Upstream sync doesn't introduce any gecko changes")
             return
 

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -469,6 +469,29 @@ class UpstreamSync(SyncProcess):
             else:
                 self.remote_branch = None
 
+    @property
+    def pr_head(self):
+        """
+        Retrieves the head of the PR ref: origin/pr/{pr_id}
+        :return: The SHA of the head commit.
+        """
+        if not self.pr:
+            logger.error("No PR ID found for %s" % self.process_name)
+            return
+
+        pr_ref = 'origin/pr/{}'.format(self.pr)
+
+        if pr_ref not in self.git_wpt.refs:
+            # Maybe we need to fetch?
+            self.git_wpt.remotes.origin.fetch()
+            if pr_ref not in self.git_wpt.refs:
+                # PR ref doesn't seem to exist
+                logger.error("No ref found for %s" % pr_ref)
+                return
+
+        ref = self.git_wpt.refs[pr_ref]
+        return ref.commit.hexsha
+
 
 def commit_message_filter(msg):
     metadata = {}

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -482,12 +482,9 @@ class UpstreamSync(SyncProcess):
         pr_ref = 'origin/pr/{}'.format(self.pr)
 
         if pr_ref not in self.git_wpt.refs:
-            # Maybe we need to fetch?
-            self.git_wpt.remotes.origin.fetch()
-            if pr_ref not in self.git_wpt.refs:
-                # PR ref doesn't seem to exist
-                logger.error("No ref found for %s" % pr_ref)
-                return
+            # PR ref doesn't seem to exist
+            logger.error("No ref found for %s" % pr_ref)
+            return
 
         ref = self.git_wpt.refs[pr_ref]
         return ref.commit.hexsha

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -397,6 +397,12 @@ def test_relanding_unchanged_upstreamed_pr(env, git_gecko, git_wpt, hg_gecko_ups
 
     assert str(git_wpt_upstream.active_branch) == "master"
     git_wpt_upstream.git.merge('gecko/1234')  # TODO avoid hardcoding?
+
+    # Create a ref on the upstream to simulate the pr than GH would setup
+    git_wpt_upstream.create_head(
+        'pr/%d' % pr['number'],
+        commit=git_wpt_upstream.refs['gecko/1234'].commit.hexsha
+    )
     git_wpt.remotes.origin.fetch()
     pr['merge_commit_sha'] = str(git_wpt_upstream.active_branch.commit.hexsha)
     env.gh_wpt.commit_prs[pr['merge_commit_sha']] = pr['number']


### PR DESCRIPTION
#379 

Added a test that replicates a potential scenario where this would arise:
1 - Create a pull request to wpt that is unrelated to Gecko and merge it
2 - Create a Gecko bug, upstream it, and merge this PR into wpt unchanged.
3 - Land the wpt changes into try/central

The LandingSync returned at step 3 should only have the PR from step 1 going into try, as it would have identified step 2's commit being from a Gecko bug and not even bothered trying to apply it.