### PR TITLE
Remove initial try push & push stability once PR is merged.

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -819,7 +819,7 @@ class DownstreamSync(SyncProcess):
 
         complete_try_push = None
         for try_push in sorted(self.try_pushes(), key=lambda x: -x.process_name.seq_id):
-            if try_push.status == "complete" and not try_push.stability:
+            if try_push.status == "complete":
                 complete_try_push = try_push
                 break
 
@@ -836,7 +836,8 @@ class DownstreamSync(SyncProcess):
         with try_push.as_mut(self._lock):
             try_tasks = complete_try_push.tasks()
             try:
-                complete_try_push.download_logs(try_tasks.wpt_tasks, report=True, raw=False)
+                complete_try_push.download_logs(try_tasks.wpt_tasks, report=True,
+                                                raw=False, first_only=True)
             except RetryableError:
                 logger.warning("Downloading logs failed")
                 return

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -171,8 +171,9 @@ class DownstreamSync(SyncProcess):
         if latest_try_push.status != "complete":
             return DownstreamAction.wait_try
 
-        # Don't worry about recreating stability try pushes for infra failures
-        if latest_try_push.infra_fail and len(self.latest_busted_try_pushes()) > 5:
+        # If we have infra failure, flag for human intervention. Retrying stability runs would be
+        # very costly
+        if latest_try_push.infra_fail:
             return DownstreamAction.manual_fix
 
         return DownstreamAction.ready

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -1026,6 +1026,7 @@ def try_push_complete(git_gecko, git_wpt, try_push, sync):
 @entry_point("downstream")
 @mut('sync')
 def pull_request_approved(git_gecko, git_wpt, sync):
+    # We no longer run Try pushes when a GH PR has been approved, so this is sort of useless now.
     try:
         sync.next_try_push()
         sync.update_github_check()

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -1035,18 +1035,6 @@ def try_push_complete(git_gecko, git_wpt, try_push, sync):
 
 @entry_point("downstream")
 @mut('sync')
-def pull_request_approved(git_gecko, git_wpt, sync):
-    # We no longer run Try pushes when a GH PR has been approved, so this is sort of useless now.
-    try:
-        sync.next_try_push()
-        sync.update_github_check()
-    except Exception as e:
-        sync.error = e
-        raise
-
-
-@entry_point("downstream")
-@mut('sync')
 def update_pr(git_gecko, git_wpt, sync, action, merge_sha, base_sha, merged_by=None):
     try:
         if action == "closed" and not merge_sha:

--- a/sync/gh.py
+++ b/sync/gh.py
@@ -374,6 +374,11 @@ class MockGitHub(GitHub):
         pr = self.get_pull(pr_id)
         pr["labels"] = [item for item in pr["labels"] if item not in labels]
 
+    def load_pull(self, data):
+        pr = self.get_pull(data["number"])
+        pr.merged = data["merged"]
+        pr.state = data["state"]
+
     def get_combined_status(self, pr_id, exclude=None):
         if exclude is None:
             exclude = set()

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -384,7 +384,7 @@ class TryPush(base.ProcessData):
                             "try", self.try_rev)
 
     @mut()
