### PR TITLE
Try to retrigger failed tasks after push to gecko

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -4,6 +4,7 @@ import shutil
 from collections import defaultdict
 
 import git
+from celery.exceptions import OperationalError
 
 import bug
 import bugcomponents
@@ -1056,6 +1057,10 @@ def push_to_gecko(git_gecko, git_wpt, sync, allow_push=True):
                             sync.finish()
                             if not sync.results_notified:
                                 env.bz.comment(sync.bug, "Result changes from PR not available.")
+    try:
+        tasks.retrigger.apply_async()
+    except OperationalError:
+        logger.warning("Failed to retrigger failed task for %s " % sync.process_name)
 
 
 @entry_point("landing")

--- a/sync/worker.py
+++ b/sync/worker.py
@@ -20,3 +20,6 @@ worker = celery.Celery('sync',
 
 worker.conf.worker_hijack_root_logger = False
 worker.conf.beat_schedule = beat_schedule
+worker.conf.broker_transport_options = {
+    "max_retries": 1,
+}


### PR DESCRIPTION
#218 

By setting the retry value to something other than 0, `apply_async` no longer hangs and will raise an `OperationalError` in a test environment due to it not being able to resolve the broker hostname. In theory this should work on production but we should keep an eye on the logs to see how it comes along. 