### PR TITLE
Handle bmo errors

### DIFF
--- a/sync/bug.py
+++ b/sync/bug.py
@@ -5,9 +5,9 @@ import traceback
 import urlparse
 
 import bugsy
+import newrelic
 
 from env import Environment
-from errors import RetryableError
 
 env = Environment()
 
@@ -96,7 +96,8 @@ class Bugzilla(object):
                 return
             except Exception as e:
                 logger.error("Failed to retrieve bug with id %s: %s" % (bug_id, e))
-                raise RetryableError
+                newrelic.agent.record_exception()
+                return
 
             self.bug_cache[bug_id] = bug
         return self.bug_cache[bug_id]
@@ -163,7 +164,7 @@ class Bugzilla(object):
             logger.warning(traceback.format_exc())
         except Exception as e:
             logger.warning("Problem setting Bug %s Whiteboard: %s" % (bug.id, e))
-            raise RetryableError("Could not set whiteboard for Bug %s" % bug.id)
+            newrelic.agent.record_exception()
 
     def get_whiteboard(self, bug):
         if not isinstance(bug, bugsy.Bug):

--- a/sync/bug.py
+++ b/sync/bug.py
@@ -7,6 +7,7 @@ import urlparse
 import bugsy
 
 from env import Environment
+from errors import RetryableError
 
 env = Environment()
 
@@ -158,6 +159,7 @@ class Bugzilla(object):
             logger.warning(traceback.format_exc())
         except Exception as e:
             logger.warning("Problem setting Bug %s Whiteboard: %s" % (bug.id, e))
+            raise RetryableError("Could not set whiteboard for Bug %s" % bug.id)
 
     def get_whiteboard(self, bug):
         if not isinstance(bug, bugsy.Bug):

--- a/sync/bug.py
+++ b/sync/bug.py
@@ -156,6 +156,8 @@ class Bugzilla(object):
             self.bugzilla.put(bug)
         except bugsy.errors.BugsyException:
             logger.warning(traceback.format_exc())
+        except Exception as e:
+            logger.warning("Problem setting Bug %s Whiteboard: %s" % (bug.id, e))
 
     def get_whiteboard(self, bug):
         if not isinstance(bug, bugsy.Bug):

--- a/sync/bug.py
+++ b/sync/bug.py
@@ -94,6 +94,10 @@ class Bugzilla(object):
             except bugsy.BugsyException:
                 logger.error("Failed to retrieve bug with id %s" % bug_id)
                 return
+            except Exception as e:
+                logger.error("Failed to retrieve bug with id %s: %s" % (bug_id, e))
+                raise RetryableError
+
             self.bug_cache[bug_id] = bug
         return self.bug_cache[bug_id]
 


### PR DESCRIPTION
Relic logs shows a high error rate at the moment to do with getting 0 length responses from BMO. Doing a broad except and raising retryable error. Maybe should be catching ValueError specifically for this?