-    def download_logs(self, wpt_tasks, raw=True, report=True, exclude=None):
+    def download_logs(self, wpt_tasks, raw=True, report=True, exclude=None, first_only=False):
         """Download all the logs for the current try push
 
         :return: List of paths to raw logs
@@ -400,7 +400,14 @@ class TryPush(base.ProcessData):
             # if a name is on the excluded list, only download SUCCESS job logs
             name = t.get("task", {}).get("metadata", {}).get("name")
             state = t.get("status", {}).get("state")
-            return name not in exclude or state == tc.SUCCESS
+            output = name not in exclude or state == tc.SUCCESS
+
+            # Add this name to exclusion list, so that we don't download the repeated run
+            # logs in a stability try run
+            if first_only and name is not None and name not in exclude:
+                exclude.append(name)
+
+            return output
 
         if self.try_rev is None:
             if wpt_tasks:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -591,6 +591,9 @@ def try_push(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_pr_sta
             landing.wpt_push(git_gecko, git_wpt, [head_rev], create_missing=False)
 
             with sync.as_mut(sync_lock):
+                env.gh_wpt.get_pull(sync.pr).merged = True
+                sync.data["affected-tests"] = {"Example": "affected"}
+                sync.next_try_push()
                 sync.data["force-metadata-ready"] = True
 
             try_push = sync.latest_try_push

--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -188,20 +188,21 @@ def test_next_try_push_infra_fail(env, git_gecko, git_wpt, pull_request,
     with patch("sync.tree.is_open", Mock(return_value=True)), patch("sync.trypush.Mach", mock_mach):
         sync = set_pr_status(pr, "success")
         env.gh_wpt.get_pull(sync.pr).merged = True
-    with SyncLock.for_process(sync.process_name) as lock:
-        with sync.as_mut(lock):
-            assert len(sync.try_pushes()) == 0
 
-            sync.data["affected-tests"] = {"testharness": ["example"]}
+        with SyncLock.for_process(sync.process_name) as lock:
+            with sync.as_mut(lock):
+                assert len(sync.try_pushes()) == 0
 
-            try_push = sync.next_try_push(try_cls=MockTryCls)
-            with try_push.as_mut(lock):
-                try_push.status = "complete"
-                try_push.infra_fail = True
+                sync.data["affected-tests"] = {"testharness": ["example"]}
 
-            # When the stability run has infra fail, we flag for human intervention
-            assert sync.next_action == downstream.DownstreamAction.manual_fix
-            assert sync.next_try_push(try_cls=MockTryCls) is None
+                try_push = sync.next_try_push(try_cls=MockTryCls)
+                with try_push.as_mut(lock):
+                    try_push.status = "complete"
+                    try_push.infra_fail = True
+
+                # When the stability run has infra fail, we flag for human intervention
+                assert sync.next_action == downstream.DownstreamAction.manual_fix
+                assert sync.next_try_push(try_cls=MockTryCls) is None
 
 
 def test_try_push_expiration(env, git_gecko, git_wpt, pull_request,

--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -84,10 +84,6 @@ def test_wpt_pr_approved(env, git_gecko, git_wpt, pull_request, set_pr_status,
             assert sync.last_pr_check == {"state": "success", "sha": pr.head}
 
         pr._approved = True
-        handlers.handle_pull_request_review(git_gecko, git_wpt,
-                                            {"action": "submitted",
-                                             "review": {"state": "approved"},
-                                             "pull_request": {"number": pr.number}})
         # A Try push is not run after approval.
         assert sync.latest_try_push is None
 

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -54,9 +54,7 @@ def test_land_try(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_p
                 assert f.read() == "Initial license\n"
 
     try_push = sync.latest_try_push
-    assert try_push is not None
-    assert try_push.status == "open"
-    assert try_push.stability is False
+    assert try_push is None
     mach_command = mock_mach.get_log()[-1]
     assert mach_command["command"] == "mach"
     assert mach_command["args"] == ("try",


### PR DESCRIPTION
With the current implementation, the bot can spam the try server with try pushes from an upstream PR (see [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1573920)). In some cases with the Chromium export bot, it also pushes stability try runs because the upstream PR is already approved but still receiving changes from the downstream Chromium repo. 

By removing the initial try push entirely and only pushing a stability run once the PR has been merged, we can reduce a significant amount of spam and save on cost. The trade-off is turn around time of the sync, but this should not be that significant.

Here I've changed `next_action` to go straight to stability run on pr merged, and the same has been done in `LandingSync.next_try_push`. Log downloading has been changed to handle stability runs by adding the names of tasks to the exclude list, which should in theory prevent the downloading of logs from repeat runs. Tests have also been updated to reflect this new workflow.