### PR TITLE
Improve handling of complete try pushes when running wptsync landing.

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -632,7 +632,8 @@ MANUAL PUSH: wpt sync bot
         if retry:
             stability = latest_try_push.stability
         else:
-            stability = latest_try_push is not None
+            stability = (latest_try_push is not None and
+                         not latest_try_push.infra_fail)
 
         trypush.TryPush.create(self._lock,
                                self,
@@ -960,8 +961,15 @@ def try_push_complete(git_gecko, git_wpt, try_push, sync, allow_push=True,
                       accept_failures=False, tasks=None):
     intermittents = []
 
-    if not accept_failures and try_push.status == "complete":
-        return
+    if try_push.status == "complete":
+        if not accept_failures and not try_push.infra_fail:
+            logger.info("Previous try push had failures, run with either --accept-failures "
+                        "or --retry")
+            return
+        elif try_push.infra_fail:
+            logger.info("Previous try push had an infra failure, retrying")
+            sync.next_try_push(retry=True)
+            return
 
     if tasks is None:
         tasks = try_push.tasks()


### PR DESCRIPTION
If the previous try push was complete but had infra fails we want to start a new
try push. And in the case that action is required, be more specific about what
can be done