### PR TITLE
Record CalledProcessErrors better with newrelic, continue raising.

### DIFF
--- a/sync/projectutil.py
+++ b/sync/projectutil.py
@@ -13,6 +13,8 @@ import types
 
 import newrelic
 
+from .errors import AbortError
+
 logger = logging.getLogger(__name__)
 
 
@@ -39,8 +41,10 @@ class Command(object):
         try:
             return subprocess.check_output(command, cwd=self.path, **opts)
         except subprocess.CalledProcessError as e:
-            newrelic.agent.record_exception(params={"mach_output": e.output})
-            raise e
+            newrelic.agent.record_exception(params={
+                "command": self.name,
+                "command_output": e.output})
+            raise AbortError("Problem running '%s' command" % self.name)
 
     def __getattr__(self, name):
         if name.endswith("_"):

--- a/sync/projectutil.py
+++ b/sync/projectutil.py
@@ -13,8 +13,6 @@ import types
 
 import newrelic
 
-from .errors import AbortError
-
 logger = logging.getLogger(__name__)
 
 
@@ -43,8 +41,9 @@ class Command(object):
         except subprocess.CalledProcessError as e:
             newrelic.agent.record_exception(params={
                 "command": self.name,
+                "exit_code": e.returncode,
                 "command_output": e.output})
-            raise AbortError("Problem running '%s' command" % self.name)
+            raise e
 
     def __getattr__(self, name):
         if name.endswith("_"):


### PR DESCRIPTION
#466

The output of recorded Newrelic log seems to be truncated due to length. This should hopefully provide us with a field to see the relevant information about the error. 