### PR TITLE
Retry apt-key command on travis if it fails

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -34,15 +34,15 @@ RUN set -eux; \
 
 RUN set -eux; \
     count=0; \
-    until sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA" || [ $count -gt 2 ]; \
+    until sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"; \
     do \
         count=$((count+1)); sleep 5; \
+        if [ $count -gt 2 ]; then \
+            echo "Failed to perform apt-key, FAILING"; \
+	    exit 1; \
+        fi; \
 	echo "apt-key adv Failed, trying again ($count/3)"; \
     done; \
-    if [ $count -gt 2 ]; then \
-        echo "Failed to perform apt-key, FAILING"; \
-	exit 1; \
-    fi; \
     wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | \
         sudo apt-key add - \
         ; \

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -33,7 +33,8 @@ RUN set -eux; \
     pip install --upgrade pip
 
 RUN set -eux; \
-    sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA"; \
+    until sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA" || ((count++ >= 3)) \
+        do echo "apt-key adv Failed, trying again"; done; \
     wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | \
         sudo apt-key add - \
         ; \

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -33,8 +33,16 @@ RUN set -eux; \
     pip install --upgrade pip
 
 RUN set -eux; \
-    until sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA" || ((count++ >= 3)) \
-        do echo "apt-key adv Failed, trying again"; done; \
+    count=0; \
+    until sudo apt-key adv --keyserver "hkps.pool.sks-keyservers.net" --recv-keys "0x6B73A36E6026DFCA" || [ $count -gt 2 ]; \
+    do \
+        count=$((count+1)); sleep 5; \
+	echo "apt-key adv Failed, trying again ($count/3)"; \
+    done; \
+    if [ $count -gt 2 ]; then \
+        echo "Failed to perform apt-key, FAILING"; \
+	exit 1; \
+    fi; \
     wget -O - "https://github.com/rabbitmq/signing-keys/releases/download/2.0/rabbitmq-release-signing-key.asc" | \
         sudo apt-key add - \
         ; \


### PR DESCRIPTION
#394

We seem to have intermittent failure when running `sudo apt-key adv ...`. One way to mitigate this and hopefully less often have to manually restart builds is to retry the command if it fails, and if it  fails a certain number of times then we fail the build. 

[Here](https://travis-ci.org/dhdavvie/wpt-sync/jobs/569397682#L1708-L1735) is an example where the command failed twice, but finally on the third attempt it passed.