### PR TITLE
Use full task set for running landing try pushes

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -640,7 +640,8 @@ MANUAL PUSH: wpt sync bot
                                stability=stability,
                                rebuild_count=0,
                                try_cls=trypush.TryFuzzyCommit,
-                               exclude=[])
+                               full=True,
+                               exclude=["-fis-", "devedition", "ccov"])
 
 
 def push(landing):

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -106,6 +106,7 @@ class TryFuzzyCommit(TryCommit):
                                              hacks=hacks, **kwargs)
         self.exclude = self.extra_args.get("exclude", ["macosx", "shippable"])
         self.include = self.extra_args.get("include", ["web-platform-tests"])
+        self.full = self.extra_args.get("full", False)
 
     def create(self):
         if self.hacks:
@@ -138,6 +139,8 @@ class TryFuzzyCommit(TryCommit):
         if self.rebuild:
             args.append("--rebuild")
             args.append(str(self.rebuild))
+        if self.full:
+            args.append("--full")
 
         if self.tests_by_type is not None:
             paths = []

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -59,8 +59,12 @@ def test_land_try(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_p
     assert try_push.stability is False
     mach_command = mock_mach.get_log()[-1]
     assert mach_command["command"] == "mach"
-    assert mach_command["args"] == ("try", "fuzzy", "-q", "web-platform-tests",
-                                    "--artifact")
+    assert mach_command["args"] == ("try",
+                                    "fuzzy",
+                                    "-q",
+                                    "web-platform-tests !-fis- !devedition !ccov",
+                                    "--artifact",
+                                    "--full")
 
 
 def test_land_commit(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_pr_status,


### PR DESCRIPTION
This is needed to enable testing aarch64 builds which run on central but not usually on try.