### PR TITLE
Avoid adding duplicate comments and needinfos in some cases

### DIFF
--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -785,7 +785,7 @@ def update_modified_sync(git_gecko, git_wpt, sync):
                     # Reset the base to origin/master
                     sync.set_wpt_base("origin/master")
                     with env.bz.bug_ctx(sync.bug) as bug:
-                        bug["comment"] = ("Failed to create upstream wpt PR for this bug due to "
+                        bug["comment"] = ("Failed to create upstream wpt PR due to "
                                           "merge conflicts. This requires fixup from a wpt sync "
                                           "admin.")
                         needinfo_users = [item.strip() for item in


### PR DESCRIPTION
When adding a needinfo check the flags for an existing similar-looking
needinfo request, and when adding a comment using the BugContext
frontend, perform a similar check that we aren't posting duplicate content.