### PR TITLE
Enable passing multiple arbitary queries to mach try fuzzy

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -638,7 +638,9 @@ MANUAL PUSH: wpt sync bot
                                rebuild_count=0,
                                try_cls=trypush.TryFuzzyCommit,
                                full=True,
-                               exclude=["devedition", "ccov"])
+                               queries=["web-platform-tests !devedition !ccov !fis",
+                                        "web-platform-tests fis !devedition !ccov !asan "
+                                        "windows10 | linux64"])
 
 
 def push(landing):

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -59,9 +59,12 @@ def test_land_try(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_p
     assert mach_command["command"] == "mach"
     assert mach_command["args"] == ("try",
                                     "fuzzy",
-                                    "-q",
-                                    "web-platform-tests !devedition !ccov",
                                     "--artifact",
+                                    "-q",
+                                    "web-platform-tests !devedition !ccov !fis",
+                                    "-q",
+                                    "web-platform-tests fis !devedition !ccov !asan "
+                                    "windows10 | linux64",
                                     "--full")
 
 

--- a/test/test_try.py
+++ b/test/test_try.py
@@ -1,13 +1,7 @@
 from mock import Mock, patch
 
-from sync import tc, trypush
+from sync import tc
 from sync.lock import SyncLock
-
-
-def test_try_fuzzy():
-    push = trypush.TryFuzzyCommit(None, None, [], 0, include=["web-platform-tests"],
-                                  exclude=["pgo", "ccov"])
-    assert push.query == "web-platform-tests !pgo !ccov"
 
 
 def test_try_task_states(mock_tasks, try_push):


### PR DESCRIPTION
Use this to implement a fisson query that more closely matches the mochitest central
configuration.