### PR TITLE
Check if the bot has merged a PR and comment on BMO

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -1047,7 +1047,7 @@ def pull_request_approved(git_gecko, git_wpt, sync):
 
 @entry_point("downstream")
 @mut('sync')
-def update_pr(git_gecko, git_wpt, sync, action, merge_sha, base_sha):
+def update_pr(git_gecko, git_wpt, sync, action, merge_sha, base_sha, merged_by=None):
     try:
         if action == "closed" and not merge_sha:
             sync.pr_status = "closed"

--- a/sync/gh.py
+++ b/sync/gh.py
@@ -420,6 +420,7 @@ class MockGitHub(GitHub):
         else:
             # TODO: raise the right kind of error here
             raise ValueError
+        pr["merged_by"] = {"login": env.config["web-platform-tests"]["github"]["user"]}
         self._log("Merged PR with id %s" % pr_id)
 
     def is_approved(self, pr_id):

--- a/sync/handlers.py
+++ b/sync/handlers.py
@@ -55,6 +55,7 @@ def handle_pr(git_gecko, git_wpt, event):
 
         merge_sha = (event["pull_request"]["merge_commit_sha"]
                      if event["pull_request"]["merged"] else None)
+        merged_by = (event["pull_request"]["merged_by"]["login"] if merge_sha else None)
         with SyncLock.for_process(sync.process_name) as lock:
             with sync.as_mut(lock):
                 update_func(git_gecko,
@@ -62,7 +63,8 @@ def handle_pr(git_gecko, git_wpt, event):
                             sync,
                             event["action"],
                             merge_sha,
-                            event["pull_request"]["base"]["sha"])
+                            event["pull_request"]["base"]["sha"],
+                            merged_by)
 
 
 def handle_status(git_gecko, git_wpt, event):

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -950,7 +950,7 @@ def commit_status_changed(git_gecko, git_wpt, sync, context, status, url, sha):
 
 @entry_point("upstream")
 @mut('sync')
-def update_pr(git_gecko, git_wpt, sync, action, merge_sha=None, base_sha=None):
+def update_pr(git_gecko, git_wpt, sync, action, merge_sha=None, base_sha=None, merged_by=None):
     """Update the sync status for a PR event on github
 
     :param action string: Either a PR action or a PR status
@@ -967,5 +967,8 @@ def update_pr(git_gecko, git_wpt, sync, action, merge_sha=None, base_sha=None):
             if sync.status not in ("complete", "wpt-merged"):
                 env.bz.comment(sync.bug, "Upstream PR merged")
                 sync.finish("wpt-merged")
+            elif (sync.status == "wpt-merged" and
+                    merged_by == env.config["web-platform-tests"]["github"]["user"]):
+                env.bz.comment(sync.bug, "Upstream PR merged by me")
     elif action == "reopened" or action == "open":
         sync.pr_status = "open"

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -420,6 +420,8 @@ class UpstreamSync(SyncProcess):
 
             try:
                 merge_sha = env.gh_wpt.merge_pull(self.pr)
+                env.bz.comment(self.bug, "Upstream PR merged by %s" %
+                               env.config["web-platform-tests"]["github"]["user"])
             except GithubException as e:
                 msg = ("Merging PR %s failed.\nMessage: %s" %
                        (env.gh_wpt.pr_url(self.pr),
@@ -965,10 +967,7 @@ def update_pr(git_gecko, git_wpt, sync, action, merge_sha=None, base_sha=None, m
             if not sync.wpt_commits and base_sha:
                 sync.set_wpt_base(base_sha)
             if sync.status not in ("complete", "wpt-merged"):
-                env.bz.comment(sync.bug, "Upstream PR merged")
+                env.bz.comment(sync.bug, "Upstream PR merged by %s" % merged_by)
                 sync.finish("wpt-merged")
-            elif (sync.status == "wpt-merged" and
-                    merged_by == env.config["web-platform-tests"]["github"]["user"]):
-                env.bz.comment(sync.bug, "Upstream PR merged by me")
     elif action == "reopened" or action == "open":
         sync.pr_status = "open"

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -207,7 +207,8 @@ def test_land_pr(env, git_gecko, git_wpt, hg_gecko_upstream, upstream_gecko_comm
                                '',
                                pr["merged_by"]["login"])
 
-    assert env.bz.output.getvalue().strip().split('\n')[-1] == "Upstream PR merged by me"
+    user = env.config["web-platform-tests"]["github"]["user"]
+    assert env.bz.output.getvalue().strip().split('\n')[-1] == "Upstream PR merged by %s" % user
 
 
 def test_land_pr_after_status_change(env, git_gecko, git_wpt, hg_gecko_upstream,

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -197,6 +197,18 @@ def test_land_pr(env, git_gecko, git_wpt, hg_gecko_upstream, upstream_gecko_comm
     pr = env.gh_wpt.get_pull(sync.pr)
     assert pr.merged
 
+    with SyncLock.for_process(sync.process_name) as lock:
+        with sync.as_mut(lock):
+            upstream.update_pr(git_gecko,
+                               git_wpt,
+                               sync,
+                               "closed",
+                               pr["merge_commit_sha"],
+                               '',
+                               pr["merged_by"]["login"])
+
+    assert env.bz.output.getvalue().strip().split('\n')[-1] == "Upstream PR merged by me"
+
 
 def test_land_pr_after_status_change(env, git_gecko, git_wpt, hg_gecko_upstream,
                                      upstream_gecko_commit):


### PR DESCRIPTION
This functionality seems to be missing. By checking the 'merged_by' user we can see if the bot has merged the PR, and report back to BMO. Extended a test to also check this comment gets posted. 