### PR TITLE
Update test types run on try

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -894,7 +894,7 @@ def update_landing(git_gecko, git_wpt, prev_wpt_head=None, new_wpt_head=None,
                                        landing,
                                        hacks=False,
                                        try_cls=trypush.TryFuzzyCommit,
-                                       exclude=["pgo", "ccov", "msvc"])
+                                       exclude=[])
             elif retry:
                 try:
                     landing.gecko_rebase(landing.gecko_integration_branch())
@@ -907,7 +907,7 @@ def update_landing(git_gecko, git_wpt, prev_wpt_head=None, new_wpt_head=None,
                                        landing,
                                        hacks=False,
                                        try_cls=trypush.TryFuzzyCommit,
-                                       exclude=["pgo", "ccov", "msvc"])
+                                       exclude=[])
             else:
                 logger.info("Got existing try push %s" % landing.latest_try_push)
 
@@ -963,7 +963,8 @@ def try_push_complete(git_gecko, git_wpt, try_push, sync, allow_push=True,
                                    hacks=False,
                                    stability=True,
                                    rebuild_count=0,
-                                   try_cls=trypush.TryFuzzyCommit, exclude=["pgo", "ccov", "msvc"])
+                                   try_cls=trypush.TryFuzzyCommit,
+                                   exclude=[])
 
             try_push.status = "complete"
             return

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -104,7 +104,7 @@ class TryFuzzyCommit(TryCommit):
     def __init__(self, git_gecko, worktree, tests_by_type, rebuild, hacks=True, **kwargs):
         super(TryFuzzyCommit, self).__init__(git_gecko, worktree, tests_by_type, rebuild,
                                              hacks=hacks, **kwargs)
-        self.exclude = self.extra_args.get("exclude", ["pgo", "ccov", "macosx"])
+        self.exclude = self.extra_args.get("exclude", ["macosx", "shippable"])
         self.include = self.extra_args.get("include", ["web-platform-tests"])
 
     def create(self):

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -59,7 +59,7 @@ def test_land_try(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_p
     assert try_push.stability is False
     mach_command = mock_mach.get_log()[-1]
     assert mach_command["command"] == "mach"
-    assert mach_command["args"] == ("try", "fuzzy", "-q", "web-platform-tests !pgo !ccov !msvc",
+    assert mach_command["args"] == ("try", "fuzzy", "-q", "web-platform-tests",
                                     "--artifact")
 
 


### PR DESCRIPTION
pgo ccov and msvc builds no longer exist, but shippable builds are slow and
can be excluded from the PR runs.