### PR TITLE
Stop repeating merge comments & stop race condition causing no merge comment

### DIFF
--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -348,6 +348,10 @@ class UpstreamSync(SyncProcess):
                     # If all the local commits are represented upstream, everything is
                     # fine and close out the sync. Otherwise we have a problem.
                     if len(self.upstreamed_gecko_commits) == len(self.gecko_commits):
+
+                        if self.status not in ("wpt-merged", "complete"):
+                            env.bz.comment(self.bug, "Upstream PR merged")
+
                         self.finish()
                     else:
                         # It's unclear what to do in this case, so mark the sync for manual
@@ -950,7 +954,7 @@ def update_pr(git_gecko, git_wpt, sync, action, merge_sha=None, base_sha=None):
             sync.merge_sha = merge_sha
             if not sync.wpt_commits and base_sha:
                 sync.set_wpt_base(base_sha)
-            if sync.status != "complete":
+            if sync.status not in ("complete", "wpt-merged"):
                 env.bz.comment(sync.bug, "Upstream PR merged")
                 sync.finish("wpt-merged")
     elif action == "reopened" or action == "open":


### PR DESCRIPTION
#377 
The issue here seemed to be caused by the code that is in charge of posting the merge comment in bugzilla doesn't then block off that execution path and will in theory re-post the comment agian and again if requested. 

#371 
Here the status of the sync was moved to "complete" without any check to notify bugzilla that the merge had been made. This meant that if update_github was called before the entry point update_pr, it would mark the sync as "complete" and update_pr would never notify bugzilla via comment. Checking the state of the sync before marking as "complete" should be enough to determine if we need to post a comment. 

Note: This will likely need a refactor later to the way status transitions and notification is handled, but for the time being these two changes should hopefully solve the issue

