### PR TITLE
Needinfo a config-defined list of users when bugs fail to apply to up…

### DIFF
--- a/config/dev/sync.ini
+++ b/config/dev/sync.ini
@@ -30,6 +30,7 @@ path.meta = testing/web-platform/meta
 worktree.max-count = 10
 logs.max-count = 20
 try.max-tests = 500
+upstream.needinfo-users=example@example.org,
 
 [web-platform-tests]
 repo.url = %ROOT%/remotes/web-platform-tests

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -733,6 +733,16 @@ def update_modified_sync(git_gecko, git_wpt, sync):
                 except AbortError:
                     # Reset the base to origin/master
                     sync.set_wpt_base("origin/master")
+                    with env.bz.bug_ctx(sync.bug) as bug:
+                        bug["comment"] = ("Failed to create upstream wpt PR for this bug due to "
+                                          "merge conflicts. This requires fixup from a wpt sync "
+                                          "admin.")
+                        needinfo_users = [item.strip() for item in
+                                          (env.config["gecko"]["upstream"]
+                                           .get("needinfo-users", "")
+                                           .split(","))]
+                        needinfo_users = [item for item in needinfo_users if item]
+                        bug.needinfo(*needinfo_users)
                     raise
 
     sync.update_github()


### PR DESCRIPTION
…stream.

This prevents the case where a patch won't apply to upstream and we fail to notice for some time
because people forget to check the list of syncs in the error state. The list of users is intended
to be the people who have access to the prod sync instance and so can fix the problem (it would be
more convenient to notify a single shared account, but it's unclear how that ought to work).