### PR TITLE
Add a github label when there is a downstream error

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -123,8 +123,11 @@ class DownstreamSync(SyncProcess):
 
     @SyncProcess.error.setter
     def error(self, value):
-        if value is not None and self.pr:
-            env.gh_wpt.add_labels(self.pr, "mozilla:gecko-blocked")
+        if self.pr:
+            if value is not None:
+                env.gh_wpt.add_labels(self.pr, "mozilla:gecko-blocked")
+            else:
+                env.gh_wpt.remove_label(self.pr, "mozilla:gecko-blocked")
         return SyncProcess.error.fset(self, value)
 
     @property

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -127,7 +127,7 @@ class DownstreamSync(SyncProcess):
             if value is not None:
                 env.gh_wpt.add_labels(self.pr, "mozilla:gecko-blocked")
             else:
-                env.gh_wpt.remove_label(self.pr, "mozilla:gecko-blocked")
+                env.gh_wpt.remove_labels(self.pr, "mozilla:gecko-blocked")
         return SyncProcess.error.fset(self, value)
 
     @property

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -121,6 +121,12 @@ class DownstreamSync(SyncProcess):
         merged unless it happens to be a fast-forward"""
         return sync_commit.WptCommit(self.git_wpt, "origin/pr/%s" % self.pr)
 
+    @SyncProcess.error.setter
+    def error(self, value):
+        if value is not None and self.pr:
+            env.gh_wpt.add_labels(self.pr, "mozilla:gecko-blocked")
+        return SyncProcess.error.fset(self, value)
+
     @property
     def pr_status(self):
         return self.data.get("pr-status", "open")

--- a/sync/gh.py
+++ b/sync/gh.py
@@ -82,6 +82,16 @@ class GitHub(object):
         issue = self.repo.get_issue(pr_id)
         issue.add_to_labels(*labels)
 
+    def remove_labels(self, pr_id, *labels):
+        issue = self.repo.get_issue(pr_id)
+        for label in labels:
+            self.remove_label(pr_id, label, issue=issue)
+
+    def remove_label(self, pr_id, label, issue=None):
+        logger.debug("Removing label %s from PR %s" % (label, pr_id))
+        issue = self.repo.get_issue(pr_id) if issue is None else issue
+        issue.remove_from_labels(label)
+
     @staticmethod
     def _summary_state(statuses):
         states = {item.state for item in statuses}
@@ -347,6 +357,15 @@ class MockGitHub(GitHub):
 
     def add_labels(self, pr_id, *labels):
         self.get_pull(pr_id)["labels"].extend(labels)
+
+    def remove_labels(self, pr_id, *labels):
+        for label in labels:
+            self.remove_label(pr_id, label)
+
+    def remove_label(self, pr_id, label):
+        pr = self.get_pull(pr_id)
+        if label in pr["labels"]:
+            pr["labels"].remove(label)
 
     def get_combined_status(self, pr_id, exclude=None):
         if exclude is None:

--- a/sync/gh.py
+++ b/sync/gh.py
@@ -356,7 +356,7 @@ class MockGitHub(GitHub):
 
     def remove_labels(self, pr_id, *labels):
         pr = self.get_pull(pr_id)
-        pr["labels"] = filter(lambda l: l not in labels, pr["labels"])
+        pr["labels"] = [item for item in pr["labels"] if item not in labels]
 
     def get_combined_status(self, pr_id, exclude=None):
         if exclude is None:

--- a/sync/gh.py
+++ b/sync/gh.py
@@ -83,14 +83,10 @@ class GitHub(object):
         issue.add_to_labels(*labels)
 
     def remove_labels(self, pr_id, *labels):
+        logger.debug("Removing labels %s from PR %s" % (labels, pr_id))
         issue = self.repo.get_issue(pr_id)
         for label in labels:
-            self.remove_label(pr_id, label, issue=issue)
-
-    def remove_label(self, pr_id, label, issue=None):
-        logger.debug("Removing label %s from PR %s" % (label, pr_id))
-        issue = self.repo.get_issue(pr_id) if issue is None else issue
-        issue.remove_from_labels(label)
+            issue.remove_from_labels(label)
 
     @staticmethod
     def _summary_state(statuses):
@@ -359,13 +355,8 @@ class MockGitHub(GitHub):
         self.get_pull(pr_id)["labels"].extend(labels)
 
     def remove_labels(self, pr_id, *labels):
-        for label in labels:
-            self.remove_label(pr_id, label)
-
-    def remove_label(self, pr_id, label):
         pr = self.get_pull(pr_id)
-        if label in pr["labels"]:
-            pr["labels"].remove(label)
+        pr["labels"] = filter(lambda l: l not in labels, pr["labels"])
 
     def get_combined_status(self, pr_id, exclude=None):
         if exclude is None:

--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -369,3 +369,9 @@ def test_github_label_on_error(env, git_gecko, git_wpt, pull_request):
             sync.error = "Infrastructure Failed"
 
     assert env.gh_wpt.get_pull(pr["number"])['labels'] == ['mozilla:gecko-blocked']
+
+    with SyncLock.for_process(sync.process_name) as lock:
+        with sync.as_mut(lock):
+            sync.update_commits()
+
+    assert env.gh_wpt.get_pull(pr["number"])['labels'] == []


### PR DESCRIPTION
#378 

This will add a label to the GH PR if something goes wrong with the downstream sync process and an error is stored. Technically this error property can be set by something other than an error happening in Gecko so maybe a different name for the label is needed?