### PR TITLE
Ensure error flag is unset when a sync is finished.

### DIFF
--- a/sync/sync.py
+++ b/sync/sync.py
@@ -653,6 +653,7 @@ class SyncProcess(object):
         # TODO: cancel related try pushes &c.
         logger.info("Marking sync %s as %s" % (self.process_name, status))
         self.status = status
+        self.error = None
         for worktree in [self.gecko_worktree, self.wpt_worktree]:
             worktree.delete()
         for repo in [self.git_gecko, self.git_wpt]:

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -208,7 +208,7 @@ def test_land_pr(env, git_gecko, git_wpt, hg_gecko_upstream, upstream_gecko_comm
                                pr["merged_by"]["login"])
 
     user = env.config["web-platform-tests"]["github"]["user"]
-    assert env.bz.output.getvalue().strip().split('\n')[-1] == "Upstream PR merged by %s" % user
+    assert ("Upstream PR merged by %s" % user) in env.bz.output.getvalue().strip().split('\n')
 
 
 def test_land_pr_after_status_change(env, git_gecko, git_wpt, hg_gecko_upstream,


### PR DESCRIPTION
This means that in cases where the error has a visible effect like in
the GitHub labels we never end up with finished syncs.