### PR TITLE
Make wptsync delete command more useful

### DIFF
--- a/sync/base.py
+++ b/sync/base.py
@@ -539,10 +539,13 @@ class ProcessData(object):
         return str(process_name)
 
     @classmethod
-    def load_by_obj(cls, repo, subtype, obj_id):
+    def load_by_obj(cls, repo, subtype, obj_id, seq_id=None):
         process_names = ProcessNameIndex(repo).get(cls.obj_type,
                                                    subtype,
                                                    obj_id)
+        if seq_id is not None:
+            process_names = {item for item in process_names
+                             if item.seq_id == int(seq_id)}
         return {cls(repo, process_name) for process_name in process_names}
 
     @classmethod

--- a/sync/command.py
+++ b/sync/command.py
@@ -371,11 +371,10 @@ def do_push(git_gecko, git_wpt, *args, **kwargs):
 def do_delete(git_gecko, git_wpt, sync_type, obj_id, *args, **kwargs):
     import trypush
     if kwargs["try"]:
-        objs = trypush.TryPush.load_by_obj(git_gecko, sync_type, obj_id)
+        objs = trypush.TryPush.load_by_obj(git_gecko, sync_type, obj_id,
+                                           seq_id=kwargs["seq_id"])
     else:
-        objs = get_syncs(git_gecko, git_wpt, sync_type, obj_id)
-    if kwargs["seq_id"]:
-        objs = [item for item in objs if str(item.process_name.seq_id) == kwargs["seq_id"]]
+        objs = get_syncs(git_gecko, git_wpt, sync_type, obj_id, seq_id=kwargs["seq_id"])
     if not kwargs["all"] and objs:
         objs = sorted(objs, key=lambda x: -int(x.process_name.seq_id))[:1]
     for obj in objs:
@@ -422,7 +421,8 @@ def do_status(git_gecko, git_wpt, obj_type, sync_type, obj_id, *args, **kwargs):
     if obj_type == "try":
         objs = trypush.TryPush.load_by_obj(git_gecko,
                                            sync_type,
-                                           obj_id)
+                                           obj_id,
+                                           seq_id=kwargs["seq_id"])
     else:
         if sync_type == "upstream":
             cls = upstream.UpstreamSync
@@ -432,13 +432,11 @@ def do_status(git_gecko, git_wpt, obj_type, sync_type, obj_id, *args, **kwargs):
             cls = landing.LandingSync
         objs = cls.load_by_obj(git_gecko,
                                git_wpt,
-                               obj_id)
+                               obj_id,
+                               seq_id=kwargs["seq_id"])
 
     if kwargs["old_status"] is not None:
         objs = {item for item in objs if item.status == kwargs["old_status"]}
-
-    if kwargs["seq_id"] is not None:
-        objs = {item for item in objs if item.process_name.seq_id == int(kwargs["seq_id"])}
 
     if not objs:
         logger.error("No matching syncs found")

--- a/sync/commit.py
+++ b/sync/commit.py
@@ -430,8 +430,7 @@ class GeckoCommit(Commit):
                 seq_id = None
             else:
                 seq_id = int(seq_id)
-            syncs = upstream.UpstreamSync.load_by_obj(git_gecko, git_wpt, bug)
-            syncs = {item for item in syncs if item.seq_id == seq_id}
+            syncs = upstream.UpstreamSync.load_by_obj(git_gecko, git_wpt, bug, seq_id=seq_id)
             assert len(syncs) <= 1
             if syncs:
                 return syncs.pop()

--- a/sync/load.py
+++ b/sync/load.py
@@ -58,9 +58,7 @@ def get_syncs(git_gecko, git_wpt, sync_type, obj_id, status=None, seq_id=None):
         "upstream": upstream.UpstreamSync
     }
     cls = cls_types[sync_type]
-    syncs = cls.load_by_obj(git_gecko, git_wpt, obj_id)
+    syncs = cls.load_by_obj(git_gecko, git_wpt, obj_id, seq_id=seq_id)
     if status:
         syncs = {sync for sync in syncs if sync.status == status}
-    if seq_id is not None:
-        syncs = {sync for sync in syncs if sync.seq_id == seq_id}
     return syncs

--- a/sync/sync.py
+++ b/sync/sync.py
@@ -326,10 +326,13 @@ class SyncProcess(object):
         return rv
 
     @classmethod
-    def load_by_obj(cls, git_gecko, git_wpt, obj_id):
+    def load_by_obj(cls, git_gecko, git_wpt, obj_id, seq_id=None):
         process_names = ProcessNameIndex(git_gecko).get(cls.obj_type,
                                                         cls.sync_type,
                                                         str(obj_id))
+        if seq_id is not None:
+            process_names = {item for item in process_names
+                             if item.seq_id == int(seq_id)}
         return {cls(git_gecko, git_wpt, process_name) for process_name in process_names}
 
     @classmethod


### PR DESCRIPTION
By default just delete the newest matching object, and add a command
line option to instead delete all. Also fix some API misuse trying to
delete try pushes and clean up the repeated code a little.