### PR TITLE
Ensure we don't get stuck with non-stability try push

### DIFF
--- a/sync/command.py
+++ b/sync/command.py
@@ -548,6 +548,10 @@ def do_landable(git_gecko, git_wpt, *args, **kwargs):
                     latest_try_push = sync.latest_try_push
                     reason = "%s %s" % (reason,
                                         latest_try_push.treeherder_url)
+                elif next_action == DownstreamAction.manual_fix:
+                    latest_try_push = sync.latest_try_push
+                    reason = "Manual fixup required %s" % (
+                        latest_try_push.treeherder_url,)
                 msg = "%s (%s)" % (msg, reason)
             elif status == LandableStatus.error:
                 sync = DownstreamSync.for_pr(git_gecko, git_wpt, pr)

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -170,6 +170,9 @@ class DownstreamSync(SyncProcess):
             if latest_try_push.status != "complete":
                 return DownstreamAction.wait_try
 
+            if self.requires_stability_try and not latest_try_push.stability:
+                return DownstreamAction.try_push_stability
+
             # If we have infra failure, flag for human intervention. Retrying stability
             # runs would be very costly
             if latest_try_push.infra_fail:


### PR DESCRIPTION
For syncs that already have a non-stability try push but require a stability try push,
ensure we schedule one. Also improve the error messages for manual_fixup cases a little.