### PR TITLE
Configure git to use a custom mergedriver for ini files where possible.

### DIFF
--- a/ansible/roles/wptsync_host/tasks/main.yml
+++ b/ansible/roles/wptsync_host/tasks/main.yml
@@ -122,5 +122,27 @@
   with_items:
     - "{{ mount_workspace| mandatory }}/logs/rabbitmq"
 
+- name: ensure git mergedriver name is added to git config
+  git_config:
+    repo: "{{ mount_repos }}/gecko"
+    scope: local
+    name: merge.metamerge.name
+    value: Automatic meta merge
+
+- name: ensure git mergedriver driver is added to git config
+  git_config:
+    repo: "{{ mount_repos }}/gecko"
+    scope: local
+    name: merge.metamerge.driver
+    value: ./mach wpt-metadata-merge %O %A %B %A || git-merge-file -q --marker-size=%L %A %O %B
+
+- name: ensure git mergedriver is configured in git attributes
+  copy:
+    src: "{{ host_config }}/gitattributes"
+    dest: "{{ mount_repos }}/gecko/info/attributes"
+    owner: wptsync
+    group: wptsync
+    mode: 0644
+
 - import_tasks: push-docker-img.yml
   when: rebuild

--- a/config/gitattributes
+++ b/config/gitattributes
@@ -1,0 +1,1 @@
+testing/web-platform/meta/** merge=metamerge


### PR DESCRIPTION
This ensures that the ini files are automerged in as many cases as possible
and prevents merge conflicts blocking landings. The only problem is that
the mergedriver has to live in the worktree for operational reasons, so
we have to fall back to the standard mergedriver in cases where it fails
e.g. because it can't be found.

The patch ensures that when we provision the host machine we add the necessary
git config to the gecko repository using the  commands, and set the
correct attributes simply by copying over the attributes file.