### PR TITLE
Only download logs from try if some tasks actually failed

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -981,7 +981,7 @@ def try_push_complete(git_gecko, git_wpt, try_push, sync):
             else:
                 logger.info("Try push %r for PR %s complete" % (try_push, sync.pr))
                 disabled = []
-                if not tasks.success():
+                if tasks.has_failures():
                     if sync.affected_tests():
                         log_files = []
                         wpt_tasks = try_push.download_logs(tasks.wpt_tasks, raw=False)

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -530,8 +530,14 @@ class TryPushTasks(object):
         wpt_tasks = self.wpt_tasks
         if wpt_tasks:
             return all(task.get("status", {}).get("state") == tc.SUCCESS for task in wpt_tasks)
-        else:
-            return False
+        return False
+
+    def has_failures(self):
+        """Check if all the wpt tasks in a try push ended with a successful status"""
+        wpt_tasks = self.wpt_tasks
+        if wpt_tasks:
+            return any(task.get("status", {}).get("state") == tc.FAIL for task in wpt_tasks)
+        return False
 
     def success_rate(self):
         wpt_tasks = self.wpt_tasks

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -533,7 +533,7 @@ class TryPushTasks(object):
         return False
 
     def has_failures(self):
-        """Check if all the wpt tasks in a try push ended with a successful status"""
+        """Check if any of the wpt tasks in a try push ended with a failure status"""
         wpt_tasks = self.wpt_tasks
         if wpt_tasks:
             return any(task.get("status", {}).get("state") == tc.FAIL for task in wpt_tasks)


### PR DESCRIPTION
Previously we checked if all tasks were a success before running the
metadata update steps. But the weaker condition of "are any jobs
actually failing" makes more sense because only failing jobs might
have logs that will result in a metadata update, and we are already
allowing the possibility that jobs don't run (leading to a status of
exception or similar) earlier in the function.