### PR TITLE
Weaker infra failure conditions, notify on build failures

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -176,7 +176,13 @@ class DownstreamSync(SyncProcess):
             # If we have infra failure, flag for human intervention. Retrying stability
             # runs would be very costly
             if latest_try_push.infra_fail:
-                return DownstreamAction.manual_fix
+                tasks = latest_try_push.tasks()
+
+                # Check if we had any successful tests
+                if tasks.has_completed_tests():
+                    return DownstreamAction.ready
+                else:
+                    return DownstreamAction.manual_fix
 
             return DownstreamAction.ready
         else:

--- a/sync/tc.py
+++ b/sync/tc.py
@@ -200,6 +200,11 @@ class TaskGroupView(object):
             if task_is_incomplete(task, tasks_by_id, allow_unscheduled):
                 yield task
 
+    def failed_builds(self):
+        """Return the builds that failed"""
+        builds = self.filter(is_build)
+        return builds.filter(is_status_fn({FAIL, EXCEPTION}))
+
     def filter(self, filter_fn):
         def combined_filter(task):
             return self.filter_fn(task) and filter_fn(task)
@@ -321,10 +326,18 @@ def is_suite_fn(suite):
     return lambda x: is_suite(suite, x)
 
 
-def is_build(task):
+def check_tag(task, tag):
     tags = task.get("task", {}).get("tags")
     if tags:
-        return tags.get("kind") == "build"
+        return tags.get("kind") == tag
+
+
+def is_test(task):
+    return check_tag(task, "test")
+
+
+def is_build(task):
+    return check_tag(task, "build")
 
 
 def is_status(statuses, task):

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -205,6 +205,7 @@ class TryPush(base.ProcessData):
             "gecko-head": sync.gecko_commits.head.sha1,
             "wpt-head": sync.wpt_commits.head.sha1,
             "status": "open",
+            "bug": sync.bug,
         }
         process_name = base.ProcessName.with_seq_id(sync.git_gecko,
                                                     cls.obj_type,
@@ -351,18 +352,45 @@ class TryPush(base.ProcessData):
         return self["stability"]
 
     @property
+    def bug(self):
+        return self.get("bug")
+
+    @property
     def infra_fail(self):
-        """Is the current try push a stability test"""
+        """Does this push have infrastructure failures"""
         if self.status == "infra-fail":
             self.status = "complete"
             self.infra_fail = True
         return self.get("infra-fail", False)
 
+    def notify_failed_builds(self):
+        tasks = tc.TaskGroup(self.taskgroup_id).view()
+        failed = tasks.failed_builds()
+
+        if not failed:
+            logger.error("No failed builds to report for Try push: %s" % self)
+            return
+
+        bug = self.bug
+
+        if not bug:
+            logger.error("No associated bug found for Try push: %s" % self)
+            return
+
+        msg = "There were infrastructure failures for the Try push (%s):\n" % self.treeherder_url
+        msg += "\n".join(task.get("task", {}).get("metadata", {}).get("name")
+                         for task in failed.tasks)
+        env.bz.comment(self.bug, msg)
+
     @infra_fail.setter
     @mut()
     def infra_fail(self, value):
-        """Is the current try push a stability test"""
+        """Set the status of this push's infrastructure failure state"""
+        if value == self.get("infra-fail"):
+            return
         self["infra-fail"] = value
+        if value:
+            self.notify_failed_builds()
 
     def tasks(self):
         """Get a list of all the taskcluster tasks for web-platform-tests
@@ -529,8 +557,13 @@ class TryPushTasks(object):
         return task_states
 
     def failed_builds(self):
+        """Return the builds that failed"""
+        return self.wpt_tasks.failed_builds()
+
+    def successful_builds(self):
+        """Return the builds that were successful"""
         builds = self.wpt_tasks.filter(tc.is_build)
-        return builds.filter(tc.is_status_fn({tc.FAIL, tc.EXCEPTION}))
+        return builds.filter(tc.is_status_fn({tc.SUCCESS}))
 
     def retriggered_wpt_states(self):
         # some retrigger requests may have failed, and we try to ignore
@@ -552,6 +585,14 @@ class TryPushTasks(object):
         wpt_tasks = self.wpt_tasks
         if wpt_tasks:
             return any(task.get("status", {}).get("state") == tc.FAIL for task in wpt_tasks)
+        return False
+
+    def has_completed_tests(self):
+        """Check if all the wpt tasks in a try push completed"""
+        wpt_tasks = self.wpt_tasks.filter(tc.is_test)
+        if wpt_tasks:
+            return any(task.get("status", {}).get("state") in (tc.SUCCESS, tc.FAIL)
+                       for task in wpt_tasks)
         return False
 
     def success_rate(self):

--- a/test/sample-data/taskcluster/taskgroup-complete-build-failed.json
+++ b/test/sample-data/taskcluster/taskgroup-complete-build-failed.json
@@ -1,0 +1,13481 @@
+{
+  "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+  "tasks": [
+    {
+      "status": {
+        "taskId": "AFSpsAVERfSdF5LJLTYeYg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.456Z",
+        "expires": "2019-10-21T10:38:11.456Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-0b57bf29d0772dd26",
+            "takenUntil": "2019-10-07T11:08:33.597Z",
+            "scheduled": "2019-10-07T10:48:33.262Z",
+            "started": "2019-10-07T10:48:33.704Z",
+            "resolved": "2019-10-07T10:54:04.865Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "X4wdBGlHSEOK68lG0AdlDQ",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.456Z",
+        "deadline": "2019-10-08T10:38:11.456Z",
+        "expires": "2019-10-21T10:38:11.456Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.456Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.456Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.456Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-asan/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-asan/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "asan": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/asan"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "ApA2K_D9TKyuKChuQE-eJg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.452Z",
+        "expires": "2019-10-21T10:38:11.452Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-04704b2046ad9fe51",
+            "takenUntil": "2019-10-07T11:08:33.573Z",
+            "scheduled": "2019-10-07T10:48:33.258Z",
+            "started": "2019-10-07T10:48:33.649Z",
+            "resolved": "2019-10-07T10:54:11.767Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "X4wdBGlHSEOK68lG0AdlDQ",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.452Z",
+        "deadline": "2019-10-08T10:38:11.452Z",
+        "expires": "2019-10-21T10:38:11.452Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.452Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.452Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.452Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-asan/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-asan/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "asan": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/asan"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "B8ReNvxoTFyIzBCfTn4yxQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.460Z",
+        "expires": "2019-10-21T10:38:11.460Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "KDHFLbeATKSQUE_3WHG_iQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.460Z",
+        "deadline": "2019-10-08T10:38:11.460Z",
+        "expires": "2019-10-21T10:38:11.460Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "KDHFLbeATKSQUE_3WHG_iQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "BnBtdjcORKmsHADUdEIhfQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.283Z",
+        "expires": "2019-10-21T10:38:12.283Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.283Z",
+        "deadline": "2019-10-08T10:38:12.283Z",
+        "expires": "2019-10-21T10:38:12.283Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "CAifbOv2RDKC0JQqzAWiuQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.475Z",
+        "expires": "2019-10-21T10:38:11.475Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-2",
+            "workerId": "i-0bd9ac14dff7ecf83",
+            "takenUntil": "2019-10-07T11:01:56.636Z",
+            "scheduled": "2019-10-07T10:41:55.883Z",
+            "started": "2019-10-07T10:41:56.708Z",
+            "resolved": "2019-10-07T10:46:47.474Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.475Z",
+        "deadline": "2019-10-08T10:38:11.475Z",
+        "expires": "2019-10-21T10:38:11.475Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.475Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.475Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.475Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=\"dom.serviceWorkers.parent_intercept=true\"",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run with serviceworker-e10s redesign enabled ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/debug-web-platform-tests-sw-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/debug-web-platform-tests-sw-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W-sw",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests with serviceworker redesign",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Cqs6gH-JTzCZGQyVbbUJlA",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.432Z",
+        "expires": "2019-10-21T10:38:11.432Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.432Z",
+        "deadline": "2019-10-08T10:38:11.432Z",
+        "expires": "2019-10-21T10:38:11.432Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "D3_DBGbhTSO6fm9TsSWFkw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.445Z",
+        "expires": "2019-10-21T10:38:10.445Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.445Z",
+        "deadline": "2019-10-08T10:38:10.445Z",
+        "expires": "2019-10-21T10:38:10.445Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "DT7-2PvCQoaZOnkPKObRXw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.414Z",
+        "expires": "2019-10-21T10:38:12.414Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-2",
+            "workerId": "i-0d4003aa6f02064b9",
+            "takenUntil": "2019-10-07T11:02:13.897Z",
+            "scheduled": "2019-10-07T10:42:13.057Z",
+            "started": "2019-10-07T10:42:14.015Z",
+            "resolved": "2019-10-07T10:44:54.260Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "FJYMxdFvSJiFSlvAScx_yg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.414Z",
+        "deadline": "2019-10-08T10:38:12.414Z",
+        "expires": "2019-10-21T10:38:12.414Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:12.414Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:12.414Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:12.414Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=12",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "DswJgYaPSuio6XPITUB9Lg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-decision",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:36:46.921Z",
+        "expires": "2019-11-04T10:36:46.921Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-0c89b6f3903132a5d",
+            "takenUntil": "2019-10-07T10:56:48.775Z",
+            "scheduled": "2019-10-07T10:36:47.451Z",
+            "started": "2019-10-07T10:36:48.849Z",
+            "resolved": "2019-10-07T10:38:27.421Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-decision",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115",
+          "index.gecko.v2.try.latest.taskgraph.decision",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.taskgraph.decision",
+          "index.gecko.v2.try.pushlog-id.432115.decision",
+          "notify.email.wptsync@mozilla.com.on-failed",
+          "notify.email.wptsync@mozilla.com.on-exception",
+          "notify.email.wptsync@mozilla.com.on-completed",
+          "index.gecko.v2.try.latest.firefox.decision",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.decision"
+        ],
+        "priority": "lowest",
+        "retries": 5,
+        "created": "2019-10-07T10:36:46.921Z",
+        "deadline": "2019-10-08T10:36:46.921Z",
+        "expires": "2019-11-04T10:36:46.921Z",
+        "scopes": [
+          "assume:repo:hg.mozilla.org/try:branch:default",
+          "queue:route:notify.email.wptsync@mozilla.com.*",
+          "in-tree:hook-action:project-gecko/in-tree-action-1-*"
+        ],
+        "payload": {
+          "env": {
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "GECKO_HEAD_REF": "0b445bf4228a963505183b157758c37664921791",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+            "TASKCLUSTER_ROOT_URL": "https://taskcluster.net",
+            "TASKCLUSTER_PROXY_URL": "http://taskcluster"
+          },
+          "cache": {
+            "level-1-checkouts-sparse-v2": "/builds/worker/checkouts"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          },
+          "image": "taskcluster/decision:2.2.0@sha256:0e9689e94605eb8395f5b49141a48148416b0d825f6f7be04c29642d1a85ee3d",
+          "maxRunTime": 1800,
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/checkouts/gecko",
+            "--gecko-sparse-profile=build/sparse-profiles/taskgraph",
+            "--",
+            "bash",
+            "-cx",
+            "cd /builds/worker/checkouts/gecko && ln -s /builds/worker/artifacts artifacts && ./mach --log-no-times taskgraph decision --pushlog-id='432115' --pushdate='1570444556' --project='try' --owner='wptsync@mozilla.com' --level='1' --tasks-for='hg-push' --base-repository=\"$GECKO_BASE_REPOSITORY\" --head-repository=\"$GECKO_HEAD_REPOSITORY\" --head-ref=\"$GECKO_HEAD_REF\" --head-rev=\"$GECKO_HEAD_REV\" \n"
+          ],
+          "artifacts": {
+            "public": {
+              "type": "directory",
+              "path": "/builds/worker/artifacts",
+              "expires": "2019-11-04T10:36:46.921Z"
+            }
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/.taskcluster.yml",
+          "name": "Gecko Decision Task",
+          "description": "The task that creates all of the other tasks in the task graph"
+        },
+        "tags": {
+          "createdForUser": "wptsync@mozilla.com",
+          "kind": "decision-task"
+        },
+        "extra": {
+          "treeherder": {
+            "machine": {
+              "platform": "gecko-decision"
+            },
+            "symbol": "D"
+          },
+          "tasks_for": "hg-push",
+          "notify": {
+            "email": {
+              "link": {
+                "text": "Treeherder Jobs",
+                "href": "https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791"
+              },
+              "subject": "Thank you for your try submission of 0b445bf4228a963505183b157758c37664921791. It's the best!",
+              "content": "Your try push has been submitted. It's the best! Use the link to view the status of your jobs."
+            }
+          }
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "E8dBX1rhRTugE8-Oa0FeFg",
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.713Z",
+        "expires": "2019-10-21T10:38:11.713Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "packet-sjc1",
+            "workerId": "machine-2",
+            "takenUntil": "2019-10-07T11:53:05.214Z",
+            "scheduled": "2019-10-07T10:45:07.293Z",
+            "started": "2019-10-07T11:33:05.285Z",
+            "resolved": "2019-10-07T11:37:25.240Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Sx3QOoliRg-81JMSzPxMWg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.713Z",
+        "deadline": "2019-10-08T10:38:11.713Z",
+        "expires": "2019-10-21T10:38:11.713Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "project:releng:services/tooltool/api/download/internal",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:capability:device:loopbackVideo",
+          "docker-worker:capability:privileged",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "capabilities": {
+            "privileged": true,
+            "devices": {
+              "loopbackVideo": true
+            }
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.713Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.713Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.713Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/geckoview-androidTest.apk",
+            "MOZHARNESS_ACTIONS": "get-secrets",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/geckoview-androidTest.apk\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "TASKCLUSTER_ROOT_URL": "https://taskcluster.net",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "android/androidx86_7_0.py web_platform_tests/prod_config_android.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-android-em-7.0-x86_64/opt-geckoview-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-android-em-7.0-x86_64/opt-geckoview-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "android-em-7-0-x86_64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "android-em-7-0-x86_64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "EMiNbI-lQ0a_NqpPhrlF_Q",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.450Z",
+        "expires": "2019-10-21T10:38:10.450Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.450Z",
+        "deadline": "2019-10-08T10:38:10.450Z",
+        "expires": "2019-10-21T10:38:10.450Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "E_kftcMSQWaa1AOqFkmrDg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.496Z",
+        "expires": "2019-10-21T10:38:11.496Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-2",
+            "workerId": "i-0e13f91ccc6bfd4fd",
+            "takenUntil": "2019-10-07T11:01:56.640Z",
+            "scheduled": "2019-10-07T10:41:55.886Z",
+            "started": "2019-10-07T10:41:56.742Z",
+            "resolved": "2019-10-07T10:46:57.330Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.496Z",
+        "deadline": "2019-10-08T10:38:11.496Z",
+        "expires": "2019-10-21T10:38:11.496Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 9000,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.496Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.496Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.496Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--enable-webrender",
+            "--setpref=layers.d3d11.enable-blacklist=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-qr/debug-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "FJYMxdFvSJiFSlvAScx_yg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.269Z",
+        "expires": "2019-11-04T10:38:09.269Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-west-2",
+            "workerId": "i-0544e3c6c78c0e138",
+            "takenUntil": "2019-10-07T10:58:29.693Z",
+            "scheduled": "2019-10-07T10:38:29.382Z",
+            "started": "2019-10-07T10:38:29.773Z",
+            "resolved": "2019-10-07T10:42:09.366Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Ly_R3E7nTKW8x40QXRLEPg",
+          "M5STQbxiRnGt4aSmWdp7Dg",
+          "MaEB78HGTw6Dp7AqnvDM1Q",
+          "MgI2k6kxSmi3SKyM8rc7UA",
+          "O-KYVZ5DQU636BcrE5Uanw",
+          "U4Ceoc56ShGNbHW71ZsQ-w",
+          "Uai_mGbWQ5ahVemoAWeuJg",
+          "bCS0hW_8SmWeIID2GP6Ktg",
+          "cMItT5VOTluDKPjeW1VHOg",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.firefox.linux64-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.firefox.linux64-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.firefox.linux64-opt",
+          "index.gecko.v2.try.pushlog-id.432115.firefox.linux64-opt",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.linux64-opt",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.269Z",
+        "deadline": "2019-10-08T10:38:09.269Z",
+        "expires": "2019-11-04T10:38:09.269Z",
+        "scopes": [
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets",
+          "auth:gcp:access-token:sccache-3/tc-l1*",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "Ly_R3E7nTKW8x40QXRLEPg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs": {
+              "path": "/builds/worker/logs/",
+              "expires": "2019-11-04T10:38:09.269Z",
+              "type": "directory"
+            },
+            "public/build": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-11-04T10:38:09.269Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/workspace/build/src",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/workspace/build/src/taskcluster/scripts/builder/build-linux.sh"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/binutils.tar.xz\", \"extract\": true, \"task\": \"M5STQbxiRnGt4aSmWdp7Dg\"}, {\"artifact\": \"public/build/clang.tar.xz\", \"extract\": true, \"task\": \"MgI2k6kxSmi3SKyM8rc7UA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"bCS0hW_8SmWeIID2GP6Ktg\"}, {\"artifact\": \"public/build/rust-size.tar.xz\", \"extract\": true, \"task\": \"Uai_mGbWQ5ahVemoAWeuJg\"}, {\"artifact\": \"public/build/cbindgen.tar.xz\", \"extract\": true, \"task\": \"MaEB78HGTw6Dp7AqnvDM1Q\"}, {\"artifact\": \"public/build/sccache.tar.xz\", \"extract\": true, \"task\": \"cMItT5VOTluDKPjeW1VHOg\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"U4Ceoc56ShGNbHW71ZsQ-w\"}, {\"artifact\": \"public/build/node.tar.xz\", \"extract\": true, \"task\": \"O-KYVZ5DQU636BcrE5Uanw\"}]",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "PYTHONUNBUFFERED": "1",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZHARNESS_SCRIPT": "mozharness/scripts/fx_desktop_build.py",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "MH_BUILD_POOL": "taskcluster",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZHARNESS_ACTIONS": "get-secrets build",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\", \"mozconfig_variant\": \"nightly\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "NEED_XVFB": "true",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "",
+            "UPLOAD_DIR": "/builds/worker/artifacts/",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GECKO_PATH": "/builds/worker/workspace/build/src",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "MOZHARNESS_CONFIG": "builds/releng_base_firefox.py builds/releng_base_linux_64_builds.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Linux64 Opt ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-linux64/opt"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-linux64/opt",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "chainOfTrust": {
+            "inputs": {
+              "docker-image": "Ly_R3E7nTKW8x40QXRLEPg"
+            }
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "linux64"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "opt": true
+            }
+          },
+          "treeherder-platform": "linux64/opt",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "G-7nN-buTKCC7V7DZabL3A",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.457Z",
+        "expires": "2019-10-21T10:38:11.457Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-1",
+            "workerId": "i-0571bec9f7b8bb624",
+            "takenUntil": "2019-10-07T11:08:33.666Z",
+            "scheduled": "2019-10-07T10:48:33.288Z",
+            "started": "2019-10-07T10:48:33.749Z",
+            "resolved": "2019-10-07T10:53:49.321Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "X4wdBGlHSEOK68lG0AdlDQ",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.457Z",
+        "deadline": "2019-10-08T10:38:11.457Z",
+        "expires": "2019-10-21T10:38:11.457Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.457Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.457Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.457Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-asan/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-asan/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "asan": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/asan"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "G_5hbYX5SveijqjP4khUiw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.278Z",
+        "expires": "2019-11-04T10:38:09.278Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-08cb4ca677811893a",
+            "takenUntil": "2019-10-07T11:21:44.698Z",
+            "scheduled": "2019-10-07T10:38:29.401Z",
+            "started": "2019-10-07T10:44:44.256Z",
+            "resolved": "2019-10-07T11:02:56.873Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "CDAcPFmBTbC4GRVbyfjrVg",
+          "CVde5A_JQa-i_bwib7x-Jg",
+          "PXqEh8AZRgGQuCsvEFls3A",
+          "RTF-ZEqwSG2ELmfXX-CAzA",
+          "WAEzVS1TT9ywiINxBj6DHw",
+          "YBeMzVRcQ_mkBaQQPe1e-A",
+          "eaBNHA-USOe-AuI2BXsUxA",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.firefox.win32-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.firefox.win32-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.firefox.win32-opt",
+          "index.gecko.v2.try.pushlog-id.432115.firefox.win32-opt",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.win32-opt",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.278Z",
+        "deadline": "2019-10-08T10:38:09.278Z",
+        "expires": "2019-11-04T10:38:09.278Z",
+        "scopes": [
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "public/build",
+              "type": "directory",
+              "name": "public/build"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            ":: sccache currently uses the full compiler commandline as input to the\n:: cache hash key, so create a symlink to the task dir and build from\n:: the symlink dir to get consistent paths.\nif exist z:\\build rmdir z:\\build",
+            "mklink /d z:\\build %cd%",
+            "icacls z:\\build /grant *S-1-1-0:D /L",
+            "cd /d z:\\build",
+            "C:/mozilla-build/python3/python3.exe run-task --gecko-checkout=./build/src -- c:/mozilla-build/python/python.exe %GECKO_PATH%/testing/mozharness/scripts/fx_desktop_build.py --config builds/releng_base_firefox.py --config builds/taskcluster_base_windows.py --config builds/taskcluster_base_win32.py --branch try --work-dir %cd:Z:=z:%\\build --append-env-variables-from-configs"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZ_SIMPLE_PACKAGE_NAME": "target",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "HG_STORE_PATH": "y:/hg-shared",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\", \"stage_platform\": \"win32\", \"mozconfig_variant\": \"nightly\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "PYTHONPATH": "./build/src/testing/mozbase/manifestparser;./build/src/testing/mozbase/mozinfo;./build/src/testing/mozbase/mozfile;./build/src/testing/mozbase/mozprocess;./build/src/third_party/python/six",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/clang.tar.bz2\", \"extract\": true, \"task\": \"eaBNHA-USOe-AuI2BXsUxA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"CVde5A_JQa-i_bwib7x-Jg\"}, {\"artifact\": \"public/build/rust-size.tar.bz2\", \"extract\": true, \"task\": \"CDAcPFmBTbC4GRVbyfjrVg\"}, {\"artifact\": \"public/build/cbindgen.tar.bz2\", \"extract\": true, \"task\": \"WAEzVS1TT9ywiINxBj6DHw\"}, {\"artifact\": \"public/build/sccache.tar.bz2\", \"extract\": true, \"task\": \"PXqEh8AZRgGQuCsvEFls3A\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"YBeMzVRcQ_mkBaQQPe1e-A\"}, {\"artifact\": \"public/build/node.tar.bz2\", \"extract\": true, \"task\": \"RTF-ZEqwSG2ELmfXX-CAzA\"}]",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "no commit message",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GECKO_PATH": "./build/src",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TOOLTOOL_MANIFEST": "browser/config/tooltool-manifests/win32/releng.manifest"
+          },
+          "mounts": [
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/misc/fetch-content"
+              },
+              "file": "./fetch-content"
+            }
+          ],
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Win32 Opt ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-win32/opt"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-win32/opt",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "windows2012-32"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "opt": true
+            }
+          },
+          "treeherder-platform": "windows2012-32/opt",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "HPYneNXbR0msImxF7QBzgQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.453Z",
+        "expires": "2019-10-21T10:38:10.453Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.453Z",
+        "deadline": "2019-10-08T10:38:10.453Z",
+        "expires": "2019-10-21T10:38:10.453Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "HpLD9XGAQdeowl-0tccv5A",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.460Z",
+        "expires": "2019-10-21T10:38:10.460Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.460Z",
+        "deadline": "2019-10-08T10:38:10.460Z",
+        "expires": "2019-10-21T10:38:10.460Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "IIo8_uFBTsiTQKEh0r0a-A",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.432Z",
+        "expires": "2019-10-21T10:38:12.432Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-2",
+            "workerId": "i-0f2c74836183399dc",
+            "takenUntil": "2019-10-07T11:02:14.142Z",
+            "scheduled": "2019-10-07T10:42:13.065Z",
+            "started": "2019-10-07T10:42:14.214Z",
+            "resolved": "2019-10-07T10:45:05.158Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "FJYMxdFvSJiFSlvAScx_yg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.432Z",
+        "deadline": "2019-10-08T10:38:12.432Z",
+        "expires": "2019-10-21T10:38:12.432Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:12.432Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:12.432Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:12.432Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=12",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "ITcapOyxSvewVt3GzyCYhw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.453Z",
+        "expires": "2019-10-21T10:38:11.453Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-1",
+            "workerId": "i-0f56317fa1189b37e",
+            "takenUntil": "2019-10-07T11:08:33.665Z",
+            "scheduled": "2019-10-07T10:48:33.291Z",
+            "started": "2019-10-07T10:48:34.169Z",
+            "resolved": "2019-10-07T10:53:45.475Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "X4wdBGlHSEOK68lG0AdlDQ",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.453Z",
+        "deadline": "2019-10-08T10:38:11.453Z",
+        "expires": "2019-10-21T10:38:11.453Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.453Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.453Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.453Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-asan/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-asan/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "asan": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/asan"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "ImkneZ61Rp2y-gt-SYoJLg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.455Z",
+        "expires": "2019-10-21T10:38:12.455Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-0445f5771380868d6",
+            "takenUntil": "2019-10-07T11:02:13.693Z",
+            "scheduled": "2019-10-07T10:42:13.053Z",
+            "started": "2019-10-07T10:42:13.767Z",
+            "resolved": "2019-10-07T10:45:07.692Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "FJYMxdFvSJiFSlvAScx_yg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.455Z",
+        "deadline": "2019-10-08T10:38:12.455Z",
+        "expires": "2019-10-21T10:38:12.455Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:12.455Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:12.455Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:12.455Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=12",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "JHIC4Kl8SMq3_KTuA2XGTA",
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.448Z",
+        "expires": "2019-10-21T10:38:11.448Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "packet-sjc1",
+            "workerId": "machine-44",
+            "takenUntil": "2019-10-07T11:54:14.793Z",
+            "scheduled": "2019-10-07T10:47:14.576Z",
+            "started": "2019-10-07T11:34:14.877Z",
+            "resolved": "2019-10-07T11:38:08.672Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "bUfsCA77RD-r2zlxW9kNzg",
+          "bemAkIsIRsOZG46_yE_UVQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.448Z",
+        "deadline": "2019-10-08T10:38:11.448Z",
+        "expires": "2019-10-21T10:38:11.448Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "project:releng:services/tooltool/api/download/internal",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:capability:device:loopbackVideo",
+          "docker-worker:capability:privileged",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "capabilities": {
+            "privileged": true,
+            "devices": {
+              "loopbackVideo": true
+            }
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.448Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.448Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.448Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/geckoview-androidTest.apk",
+            "MOZHARNESS_ACTIONS": "get-secrets",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/geckoview-androidTest.apk\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "TASKCLUSTER_ROOT_URL": "https://taskcluster.net",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "android/androidx86_7_0.py web_platform_tests/prod_config_android.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-android-em-7.0-x86_64/debug-geckoview-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-android-em-7.0-x86_64/debug-geckoview-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "android-em-7-0-x86_64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "android-em-7-0-x86_64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Jl3OGh7XQRSMXZAPA_NpQg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.474Z",
+        "expires": "2019-10-21T10:38:11.474Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-06eef8110898d4802",
+            "takenUntil": "2019-10-07T11:01:57.210Z",
+            "scheduled": "2019-10-07T10:41:55.902Z",
+            "started": "2019-10-07T10:41:57.291Z",
+            "resolved": "2019-10-07T10:46:17.188Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.474Z",
+        "deadline": "2019-10-08T10:38:11.474Z",
+        "expires": "2019-10-21T10:38:11.474Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.474Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.474Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.474Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=\"dom.serviceWorkers.parent_intercept=true\"",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run with serviceworker-e10s redesign enabled ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/debug-web-platform-tests-sw-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/debug-web-platform-tests-sw-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W-sw",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests with serviceworker redesign",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "KDHFLbeATKSQUE_3WHG_iQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.291Z",
+        "expires": "2019-11-04T10:38:09.291Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-08695eda0e792529f",
+            "takenUntil": "2019-10-07T11:21:34.558Z",
+            "scheduled": "2019-10-07T10:38:29.400Z",
+            "started": "2019-10-07T10:44:33.953Z",
+            "resolved": "2019-10-07T11:02:20.732Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "CDAcPFmBTbC4GRVbyfjrVg",
+          "CVde5A_JQa-i_bwib7x-Jg",
+          "PXqEh8AZRgGQuCsvEFls3A",
+          "RTF-ZEqwSG2ELmfXX-CAzA",
+          "WAEzVS1TT9ywiINxBj6DHw",
+          "YBeMzVRcQ_mkBaQQPe1e-A",
+          "eaBNHA-USOe-AuI2BXsUxA",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.firefox.win32-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.firefox.win32-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.firefox.win32-debug",
+          "index.gecko.v2.try.pushlog-id.432115.firefox.win32-debug",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.win32-debug",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.291Z",
+        "deadline": "2019-10-08T10:38:09.291Z",
+        "expires": "2019-11-04T10:38:09.291Z",
+        "scopes": [
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "public/build",
+              "type": "directory",
+              "name": "public/build"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            ":: sccache currently uses the full compiler commandline as input to the\n:: cache hash key, so create a symlink to the task dir and build from\n:: the symlink dir to get consistent paths.\nif exist z:\\build rmdir z:\\build",
+            "mklink /d z:\\build %cd%",
+            "icacls z:\\build /grant *S-1-1-0:D /L",
+            "cd /d z:\\build",
+            "C:/mozilla-build/python3/python3.exe run-task --gecko-checkout=./build/src -- c:/mozilla-build/python/python.exe %GECKO_PATH%/testing/mozharness/scripts/fx_desktop_build.py --config builds/releng_base_firefox.py --config builds/taskcluster_base_windows.py --config builds/taskcluster_base_win32.py --config builds/taskcluster_sub_win32/debug.py --branch try --work-dir %cd:Z:=z:%\\build --append-env-variables-from-configs"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZ_SIMPLE_PACKAGE_NAME": "target",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "HG_STORE_PATH": "y:/hg-shared",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\", \"mozconfig_variant\": \"debug\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "PYTHONPATH": "./build/src/testing/mozbase/manifestparser;./build/src/testing/mozbase/mozinfo;./build/src/testing/mozbase/mozfile;./build/src/testing/mozbase/mozprocess;./build/src/third_party/python/six",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/clang.tar.bz2\", \"extract\": true, \"task\": \"eaBNHA-USOe-AuI2BXsUxA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"CVde5A_JQa-i_bwib7x-Jg\"}, {\"artifact\": \"public/build/rust-size.tar.bz2\", \"extract\": true, \"task\": \"CDAcPFmBTbC4GRVbyfjrVg\"}, {\"artifact\": \"public/build/cbindgen.tar.bz2\", \"extract\": true, \"task\": \"WAEzVS1TT9ywiINxBj6DHw\"}, {\"artifact\": \"public/build/sccache.tar.bz2\", \"extract\": true, \"task\": \"PXqEh8AZRgGQuCsvEFls3A\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"YBeMzVRcQ_mkBaQQPe1e-A\"}, {\"artifact\": \"public/build/node.tar.bz2\", \"extract\": true, \"task\": \"RTF-ZEqwSG2ELmfXX-CAzA\"}]",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "no commit message",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GECKO_PATH": "./build/src",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TOOLTOOL_MANIFEST": "browser/config/tooltool-manifests/win32/releng.manifest"
+          },
+          "mounts": [
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/misc/fetch-content"
+              },
+              "file": "./fetch-content"
+            }
+          ],
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Win32 Debug ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-win32/debug"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-win32/debug",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "windows2012-32"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "debug": true
+            }
+          },
+          "treeherder-platform": "windows2012-32/debug",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "L-SgZpgzTlSnAtWUIHU66g",
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.446Z",
+        "expires": "2019-10-21T10:38:11.446Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "packet-sjc1",
+            "workerId": "machine-25",
+            "takenUntil": "2019-10-07T11:53:32.115Z",
+            "scheduled": "2019-10-07T10:47:14.527Z",
+            "started": "2019-10-07T11:33:32.216Z",
+            "resolved": "2019-10-07T11:37:28.756Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "bUfsCA77RD-r2zlxW9kNzg",
+          "bemAkIsIRsOZG46_yE_UVQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.446Z",
+        "deadline": "2019-10-08T10:38:11.446Z",
+        "expires": "2019-10-21T10:38:11.446Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "project:releng:services/tooltool/api/download/internal",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:capability:device:loopbackVideo",
+          "docker-worker:capability:privileged",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "capabilities": {
+            "privileged": true,
+            "devices": {
+              "loopbackVideo": true
+            }
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.446Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.446Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.446Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/geckoview-androidTest.apk",
+            "MOZHARNESS_ACTIONS": "get-secrets",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/geckoview-androidTest.apk\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "TASKCLUSTER_ROOT_URL": "https://taskcluster.net",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "android/androidx86_7_0.py web_platform_tests/prod_config_android.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-android-em-7.0-x86_64/debug-geckoview-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-android-em-7.0-x86_64/debug-geckoview-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "android-em-7-0-x86_64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "android-em-7-0-x86_64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "LRsLJxrURZGNHemCqIELvQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.474Z",
+        "expires": "2019-10-21T10:38:11.474Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-02fab44b2393bfb23",
+            "takenUntil": "2019-10-07T11:01:56.802Z",
+            "scheduled": "2019-10-07T10:41:55.884Z",
+            "started": "2019-10-07T10:41:56.879Z",
+            "resolved": "2019-10-07T10:46:27.005Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.474Z",
+        "deadline": "2019-10-08T10:38:11.474Z",
+        "expires": "2019-10-21T10:38:11.474Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.474Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.474Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.474Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=\"dom.serviceWorkers.parent_intercept=true\"",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run with serviceworker-e10s redesign enabled ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/debug-web-platform-tests-sw-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/debug-web-platform-tests-sw-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W-sw",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests with serviceworker redesign",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "MMXOahgdROGE9lqNp12K2g",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.434Z",
+        "expires": "2019-10-21T10:38:11.434Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.434Z",
+        "deadline": "2019-10-08T10:38:11.434Z",
+        "expires": "2019-10-21T10:38:11.434Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Mm13JLTfTyOhwL6S_f_JVA",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.416Z",
+        "expires": "2019-10-21T10:38:11.416Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "G_5hbYX5SveijqjP4khUiw"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.416Z",
+        "deadline": "2019-10-08T10:38:11.416Z",
+        "expires": "2019-10-21T10:38:11.416Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "G_5hbYX5SveijqjP4khUiw",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "N2Sfz1VNSrq_S4wTiBslAA",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.270Z",
+        "expires": "2019-10-21T10:38:12.270Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.270Z",
+        "deadline": "2019-10-08T10:38:12.270Z",
+        "expires": "2019-10-21T10:38:12.270Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "NL-I5-UFTOC9mXXpHRoPoA",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.436Z",
+        "expires": "2019-10-21T10:38:11.436Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.436Z",
+        "deadline": "2019-10-08T10:38:11.436Z",
+        "expires": "2019-10-21T10:38:11.436Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "NZ4Ch8O6Qx65XN1fYSZa0w",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.484Z",
+        "expires": "2019-10-21T10:38:11.484Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-08f5f119843961776",
+            "takenUntil": "2019-10-07T11:01:56.244Z",
+            "scheduled": "2019-10-07T10:41:55.881Z",
+            "started": "2019-10-07T10:41:56.316Z",
+            "resolved": "2019-10-07T10:47:05.908Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.484Z",
+        "deadline": "2019-10-08T10:38:11.484Z",
+        "expires": "2019-10-21T10:38:11.484Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 9000,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.484Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.484Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.484Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--enable-webrender",
+            "--setpref=layers.d3d11.enable-blacklist=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-qr/debug-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "NsfVntnvRJiyVq9IhHSxQQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.280Z",
+        "expires": "2019-11-04T10:38:09.280Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-00bd0ba502aa68152",
+            "takenUntil": "2019-10-07T10:58:29.752Z",
+            "scheduled": "2019-10-07T10:38:29.396Z",
+            "started": "2019-10-07T10:38:29.829Z",
+            "resolved": "2019-10-07T10:52:11.065Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "HF7QfhcURQ2TdwiIHwTQzQ",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.280Z",
+        "deadline": "2019-10-08T10:38:09.280Z",
+        "expires": "2019-11-04T10:38:09.280Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 1800,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "HF7QfhcURQ2TdwiIHwTQzQ"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts"
+          },
+          "artifacts": {
+            "public/code-review/mozlint.json": {
+              "path": "/builds/worker/mozlint.json",
+              "expires": "2019-11-04T10:38:09.280Z",
+              "type": "file"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/checkouts/gecko",
+            "--fetch-hgfingerprint",
+            "--task-cwd",
+            "/builds/worker/checkouts/gecko",
+            "--",
+            "bash",
+            "-cx",
+            "cp -r /build/node_modules_eslint node_modules && ln -s ../tools/lint/eslint/eslint-plugin-mozilla node_modules && ln -s ../tools/lint/eslint/eslint-plugin-spidermonkey-js node_modules && ./mach lint -l eslint -f treeherder --quiet -f json:/builds/worker/mozlint.json\n"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "CARGO_HOME": "/build/rust",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "RUSTFMT": "/build/rust/bin/rustfmt",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts",
+            "RUSTUP_HOME": "/build/rust",
+            "MOZ_AUTOMATION": "1",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified"
+          },
+          "features": {
+            "taskclusterProxy": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/source-test",
+          "description": "JS lint check ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "source-test-mozlint-eslint"
+        },
+        "tags": {
+          "kind": "source-test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "source-test-mozlint-eslint",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "js",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "lint"
+            },
+            "groupName": "JavaScript checks",
+            "tier": 1,
+            "symbol": "ES"
+          },
+          "treeherder-platform": "lint/opt",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "OH3zP8PCT5uXt8Ys4nAciw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.434Z",
+        "expires": "2019-10-21T10:38:12.434Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-0ffe796c014d77b5e",
+            "takenUntil": "2019-10-07T11:02:14.143Z",
+            "scheduled": "2019-10-07T10:42:13.071Z",
+            "started": "2019-10-07T10:42:14.213Z",
+            "resolved": "2019-10-07T10:45:32.925Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "FJYMxdFvSJiFSlvAScx_yg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.434Z",
+        "deadline": "2019-10-08T10:38:12.434Z",
+        "expires": "2019-10-21T10:38:12.434Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:12.434Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:12.434Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:12.434Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=12",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.273Z",
+        "expires": "2019-11-04T10:38:09.273Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-1",
+            "workerId": "i-0899741bb27792f19",
+            "takenUntil": "2019-10-07T11:22:57.195Z",
+            "scheduled": "2019-10-07T10:38:29.419Z",
+            "started": "2019-10-07T10:45:57.122Z",
+            "resolved": "2019-10-07T11:04:42.580Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "CDAcPFmBTbC4GRVbyfjrVg",
+          "CVde5A_JQa-i_bwib7x-Jg",
+          "PXqEh8AZRgGQuCsvEFls3A",
+          "RTF-ZEqwSG2ELmfXX-CAzA",
+          "WAEzVS1TT9ywiINxBj6DHw",
+          "YBeMzVRcQ_mkBaQQPe1e-A",
+          "eaBNHA-USOe-AuI2BXsUxA",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.firefox.win64-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.firefox.win64-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.firefox.win64-opt",
+          "index.gecko.v2.try.pushlog-id.432115.firefox.win64-opt",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.win64-opt",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.273Z",
+        "deadline": "2019-10-08T10:38:09.273Z",
+        "expires": "2019-11-04T10:38:09.273Z",
+        "scopes": [
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "public/build",
+              "type": "directory",
+              "name": "public/build"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            ":: sccache currently uses the full compiler commandline as input to the\n:: cache hash key, so create a symlink to the task dir and build from\n:: the symlink dir to get consistent paths.\nif exist z:\\build rmdir z:\\build",
+            "mklink /d z:\\build %cd%",
+            "icacls z:\\build /grant *S-1-1-0:D /L",
+            "cd /d z:\\build",
+            "C:/mozilla-build/python3/python3.exe run-task --gecko-checkout=./build/src -- c:/mozilla-build/python/python.exe %GECKO_PATH%/testing/mozharness/scripts/fx_desktop_build.py --config builds/releng_base_firefox.py --config builds/taskcluster_base_windows.py --config builds/taskcluster_base_win64.py --branch try --work-dir %cd:Z:=z:%\\build --append-env-variables-from-configs"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZ_SIMPLE_PACKAGE_NAME": "target",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "HG_STORE_PATH": "y:/hg-shared",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\", \"stage_platform\": \"win64\", \"mozconfig_variant\": \"nightly\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "PYTHONPATH": "./build/src/testing/mozbase/manifestparser;./build/src/testing/mozbase/mozinfo;./build/src/testing/mozbase/mozfile;./build/src/testing/mozbase/mozprocess;./build/src/third_party/python/six",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/clang.tar.bz2\", \"extract\": true, \"task\": \"eaBNHA-USOe-AuI2BXsUxA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"CVde5A_JQa-i_bwib7x-Jg\"}, {\"artifact\": \"public/build/rust-size.tar.bz2\", \"extract\": true, \"task\": \"CDAcPFmBTbC4GRVbyfjrVg\"}, {\"artifact\": \"public/build/cbindgen.tar.bz2\", \"extract\": true, \"task\": \"WAEzVS1TT9ywiINxBj6DHw\"}, {\"artifact\": \"public/build/sccache.tar.bz2\", \"extract\": true, \"task\": \"PXqEh8AZRgGQuCsvEFls3A\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"YBeMzVRcQ_mkBaQQPe1e-A\"}, {\"artifact\": \"public/build/node.tar.bz2\", \"extract\": true, \"task\": \"RTF-ZEqwSG2ELmfXX-CAzA\"}]",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "no commit message",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GECKO_PATH": "./build/src",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TOOLTOOL_MANIFEST": "browser/config/tooltool-manifests/win64/releng.manifest"
+          },
+          "mounts": [
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/misc/fetch-content"
+              },
+              "file": "./fetch-content"
+            }
+          ],
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Win64 Opt ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-win64/opt"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-win64/opt",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "windows2012-64"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "opt": true
+            }
+          },
+          "treeherder-platform": "windows2012-64/opt",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "P5DZEqEQSZ2f4oLyP_qCxA",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.454Z",
+        "expires": "2019-10-21T10:38:11.454Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-2",
+            "workerId": "i-07b50212eb2038967",
+            "takenUntil": "2019-10-07T11:08:33.681Z",
+            "scheduled": "2019-10-07T10:48:33.280Z",
+            "started": "2019-10-07T10:48:33.759Z",
+            "resolved": "2019-10-07T10:54:16.950Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "X4wdBGlHSEOK68lG0AdlDQ",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.454Z",
+        "deadline": "2019-10-08T10:38:11.454Z",
+        "expires": "2019-10-21T10:38:11.454Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.454Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.454Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.454Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/X4wdBGlHSEOK68lG0AdlDQ/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-asan/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-asan/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "asan": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/asan"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "P9TrHbWCSHOxY8cx_rbthg",
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.549Z",
+        "expires": "2019-10-21T10:38:11.549Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "packet-sjc1",
+            "workerId": "machine-20",
+            "takenUntil": "2019-10-07T11:52:38.697Z",
+            "scheduled": "2019-10-07T10:45:07.221Z",
+            "started": "2019-10-07T11:32:38.772Z",
+            "resolved": "2019-10-07T11:36:46.582Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Sx3QOoliRg-81JMSzPxMWg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.549Z",
+        "deadline": "2019-10-08T10:38:11.549Z",
+        "expires": "2019-10-21T10:38:11.549Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "project:releng:services/tooltool/api/download/internal",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:capability:device:loopbackVideo",
+          "docker-worker:capability:privileged",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "capabilities": {
+            "privileged": true,
+            "devices": {
+              "loopbackVideo": true
+            }
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.549Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.549Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.549Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/geckoview-androidTest.apk",
+            "MOZHARNESS_ACTIONS": "get-secrets",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/geckoview-androidTest.apk\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "TASKCLUSTER_ROOT_URL": "https://taskcluster.net",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "android/androidx86_7_0.py web_platform_tests/prod_config_android.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-android-em-7.0-x86_64/opt-geckoview-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-android-em-7.0-x86_64/opt-geckoview-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "android-em-7-0-x86_64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "android-em-7-0-x86_64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "PDy94NcmTW2B7Q3jWRt_HQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.403Z",
+        "expires": "2019-10-21T10:38:11.403Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-082a37951e23e4eac",
+            "takenUntil": "2019-10-07T11:02:13.694Z",
+            "scheduled": "2019-10-07T10:42:13.051Z",
+            "started": "2019-10-07T10:42:13.768Z",
+            "resolved": "2019-10-07T10:45:45.001Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "FJYMxdFvSJiFSlvAScx_yg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.403Z",
+        "deadline": "2019-10-08T10:38:11.403Z",
+        "expires": "2019-10-21T10:38:11.403Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.403Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.403Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.403Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--enable-webrender",
+            "--setpref=layers.d3d11.enable-blacklist=false",
+            "--total-chunk=12",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-qr/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "linux64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "PdPfp85USou2HCUE4TGs_w",
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.442Z",
+        "expires": "2019-10-21T10:38:11.442Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "packet-sjc1",
+            "workerId": "machine-53",
+            "takenUntil": "2019-10-07T11:53:37.091Z",
+            "scheduled": "2019-10-07T10:47:14.561Z",
+            "started": "2019-10-07T11:33:37.164Z",
+            "resolved": "2019-10-07T11:37:28.638Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "bUfsCA77RD-r2zlxW9kNzg",
+          "bemAkIsIRsOZG46_yE_UVQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.442Z",
+        "deadline": "2019-10-08T10:38:11.442Z",
+        "expires": "2019-10-21T10:38:11.442Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "project:releng:services/tooltool/api/download/internal",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:capability:device:loopbackVideo",
+          "docker-worker:capability:privileged",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "capabilities": {
+            "privileged": true,
+            "devices": {
+              "loopbackVideo": true
+            }
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.442Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.442Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.442Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/geckoview-androidTest.apk",
+            "MOZHARNESS_ACTIONS": "get-secrets",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/geckoview-androidTest.apk\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "TASKCLUSTER_ROOT_URL": "https://taskcluster.net",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "android/androidx86_7_0.py web_platform_tests/prod_config_android.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-android-em-7.0-x86_64/debug-geckoview-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-android-em-7.0-x86_64/debug-geckoview-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "android-em-7-0-x86_64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "android-em-7-0-x86_64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Plzbf0xoQxi8w_FJ0ErYxw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.320Z",
+        "expires": "2019-10-21T10:38:12.320Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.320Z",
+        "deadline": "2019-10-08T10:38:12.320Z",
+        "expires": "2019-10-21T10:38:12.320Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "PtBWof3LRoKpvwAvKS0gDA",
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.595Z",
+        "expires": "2019-10-21T10:38:11.595Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "packet-sjc1",
+            "workerId": "machine-33",
+            "takenUntil": "2019-10-07T11:52:36.098Z",
+            "scheduled": "2019-10-07T10:45:07.208Z",
+            "started": "2019-10-07T11:32:36.169Z",
+            "resolved": "2019-10-07T11:36:52.559Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Sx3QOoliRg-81JMSzPxMWg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.595Z",
+        "deadline": "2019-10-08T10:38:11.595Z",
+        "expires": "2019-10-21T10:38:11.595Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "project:releng:services/tooltool/api/download/internal",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:capability:device:loopbackVideo",
+          "docker-worker:capability:privileged",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "capabilities": {
+            "privileged": true,
+            "devices": {
+              "loopbackVideo": true
+            }
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.595Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.595Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.595Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/geckoview-androidTest.apk",
+            "MOZHARNESS_ACTIONS": "get-secrets",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/geckoview-androidTest.apk\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "TASKCLUSTER_ROOT_URL": "https://taskcluster.net",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "android/androidx86_7_0.py web_platform_tests/prod_config_android.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-android-em-7.0-x86_64/opt-geckoview-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-android-em-7.0-x86_64/opt-geckoview-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "android-em-7-0-x86_64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "android-em-7-0-x86_64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "QUJ-OsS6RqmqMcjsRjmVBQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.332Z",
+        "expires": "2019-10-21T10:38:12.332Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.332Z",
+        "deadline": "2019-10-08T10:38:12.332Z",
+        "expires": "2019-10-21T10:38:12.332Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.279Z",
+        "expires": "2019-11-04T10:38:09.279Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-090cc1f0a8776a897",
+            "takenUntil": "2019-10-07T11:05:26.981Z",
+            "scheduled": "2019-10-07T10:38:29.411Z",
+            "started": "2019-10-07T10:45:27.057Z",
+            "resolved": "2019-10-07T10:59:44.379Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "CDAcPFmBTbC4GRVbyfjrVg",
+          "CVde5A_JQa-i_bwib7x-Jg",
+          "PXqEh8AZRgGQuCsvEFls3A",
+          "RTF-ZEqwSG2ELmfXX-CAzA",
+          "WAEzVS1TT9ywiINxBj6DHw",
+          "YBeMzVRcQ_mkBaQQPe1e-A",
+          "eaBNHA-USOe-AuI2BXsUxA",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.firefox.win64-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.firefox.win64-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.firefox.win64-debug",
+          "index.gecko.v2.try.pushlog-id.432115.firefox.win64-debug",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.win64-debug",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.279Z",
+        "deadline": "2019-10-08T10:38:09.279Z",
+        "expires": "2019-11-04T10:38:09.279Z",
+        "scopes": [
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "public/build",
+              "type": "directory",
+              "name": "public/build"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            ":: sccache currently uses the full compiler commandline as input to the\n:: cache hash key, so create a symlink to the task dir and build from\n:: the symlink dir to get consistent paths.\nif exist z:\\build rmdir z:\\build",
+            "mklink /d z:\\build %cd%",
+            "icacls z:\\build /grant *S-1-1-0:D /L",
+            "cd /d z:\\build",
+            "C:/mozilla-build/python3/python3.exe run-task --gecko-checkout=./build/src -- c:/mozilla-build/python/python.exe %GECKO_PATH%/testing/mozharness/scripts/fx_desktop_build.py --config builds/releng_base_firefox.py --config builds/taskcluster_base_windows.py --config builds/taskcluster_base_win64.py --config builds/taskcluster_sub_win64/debug.py --branch try --work-dir %cd:Z:=z:%\\build --append-env-variables-from-configs"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZ_SIMPLE_PACKAGE_NAME": "target",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "HG_STORE_PATH": "y:/hg-shared",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\", \"mozconfig_variant\": \"debug\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "PYTHONPATH": "./build/src/testing/mozbase/manifestparser;./build/src/testing/mozbase/mozinfo;./build/src/testing/mozbase/mozfile;./build/src/testing/mozbase/mozprocess;./build/src/third_party/python/six",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/clang.tar.bz2\", \"extract\": true, \"task\": \"eaBNHA-USOe-AuI2BXsUxA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"CVde5A_JQa-i_bwib7x-Jg\"}, {\"artifact\": \"public/build/rust-size.tar.bz2\", \"extract\": true, \"task\": \"CDAcPFmBTbC4GRVbyfjrVg\"}, {\"artifact\": \"public/build/cbindgen.tar.bz2\", \"extract\": true, \"task\": \"WAEzVS1TT9ywiINxBj6DHw\"}, {\"artifact\": \"public/build/sccache.tar.bz2\", \"extract\": true, \"task\": \"PXqEh8AZRgGQuCsvEFls3A\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"YBeMzVRcQ_mkBaQQPe1e-A\"}, {\"artifact\": \"public/build/node.tar.bz2\", \"extract\": true, \"task\": \"RTF-ZEqwSG2ELmfXX-CAzA\"}]",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "no commit message",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GECKO_PATH": "./build/src",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TOOLTOOL_MANIFEST": "browser/config/tooltool-manifests/win64/releng.manifest"
+          },
+          "mounts": [
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/misc/fetch-content"
+              },
+              "file": "./fetch-content"
+            }
+          ],
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Win64 Debug ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-win64/debug"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-win64/debug",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "windows2012-64"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "debug": true
+            }
+          },
+          "treeherder-platform": "windows2012-64/debug",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "R4oRDJ67RUa3K5P54z1CZw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.292Z",
+        "expires": "2019-10-21T10:38:12.292Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.292Z",
+        "deadline": "2019-10-08T10:38:12.292Z",
+        "expires": "2019-10-21T10:38:12.292Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "RnrGLDxhTsSsHjeCYnOQKw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.400Z",
+        "expires": "2019-10-21T10:38:11.400Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-2",
+            "workerId": "i-057864d93ccc6b9e0",
+            "takenUntil": "2019-10-07T11:02:13.906Z",
+            "scheduled": "2019-10-07T10:42:13.063Z",
+            "started": "2019-10-07T10:42:14.012Z",
+            "resolved": "2019-10-07T10:45:16.086Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "FJYMxdFvSJiFSlvAScx_yg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.400Z",
+        "deadline": "2019-10-08T10:38:11.400Z",
+        "expires": "2019-10-21T10:38:11.400Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.400Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.400Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.400Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--enable-webrender",
+            "--setpref=layers.d3d11.enable-blacklist=false",
+            "--total-chunk=12",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-qr/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "linux64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Rnv-2SRaStqG9gPAlhyMfg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.430Z",
+        "expires": "2019-10-21T10:38:11.430Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.430Z",
+        "deadline": "2019-10-08T10:38:11.430Z",
+        "expires": "2019-10-21T10:38:11.430Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "RqrmC1TSTHWlnU-hT35Rpw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.284Z",
+        "expires": "2019-11-04T10:38:09.284Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-west-1",
+            "workerId": "i-07eda4edae7afb760",
+            "takenUntil": "2019-10-07T10:58:29.695Z",
+            "scheduled": "2019-10-07T10:38:29.388Z",
+            "started": "2019-10-07T10:38:29.774Z",
+            "resolved": "2019-10-07T10:41:53.153Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Ly_R3E7nTKW8x40QXRLEPg",
+          "M5STQbxiRnGt4aSmWdp7Dg",
+          "MaEB78HGTw6Dp7AqnvDM1Q",
+          "MgI2k6kxSmi3SKyM8rc7UA",
+          "O-KYVZ5DQU636BcrE5Uanw",
+          "U4Ceoc56ShGNbHW71ZsQ-w",
+          "Uai_mGbWQ5ahVemoAWeuJg",
+          "bCS0hW_8SmWeIID2GP6Ktg",
+          "cMItT5VOTluDKPjeW1VHOg",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.firefox.linux64-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.firefox.linux64-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.firefox.linux64-debug",
+          "index.gecko.v2.try.pushlog-id.432115.firefox.linux64-debug",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.linux64-debug",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.284Z",
+        "deadline": "2019-10-08T10:38:09.284Z",
+        "expires": "2019-11-04T10:38:09.284Z",
+        "scopes": [
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets",
+          "auth:gcp:access-token:sccache-3/tc-l1*",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 5400,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "Ly_R3E7nTKW8x40QXRLEPg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs": {
+              "path": "/builds/worker/logs/",
+              "expires": "2019-11-04T10:38:09.284Z",
+              "type": "directory"
+            },
+            "public/build": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-11-04T10:38:09.284Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/workspace/build/src",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/workspace/build/src/taskcluster/scripts/builder/build-linux.sh"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/binutils.tar.xz\", \"extract\": true, \"task\": \"M5STQbxiRnGt4aSmWdp7Dg\"}, {\"artifact\": \"public/build/clang.tar.xz\", \"extract\": true, \"task\": \"MgI2k6kxSmi3SKyM8rc7UA\"}, {\"artifact\": \"public/build/cbindgen.tar.xz\", \"extract\": true, \"task\": \"MaEB78HGTw6Dp7AqnvDM1Q\"}, {\"artifact\": \"public/build/sccache.tar.xz\", \"extract\": true, \"task\": \"cMItT5VOTluDKPjeW1VHOg\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"bCS0hW_8SmWeIID2GP6Ktg\"}, {\"artifact\": \"public/build/rust-size.tar.xz\", \"extract\": true, \"task\": \"Uai_mGbWQ5ahVemoAWeuJg\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"U4Ceoc56ShGNbHW71ZsQ-w\"}, {\"artifact\": \"public/build/node.tar.xz\", \"extract\": true, \"task\": \"O-KYVZ5DQU636BcrE5Uanw\"}]",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "PYTHONUNBUFFERED": "1",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZHARNESS_SCRIPT": "mozharness/scripts/fx_desktop_build.py",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "MH_BUILD_POOL": "taskcluster",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MH_CUSTOM_BUILD_VARIANT_CFG": "debug",
+            "MOZHARNESS_ACTIONS": "get-secrets build",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\", \"mozconfig_variant\": \"debug\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "NEED_XVFB": "true",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "",
+            "UPLOAD_DIR": "/builds/worker/artifacts/",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GECKO_PATH": "/builds/worker/workspace/build/src",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "MOZHARNESS_CONFIG": "builds/releng_base_firefox.py builds/releng_base_linux_64_builds.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Linux64 Debug ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-linux64/debug"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-linux64/debug",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "chainOfTrust": {
+            "inputs": {
+              "docker-image": "Ly_R3E7nTKW8x40QXRLEPg"
+            }
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "linux64"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "debug": true
+            }
+          },
+          "treeherder-platform": "linux64/debug",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "RwgfXweRR-mxRSRYAY--lg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.458Z",
+        "expires": "2019-10-21T10:38:10.458Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.458Z",
+        "deadline": "2019-10-08T10:38:10.458Z",
+        "expires": "2019-10-21T10:38:10.458Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "S44ZgseQS8O8EJe0r84R3Q",
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.444Z",
+        "expires": "2019-10-21T10:38:11.444Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "packet-sjc1",
+            "workerId": "machine-44",
+            "takenUntil": "2019-10-07T11:53:14.560Z",
+            "scheduled": "2019-10-07T10:47:14.492Z",
+            "started": "2019-10-07T11:33:14.637Z",
+            "resolved": "2019-10-07T11:37:14.485Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "bUfsCA77RD-r2zlxW9kNzg",
+          "bemAkIsIRsOZG46_yE_UVQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.444Z",
+        "deadline": "2019-10-08T10:38:11.444Z",
+        "expires": "2019-10-21T10:38:11.444Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "project:releng:services/tooltool/api/download/internal",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:capability:device:loopbackVideo",
+          "docker-worker:capability:privileged",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "capabilities": {
+            "privileged": true,
+            "devices": {
+              "loopbackVideo": true
+            }
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.444Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.444Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.444Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/geckoview-androidTest.apk",
+            "MOZHARNESS_ACTIONS": "get-secrets",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/geckoview-androidTest.apk\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "TASKCLUSTER_ROOT_URL": "https://taskcluster.net",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "android/androidx86_7_0.py web_platform_tests/prod_config_android.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-android-em-7.0-x86_64/debug-geckoview-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-android-em-7.0-x86_64/debug-geckoview-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "android-em-7-0-x86_64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "android-em-7-0-x86_64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "SbBqiR0GQo-yM2TIjpDZMw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.282Z",
+        "expires": "2019-11-04T10:38:09.282Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-west-1",
+            "workerId": "i-08e1a91ebf8b75f75",
+            "takenUntil": "2019-10-07T10:58:30.044Z",
+            "scheduled": "2019-10-07T10:38:29.412Z",
+            "started": "2019-10-07T10:38:30.129Z",
+            "resolved": "2019-10-07T10:41:53.506Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "HF7QfhcURQ2TdwiIHwTQzQ",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.282Z",
+        "deadline": "2019-10-08T10:38:09.282Z",
+        "expires": "2019-11-04T10:38:09.282Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 1800,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "HF7QfhcURQ2TdwiIHwTQzQ"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts"
+          },
+          "artifacts": {
+            "public/code-review/mozlint.json": {
+              "path": "/builds/worker/mozlint.json",
+              "expires": "2019-11-04T10:38:09.282Z",
+              "type": "file"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/checkouts/gecko",
+            "--fetch-hgfingerprint",
+            "--task-cwd",
+            "/builds/worker/checkouts/gecko",
+            "--",
+            "bash",
+            "-cx",
+            "./mach lint -l test-disable -f treeherder -f json:/builds/worker/mozlint.json"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "CARGO_HOME": "/build/rust",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "RUSTFMT": "/build/rust/bin/rustfmt",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts",
+            "RUSTUP_HOME": "/build/rust",
+            "MOZ_AUTOMATION": "1",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified"
+          },
+          "features": {
+            "taskclusterProxy": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/source-test",
+          "description": "lint test manifests ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "source-test-mozlint-test-manifest"
+        },
+        "tags": {
+          "kind": "source-test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "source-test-mozlint-test-manifest",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "misc",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "lint"
+            },
+            "groupName": "Misc checks",
+            "tier": 1,
+            "symbol": "tm"
+          },
+          "treeherder-platform": "lint/opt",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Sx3QOoliRg-81JMSzPxMWg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.290Z",
+        "expires": "2019-11-04T10:38:09.290Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-040d494e94663fc73",
+            "takenUntil": "2019-10-07T10:58:29.751Z",
+            "scheduled": "2019-10-07T10:38:29.416Z",
+            "started": "2019-10-07T10:38:29.825Z",
+            "resolved": "2019-10-07T10:45:03.634Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "G2uFNVJQS--ciKaLRwkCwQ",
+          "MaEB78HGTw6Dp7AqnvDM1Q",
+          "MgI2k6kxSmi3SKyM8rc7UA",
+          "O-KYVZ5DQU636BcrE5Uanw",
+          "QOzMv9PzRsCaahfKO3GFhw",
+          "U4Ceoc56ShGNbHW71ZsQ-w",
+          "Uai_mGbWQ5ahVemoAWeuJg",
+          "V_Yy47svRwav6uPUv4J9ZA",
+          "aNZB8MtiT6yDsqDHEdfggQ",
+          "bT6TwSGUS2uA5gAwnB3ULQ",
+          "cMItT5VOTluDKPjeW1VHOg",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.mobile.android-x86_64-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.mobile.android-x86_64-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.mobile.android-x86_64-opt",
+          "index.gecko.v2.try.pushlog-id.432115.mobile.android-x86_64-opt",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.mobile.android-x86_64-opt",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.290Z",
+        "deadline": "2019-10-08T10:38:09.290Z",
+        "expires": "2019-11-04T10:38:09.290Z",
+        "scopes": [
+          "queue:get-artifact:project/gecko/android-ndk/*",
+          "queue:get-artifact:project/gecko/android-sdk/*",
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "project:releng:services/tooltool/api/download/internal",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets",
+          "auth:gcp:access-token:sccache-3/tc-l1*",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "QOzMv9PzRsCaahfKO3GFhw"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/build/maven": {
+              "path": "/builds/worker/workspace/build/src/obj-firefox/gradle/build/mobile/android/geckoview/maven/",
+              "expires": "2019-11-04T10:38:09.290Z",
+              "type": "directory"
+            },
+            "public/build/geckoview_example.apk": {
+              "path": "/builds/worker/workspace/build/src/obj-firefox/gradle/build/mobile/android/geckoview_example/outputs/apk/withGeckoBinaries/debug/geckoview_example-withGeckoBinaries-debug.apk",
+              "expires": "2019-11-04T10:38:09.290Z",
+              "type": "file"
+            },
+            "public/build": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-11-04T10:38:09.290Z",
+              "type": "directory"
+            },
+            "public/logs": {
+              "path": "/builds/worker/logs/",
+              "expires": "2019-11-04T10:38:09.290Z",
+              "type": "directory"
+            },
+            "public/build/geckoview-androidTest.apk": {
+              "path": "/builds/worker/workspace/build/src/obj-firefox/gradle/build/mobile/android/geckoview/outputs/apk/androidTest/withGeckoBinaries/debug/geckoview-withGeckoBinaries-debug-androidTest.apk",
+              "expires": "2019-11-04T10:38:09.290Z",
+              "type": "file"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/workspace/build/src",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/workspace/build/src/taskcluster/scripts/builder/build-linux.sh"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/android-gradle-dependencies.tar.xz\", \"extract\": true, \"task\": \"aNZB8MtiT6yDsqDHEdfggQ\"}, {\"artifact\": \"project/gecko/android-ndk/android-ndk.tar.xz\", \"extract\": true, \"task\": \"G2uFNVJQS--ciKaLRwkCwQ\"}, {\"artifact\": \"project/gecko/android-sdk/android-sdk-linux.tar.xz\", \"extract\": true, \"task\": \"V_Yy47svRwav6uPUv4J9ZA\"}, {\"artifact\": \"public/build/clang.tar.xz\", \"extract\": true, \"task\": \"MgI2k6kxSmi3SKyM8rc7UA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"bT6TwSGUS2uA5gAwnB3ULQ\"}, {\"artifact\": \"public/build/rust-size.tar.xz\", \"extract\": true, \"task\": \"Uai_mGbWQ5ahVemoAWeuJg\"}, {\"artifact\": \"public/build/cbindgen.tar.xz\", \"extract\": true, \"task\": \"MaEB78HGTw6Dp7AqnvDM1Q\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"U4Ceoc56ShGNbHW71ZsQ-w\"}, {\"artifact\": \"public/build/node.tar.xz\", \"extract\": true, \"task\": \"O-KYVZ5DQU636BcrE5Uanw\"}, {\"artifact\": \"public/build/sccache.tar.xz\", \"extract\": true, \"task\": \"cMItT5VOTluDKPjeW1VHOg\"}]",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "PYTHONUNBUFFERED": "1",
+            "MH_CUSTOM_BUILD_VARIANT_CFG": "x86_64",
+            "MOZHARNESS_SCRIPT": "mozharness/scripts/fx_desktop_build.py",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "MH_BUILD_POOL": "taskcluster",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZHARNESS_ACTIONS": "get-secrets build",
+            "GECKO_PATH": "/builds/worker/workspace/build/src",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\"}",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "NEED_XVFB": "false",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "",
+            "UPLOAD_DIR": "/builds/worker/artifacts/",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GRADLE_USER_HOME": "/builds/worker/workspace/build/src/mobile/android/gradle/dotgradle-offline",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "TOOLTOOL_MANIFEST": "mobile/android/config/tooltool-manifests/android-x86/releng.manifest",
+            "MOZHARNESS_CONFIG": "builds/releng_base_android_64_builds.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Android 5.0 x86-64 Opt ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-android-x86_64/opt"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-android-x86_64/opt",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "chainOfTrust": {
+            "inputs": {
+              "docker-image": "QOzMv9PzRsCaahfKO3GFhw"
+            }
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "android-5-0-x86_64"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "opt": true
+            }
+          },
+          "treeherder-platform": "android-5-0-x86_64/opt",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "TQHdkUHRT969iu-C07zm7Q",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.468Z",
+        "expires": "2019-10-21T10:38:11.468Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "KDHFLbeATKSQUE_3WHG_iQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.468Z",
+        "deadline": "2019-10-08T10:38:11.468Z",
+        "expires": "2019-10-21T10:38:11.468Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "KDHFLbeATKSQUE_3WHG_iQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "TSMc6y1wSkW5Gv257nxCuQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.264Z",
+        "expires": "2019-11-04T10:38:09.264Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-west-2",
+            "workerId": "i-0062dff9a1f21326d",
+            "takenUntil": "2019-10-07T10:58:29.743Z",
+            "scheduled": "2019-10-07T10:38:29.399Z",
+            "started": "2019-10-07T10:38:29.833Z",
+            "resolved": "2019-10-07T10:50:28.656Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "HF7QfhcURQ2TdwiIHwTQzQ",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.264Z",
+        "deadline": "2019-10-08T10:38:09.264Z",
+        "expires": "2019-11-04T10:38:09.264Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 1800,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "HF7QfhcURQ2TdwiIHwTQzQ"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts"
+          },
+          "artifacts": {
+            "public/code-review/mozlint.json": {
+              "path": "/builds/worker/mozlint.json",
+              "expires": "2019-11-04T10:38:09.264Z",
+              "type": "file"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/checkouts/gecko",
+            "--fetch-hgfingerprint",
+            "--task-cwd",
+            "/builds/worker/checkouts/gecko",
+            "--",
+            "bash",
+            "-cx",
+            "./mach lint -l license -f treeherder -f json:/builds/worker/mozlint.json"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "CARGO_HOME": "/build/rust",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "RUSTFMT": "/build/rust/bin/rustfmt",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts",
+            "RUSTUP_HOME": "/build/rust",
+            "MOZ_AUTOMATION": "1",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified"
+          },
+          "features": {
+            "taskclusterProxy": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/source-test",
+          "description": "Check for license blocks in source files. ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "source-test-mozlint-license"
+        },
+        "tags": {
+          "kind": "source-test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "source-test-mozlint-license",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "pedantic",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "lint"
+            },
+            "groupName": "pedantic checks",
+            "tier": 1,
+            "symbol": "license"
+          },
+          "treeherder-platform": "lint/opt",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "TiDyXxa5RyyV_bnlTtoFZg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.467Z",
+        "expires": "2019-10-21T10:38:11.467Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "KDHFLbeATKSQUE_3WHG_iQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.467Z",
+        "deadline": "2019-10-08T10:38:11.467Z",
+        "expires": "2019-10-21T10:38:11.467Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "KDHFLbeATKSQUE_3WHG_iQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "U-DnwR4TRXiJY-MXgl2ZcQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.409Z",
+        "expires": "2019-10-21T10:38:11.409Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-06c024e3323946e0e",
+            "takenUntil": "2019-10-07T11:02:14.141Z",
+            "scheduled": "2019-10-07T10:42:13.069Z",
+            "started": "2019-10-07T10:42:14.214Z",
+            "resolved": "2019-10-07T10:48:45.087Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "FJYMxdFvSJiFSlvAScx_yg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.409Z",
+        "deadline": "2019-10-08T10:38:11.409Z",
+        "expires": "2019-10-21T10:38:11.409Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.409Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.409Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.409Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--enable-webrender",
+            "--setpref=layers.d3d11.enable-blacklist=false",
+            "--total-chunk=12",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-qr/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "linux64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "U6NnV5QUTm6Z5jAVZj5sLw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.449Z",
+        "expires": "2019-10-21T10:38:10.449Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.449Z",
+        "deadline": "2019-10-08T10:38:10.449Z",
+        "expires": "2019-10-21T10:38:10.449Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "UWMEikHNTYyL6qGb3Q8VLQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.481Z",
+        "expires": "2019-10-21T10:38:11.481Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-2",
+            "workerId": "i-0aa3d9bba9709008d",
+            "takenUntil": "2019-10-07T11:01:57.207Z",
+            "scheduled": "2019-10-07T10:41:55.898Z",
+            "started": "2019-10-07T10:41:57.287Z",
+            "resolved": "2019-10-07T10:46:44.928Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.481Z",
+        "deadline": "2019-10-08T10:38:11.481Z",
+        "expires": "2019-10-21T10:38:11.481Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 9000,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.481Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.481Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.481Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--enable-webrender",
+            "--setpref=layers.d3d11.enable-blacklist=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-qr/debug-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "W2XUbPFzSjO-EemoCwTdow",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.422Z",
+        "expires": "2019-10-21T10:38:11.422Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-2",
+            "workerId": "i-023a98a0be213c0be",
+            "takenUntil": "2019-10-07T11:01:56.634Z",
+            "scheduled": "2019-10-07T10:41:55.882Z",
+            "started": "2019-10-07T10:41:56.707Z",
+            "resolved": "2019-10-07T10:46:38.802Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.422Z",
+        "deadline": "2019-10-08T10:38:11.422Z",
+        "expires": "2019-10-21T10:38:11.422Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.422Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.422Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.422Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/debug-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "WVoDCLXmSh-KAGBA8pKkSw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.458Z",
+        "expires": "2019-10-21T10:38:11.458Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "KDHFLbeATKSQUE_3WHG_iQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.458Z",
+        "deadline": "2019-10-08T10:38:11.458Z",
+        "expires": "2019-10-21T10:38:11.458Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "KDHFLbeATKSQUE_3WHG_iQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "X4wdBGlHSEOK68lG0AdlDQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.267Z",
+        "expires": "2019-11-04T10:38:09.267Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-0e96a5b732cd2acd5",
+            "takenUntil": "2019-10-07T10:58:29.747Z",
+            "scheduled": "2019-10-07T10:38:29.414Z",
+            "started": "2019-10-07T10:38:29.824Z",
+            "resolved": "2019-10-07T10:48:31.148Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Ly_R3E7nTKW8x40QXRLEPg",
+          "M5STQbxiRnGt4aSmWdp7Dg",
+          "MaEB78HGTw6Dp7AqnvDM1Q",
+          "MgI2k6kxSmi3SKyM8rc7UA",
+          "O-KYVZ5DQU636BcrE5Uanw",
+          "U4Ceoc56ShGNbHW71ZsQ-w",
+          "Uai_mGbWQ5ahVemoAWeuJg",
+          "bCS0hW_8SmWeIID2GP6Ktg",
+          "cMItT5VOTluDKPjeW1VHOg",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.firefox.linux64-asan-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.firefox.linux64-asan-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.firefox.linux64-asan-opt",
+          "index.gecko.v2.try.pushlog-id.432115.firefox.linux64-asan-opt",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.linux64-asan-opt",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.267Z",
+        "deadline": "2019-10-08T10:38:09.267Z",
+        "expires": "2019-11-04T10:38:09.267Z",
+        "scopes": [
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets",
+          "auth:gcp:access-token:sccache-3/tc-l1*",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 5400,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "Ly_R3E7nTKW8x40QXRLEPg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs": {
+              "path": "/builds/worker/logs/",
+              "expires": "2019-11-04T10:38:09.267Z",
+              "type": "directory"
+            },
+            "public/build": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-11-04T10:38:09.267Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/workspace/build/src",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/workspace/build/src/taskcluster/scripts/builder/build-linux.sh"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/binutils.tar.xz\", \"extract\": true, \"task\": \"M5STQbxiRnGt4aSmWdp7Dg\"}, {\"artifact\": \"public/build/clang.tar.xz\", \"extract\": true, \"task\": \"MgI2k6kxSmi3SKyM8rc7UA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"bCS0hW_8SmWeIID2GP6Ktg\"}, {\"artifact\": \"public/build/rust-size.tar.xz\", \"extract\": true, \"task\": \"Uai_mGbWQ5ahVemoAWeuJg\"}, {\"artifact\": \"public/build/cbindgen.tar.xz\", \"extract\": true, \"task\": \"MaEB78HGTw6Dp7AqnvDM1Q\"}, {\"artifact\": \"public/build/sccache.tar.xz\", \"extract\": true, \"task\": \"cMItT5VOTluDKPjeW1VHOg\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"U4Ceoc56ShGNbHW71ZsQ-w\"}, {\"artifact\": \"public/build/node.tar.xz\", \"extract\": true, \"task\": \"O-KYVZ5DQU636BcrE5Uanw\"}]",
+            "PERFHERDER_EXTRA_OPTIONS": "opt asan",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "PYTHONUNBUFFERED": "1",
+            "TRY_COMMIT_MSG": "",
+            "MH_CUSTOM_BUILD_VARIANT_CFG": "asan-tc",
+            "MOZHARNESS_SCRIPT": "mozharness/scripts/fx_desktop_build.py",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "MH_BUILD_POOL": "taskcluster",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZHARNESS_ACTIONS": "get-secrets build",
+            "GECKO_PATH": "/builds/worker/workspace/build/src",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\", \"mozconfig_variant\": \"nightly-asan\"}",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "NEED_XVFB": "true",
+            "USE_SCCACHE": "1",
+            "MOZ_DISABLE_FULL_SYMBOLS": "1",
+            "UPLOAD_DIR": "/builds/worker/artifacts/",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "MOZHARNESS_CONFIG": "builds/releng_base_firefox.py builds/releng_base_linux_64_builds.py",
+            "ASAN_OPTIONS": "detect_leaks=0"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Linux64 Opt ASAN ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-linux64-asan/opt"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-linux64-asan/opt",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "chainOfTrust": {
+            "inputs": {
+              "docker-image": "Ly_R3E7nTKW8x40QXRLEPg"
+            }
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "linux64"
+            },
+            "tier": 1,
+            "symbol": "Bo",
+            "jobKind": "build",
+            "collection": {
+              "asan": true
+            }
+          },
+          "treeherder-platform": "linux64/asan",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "XA-_TkI8RMS0As1zCv2FPA",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.412Z",
+        "expires": "2019-10-21T10:38:11.412Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "G_5hbYX5SveijqjP4khUiw"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.412Z",
+        "deadline": "2019-10-08T10:38:11.412Z",
+        "expires": "2019-10-21T10:38:11.412Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "G_5hbYX5SveijqjP4khUiw",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "XHDn_z9XTJGPwTqAotyYFg",
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.577Z",
+        "expires": "2019-10-21T10:38:11.577Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "packet-sjc1",
+            "workerId": "machine-18",
+            "takenUntil": "2019-10-07T11:52:13.236Z",
+            "scheduled": "2019-10-07T10:45:07.178Z",
+            "started": "2019-10-07T11:32:13.329Z",
+            "resolved": "2019-10-07T11:36:16.854Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Sx3QOoliRg-81JMSzPxMWg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.577Z",
+        "deadline": "2019-10-08T10:38:11.577Z",
+        "expires": "2019-10-21T10:38:11.577Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "project:releng:services/tooltool/api/download/internal",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:capability:device:loopbackVideo",
+          "docker-worker:capability:privileged",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "capabilities": {
+            "privileged": true,
+            "devices": {
+              "loopbackVideo": true
+            }
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.577Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.577Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.577Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/geckoview-androidTest.apk",
+            "MOZHARNESS_ACTIONS": "get-secrets",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/geckoview-androidTest.apk\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "TASKCLUSTER_ROOT_URL": "https://taskcluster.net",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "android/androidx86_7_0.py web_platform_tests/prod_config_android.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-android-em-7.0-x86_64/opt-geckoview-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-android-em-7.0-x86_64/opt-geckoview-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "android-em-7-0-x86_64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "android-em-7-0-x86_64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "XQmykYj_RrqedOSEvZCJmw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.419Z",
+        "expires": "2019-10-21T10:38:11.419Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-000761b6712d41a3a",
+            "takenUntil": "2019-10-07T11:01:57.489Z",
+            "scheduled": "2019-10-07T10:41:55.899Z",
+            "started": "2019-10-07T10:41:57.562Z",
+            "resolved": "2019-10-07T10:46:44.076Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.419Z",
+        "deadline": "2019-10-08T10:38:11.419Z",
+        "expires": "2019-10-21T10:38:11.419Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.419Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.419Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.419Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/debug-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "XY5abAV2R7yMzl4C55KR0w",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.454Z",
+        "expires": "2019-10-21T10:38:10.454Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.454Z",
+        "deadline": "2019-10-08T10:38:10.454Z",
+        "expires": "2019-10-21T10:38:10.454Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Xxv6k8CDRZ61ZFQ5298Mgg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.447Z",
+        "expires": "2019-10-21T10:38:10.447Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.447Z",
+        "deadline": "2019-10-08T10:38:10.447Z",
+        "expires": "2019-10-21T10:38:10.447Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "YkmiIfY_SH2BGn0Qjf4BAA",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.411Z",
+        "expires": "2019-10-21T10:38:11.411Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "G_5hbYX5SveijqjP4khUiw"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.411Z",
+        "deadline": "2019-10-08T10:38:11.411Z",
+        "expires": "2019-10-21T10:38:11.411Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "G_5hbYX5SveijqjP4khUiw",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "ZDcoZiKmQiqf6ipQOrMOiA",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.405Z",
+        "expires": "2019-10-21T10:38:11.405Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-1",
+            "workerId": "i-02f32e51f2a0fd45f",
+            "takenUntil": "2019-10-07T11:02:14.238Z",
+            "scheduled": "2019-10-07T10:42:13.075Z",
+            "started": "2019-10-07T10:42:14.310Z",
+            "resolved": "2019-10-07T10:45:12.783Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "FJYMxdFvSJiFSlvAScx_yg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.405Z",
+        "deadline": "2019-10-08T10:38:11.405Z",
+        "expires": "2019-10-21T10:38:11.405Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.405Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.405Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.405Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--enable-webrender",
+            "--setpref=layers.d3d11.enable-blacklist=false",
+            "--total-chunk=12",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-qr/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "linux64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "ZF_zVK1fSGyYna3ceaoV8Q",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.456Z",
+        "expires": "2019-10-21T10:38:10.456Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.456Z",
+        "deadline": "2019-10-08T10:38:10.456Z",
+        "expires": "2019-10-21T10:38:10.456Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "ZL9junh3SEa5q9CnI0erAg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.272Z",
+        "expires": "2019-11-04T10:38:09.272Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-05d2882925a49147c",
+            "takenUntil": "2019-10-07T10:58:30.046Z",
+            "scheduled": "2019-10-07T10:38:29.417Z",
+            "started": "2019-10-07T10:38:30.130Z",
+            "resolved": "2019-10-07T10:43:04.277Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "HF7QfhcURQ2TdwiIHwTQzQ",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.272Z",
+        "deadline": "2019-10-08T10:38:09.272Z",
+        "expires": "2019-11-04T10:38:09.272Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 1800,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "HF7QfhcURQ2TdwiIHwTQzQ"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts"
+          },
+          "artifacts": {
+            "public/code-review/mozlint.json": {
+              "path": "/builds/worker/mozlint.json",
+              "expires": "2019-11-04T10:38:09.272Z",
+              "type": "file"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/checkouts/gecko",
+            "--fetch-hgfingerprint",
+            "--task-cwd",
+            "/builds/worker/checkouts/gecko",
+            "--",
+            "bash",
+            "-cx",
+            "./mach lint -l wpt -f treeherder -f json:/builds/worker/mozlint.json"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "CARGO_HOME": "/build/rust",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "RUSTFMT": "/build/rust/bin/rustfmt",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts",
+            "RUSTUP_HOME": "/build/rust",
+            "MOZ_AUTOMATION": "1",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified"
+          },
+          "features": {
+            "taskclusterProxy": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/source-test",
+          "description": "web-platform-tests linter ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "source-test-mozlint-wptlint-gecko"
+        },
+        "tags": {
+          "kind": "source-test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "source-test-mozlint-wptlint-gecko",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "misc",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "lint"
+            },
+            "groupName": "Misc checks",
+            "tier": 1,
+            "symbol": "W"
+          },
+          "treeherder-platform": "lint/opt",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "ZgJbhxNjQkmXGcFgImomxw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.429Z",
+        "expires": "2019-10-21T10:38:11.429Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-1",
+            "workerId": "i-0f56317fa1189b37e",
+            "takenUntil": "2019-10-07T11:01:56.727Z",
+            "scheduled": "2019-10-07T10:41:55.887Z",
+            "started": "2019-10-07T10:41:56.800Z",
+            "resolved": "2019-10-07T10:46:23.793Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.429Z",
+        "deadline": "2019-10-08T10:38:11.429Z",
+        "expires": "2019-10-21T10:38:11.429Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.429Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.429Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.429Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/debug-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "b5_MFUQTTuyXCq0d3QY89w",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.426Z",
+        "expires": "2019-10-21T10:38:11.426Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-039978cc367caa84a",
+            "takenUntil": "2019-10-07T11:01:56.753Z",
+            "scheduled": "2019-10-07T10:41:55.889Z",
+            "started": "2019-10-07T10:41:56.825Z",
+            "resolved": "2019-10-07T10:46:45.135Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.426Z",
+        "deadline": "2019-10-08T10:38:11.426Z",
+        "expires": "2019-10-21T10:38:11.426Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.426Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.426Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.426Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/debug-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "bYNT_Ce-TjubnkVe6eDbGA",
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.563Z",
+        "expires": "2019-10-21T10:38:11.563Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "packet-sjc1",
+            "workerId": "machine-32",
+            "takenUntil": "2019-10-07T11:52:29.365Z",
+            "scheduled": "2019-10-07T10:45:07.205Z",
+            "started": "2019-10-07T11:32:29.438Z",
+            "resolved": "2019-10-07T11:36:32.757Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Sx3QOoliRg-81JMSzPxMWg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.563Z",
+        "deadline": "2019-10-08T10:38:11.563Z",
+        "expires": "2019-10-21T10:38:11.563Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "project:releng:services/tooltool/api/download/internal",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:capability:device:loopbackVideo",
+          "docker-worker:capability:privileged",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "capabilities": {
+            "privileged": true,
+            "devices": {
+              "loopbackVideo": true
+            }
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.563Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.563Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.563Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/geckoview-androidTest.apk",
+            "MOZHARNESS_ACTIONS": "get-secrets",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/geckoview-androidTest.apk\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/Sx3QOoliRg-81JMSzPxMWg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "TASKCLUSTER_ROOT_URL": "https://taskcluster.net",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "android/androidx86_7_0.py web_platform_tests/prod_config_android.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-android-em-7.0-x86_64/opt-geckoview-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-android-em-7.0-x86_64/opt-geckoview-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "android-em-7-0-x86_64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "android-em-7-0-x86_64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "bbUXfquRTbu4sR17pRyupw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.424Z",
+        "expires": "2019-10-21T10:38:11.424Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-1",
+            "workerId": "i-069b371a5358db78a",
+            "takenUntil": "2019-10-07T11:01:56.243Z",
+            "scheduled": "2019-10-07T10:41:55.878Z",
+            "started": "2019-10-07T10:41:56.319Z",
+            "resolved": "2019-10-07T10:46:34.512Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.424Z",
+        "deadline": "2019-10-08T10:38:11.424Z",
+        "expires": "2019-10-21T10:38:11.424Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.424Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.424Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.424Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/debug-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "bemAkIsIRsOZG46_yE_UVQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.287Z",
+        "expires": "2019-11-04T10:38:09.287Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-02a66959428ebaa56",
+            "takenUntil": "2019-10-07T10:58:29.749Z",
+            "scheduled": "2019-10-07T10:38:29.418Z",
+            "started": "2019-10-07T10:38:29.823Z",
+            "resolved": "2019-10-07T10:47:13.057Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "G2uFNVJQS--ciKaLRwkCwQ",
+          "MaEB78HGTw6Dp7AqnvDM1Q",
+          "MgI2k6kxSmi3SKyM8rc7UA",
+          "O-KYVZ5DQU636BcrE5Uanw",
+          "QOzMv9PzRsCaahfKO3GFhw",
+          "U4Ceoc56ShGNbHW71ZsQ-w",
+          "Uai_mGbWQ5ahVemoAWeuJg",
+          "V_Yy47svRwav6uPUv4J9ZA",
+          "aNZB8MtiT6yDsqDHEdfggQ",
+          "bT6TwSGUS2uA5gAwnB3ULQ",
+          "cMItT5VOTluDKPjeW1VHOg",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.mobile.android-x86_64-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.mobile.android-x86_64-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.mobile.android-x86_64-debug",
+          "index.gecko.v2.try.pushlog-id.432115.mobile.android-x86_64-debug",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.mobile.android-x86_64-debug",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.287Z",
+        "deadline": "2019-10-08T10:38:09.287Z",
+        "expires": "2019-11-04T10:38:09.287Z",
+        "scopes": [
+          "queue:get-artifact:project/gecko/android-ndk/*",
+          "queue:get-artifact:project/gecko/android-sdk/*",
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "project:releng:services/tooltool/api/download/internal",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets",
+          "auth:gcp:access-token:sccache-3/tc-l1*",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "QOzMv9PzRsCaahfKO3GFhw"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/build/maven": {
+              "path": "/builds/worker/workspace/build/src/obj-firefox/gradle/build/mobile/android/geckoview/maven/",
+              "expires": "2019-11-04T10:38:09.287Z",
+              "type": "directory"
+            },
+            "public/build/geckoview_example.apk": {
+              "path": "/builds/worker/workspace/build/src/obj-firefox/gradle/build/mobile/android/geckoview_example/outputs/apk/withGeckoBinaries/debug/geckoview_example-withGeckoBinaries-debug.apk",
+              "expires": "2019-11-04T10:38:09.287Z",
+              "type": "file"
+            },
+            "public/build": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-11-04T10:38:09.287Z",
+              "type": "directory"
+            },
+            "public/logs": {
+              "path": "/builds/worker/logs/",
+              "expires": "2019-11-04T10:38:09.287Z",
+              "type": "directory"
+            },
+            "public/build/geckoview-androidTest.apk": {
+              "path": "/builds/worker/workspace/build/src/obj-firefox/gradle/build/mobile/android/geckoview/outputs/apk/androidTest/withGeckoBinaries/debug/geckoview-withGeckoBinaries-debug-androidTest.apk",
+              "expires": "2019-11-04T10:38:09.287Z",
+              "type": "file"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/workspace/build/src",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/workspace/build/src/taskcluster/scripts/builder/build-linux.sh"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/android-gradle-dependencies.tar.xz\", \"extract\": true, \"task\": \"aNZB8MtiT6yDsqDHEdfggQ\"}, {\"artifact\": \"project/gecko/android-ndk/android-ndk.tar.xz\", \"extract\": true, \"task\": \"G2uFNVJQS--ciKaLRwkCwQ\"}, {\"artifact\": \"project/gecko/android-sdk/android-sdk-linux.tar.xz\", \"extract\": true, \"task\": \"V_Yy47svRwav6uPUv4J9ZA\"}, {\"artifact\": \"public/build/clang.tar.xz\", \"extract\": true, \"task\": \"MgI2k6kxSmi3SKyM8rc7UA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"bT6TwSGUS2uA5gAwnB3ULQ\"}, {\"artifact\": \"public/build/rust-size.tar.xz\", \"extract\": true, \"task\": \"Uai_mGbWQ5ahVemoAWeuJg\"}, {\"artifact\": \"public/build/cbindgen.tar.xz\", \"extract\": true, \"task\": \"MaEB78HGTw6Dp7AqnvDM1Q\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"U4Ceoc56ShGNbHW71ZsQ-w\"}, {\"artifact\": \"public/build/node.tar.xz\", \"extract\": true, \"task\": \"O-KYVZ5DQU636BcrE5Uanw\"}, {\"artifact\": \"public/build/sccache.tar.xz\", \"extract\": true, \"task\": \"cMItT5VOTluDKPjeW1VHOg\"}]",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "PYTHONUNBUFFERED": "1",
+            "MH_CUSTOM_BUILD_VARIANT_CFG": "x86_64-debug",
+            "MOZHARNESS_SCRIPT": "mozharness/scripts/fx_desktop_build.py",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "MH_BUILD_POOL": "taskcluster",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZHARNESS_ACTIONS": "get-secrets build",
+            "GECKO_PATH": "/builds/worker/workspace/build/src",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\"}",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "NEED_XVFB": "false",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "",
+            "UPLOAD_DIR": "/builds/worker/artifacts/",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GRADLE_USER_HOME": "/builds/worker/workspace/build/src/mobile/android/gradle/dotgradle-offline",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "TOOLTOOL_MANIFEST": "mobile/android/config/tooltool-manifests/android-x86/releng.manifest",
+            "MOZHARNESS_CONFIG": "builds/releng_base_android_64_builds.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Android 5.0 x86-64 Debug ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-android-x86_64/debug"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-android-x86_64/debug",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "chainOfTrust": {
+            "inputs": {
+              "docker-image": "QOzMv9PzRsCaahfKO3GFhw"
+            }
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "android-5-0-x86_64"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "debug": true
+            }
+          },
+          "treeherder-platform": "android-5-0-x86_64/debug",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "c23T7EnvQmy5Wqnr7zVHzQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.460Z",
+        "expires": "2019-10-21T10:38:11.460Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "KDHFLbeATKSQUE_3WHG_iQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.460Z",
+        "deadline": "2019-10-08T10:38:11.460Z",
+        "expires": "2019-10-21T10:38:11.460Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "KDHFLbeATKSQUE_3WHG_iQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "c6VFEE-6T_ezUQfKDRTXrQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.414Z",
+        "expires": "2019-10-21T10:38:11.414Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "G_5hbYX5SveijqjP4khUiw"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.414Z",
+        "deadline": "2019-10-08T10:38:11.414Z",
+        "expires": "2019-10-21T10:38:11.414Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "G_5hbYX5SveijqjP4khUiw",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "cRLnh5OXTp6G7W6AxlhVVg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.483Z",
+        "expires": "2019-10-21T10:38:11.483Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-1",
+            "workerId": "i-022072d7283b83e5e",
+            "takenUntil": "2019-10-07T11:01:56.637Z",
+            "scheduled": "2019-10-07T10:41:55.885Z",
+            "started": "2019-10-07T10:41:56.709Z",
+            "resolved": "2019-10-07T10:47:00.046Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.483Z",
+        "deadline": "2019-10-08T10:38:11.483Z",
+        "expires": "2019-10-21T10:38:11.483Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 9000,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.483Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.483Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.483Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--enable-webrender",
+            "--setpref=layers.d3d11.enable-blacklist=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-qr/debug-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "cU0GRAEpTQ-HT3aJo1TBug",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.479Z",
+        "expires": "2019-10-21T10:38:11.479Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-1",
+            "workerId": "i-0571bec9f7b8bb624",
+            "takenUntil": "2019-10-07T11:01:56.633Z",
+            "scheduled": "2019-10-07T10:41:55.879Z",
+            "started": "2019-10-07T10:41:56.706Z",
+            "resolved": "2019-10-07T10:46:59.823Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.479Z",
+        "deadline": "2019-10-08T10:38:11.479Z",
+        "expires": "2019-10-21T10:38:11.479Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 9000,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.479Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.479Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.479Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--enable-webrender",
+            "--setpref=layers.d3d11.enable-blacklist=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-qr/debug-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "cZrdVoIVSzmvFgP49sVPxg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.474Z",
+        "expires": "2019-10-21T10:38:11.474Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-0eb894975f346aae6",
+            "takenUntil": "2019-10-07T11:01:57.240Z",
+            "scheduled": "2019-10-07T10:41:55.941Z",
+            "started": "2019-10-07T10:41:57.319Z",
+            "resolved": "2019-10-07T10:46:41.740Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.474Z",
+        "deadline": "2019-10-08T10:38:11.474Z",
+        "expires": "2019-10-21T10:38:11.474Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.474Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.474Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.474Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=\"dom.serviceWorkers.parent_intercept=true\"",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run with serviceworker-e10s redesign enabled ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/debug-web-platform-tests-sw-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/debug-web-platform-tests-sw-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W-sw",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests with serviceworker redesign",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "cksAwgt1Rt-JyphT_B2t5A",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.407Z",
+        "expires": "2019-10-21T10:38:11.407Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-0b57bf29d0772dd26",
+            "takenUntil": "2019-10-07T11:02:13.541Z",
+            "scheduled": "2019-10-07T10:42:13.047Z",
+            "started": "2019-10-07T10:42:13.614Z",
+            "resolved": "2019-10-07T10:45:33.342Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "FJYMxdFvSJiFSlvAScx_yg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.407Z",
+        "deadline": "2019-10-08T10:38:11.407Z",
+        "expires": "2019-10-21T10:38:11.407Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.407Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.407Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.407Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--enable-webrender",
+            "--setpref=layers.d3d11.enable-blacklist=false",
+            "--total-chunk=12",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64-qr/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "linux64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "d6QK9Fs-TJ2y03e2OZg5Tg",
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.450Z",
+        "expires": "2019-10-21T10:38:11.450Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "packet-sjc1",
+            "workerId": "machine-22",
+            "takenUntil": "2019-10-07T11:54:08.111Z",
+            "scheduled": "2019-10-07T10:47:14.571Z",
+            "started": "2019-10-07T11:34:08.220Z",
+            "resolved": "2019-10-07T11:38:05.122Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "terraform-packet",
+        "workerType": "gecko-t-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "bUfsCA77RD-r2zlxW9kNzg",
+          "bemAkIsIRsOZG46_yE_UVQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.450Z",
+        "deadline": "2019-10-08T10:38:11.450Z",
+        "expires": "2019-10-21T10:38:11.450Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "project:releng:services/tooltool/api/download/internal",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:capability:device:loopbackVideo",
+          "docker-worker:capability:privileged",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "capabilities": {
+            "privileged": true,
+            "devices": {
+              "loopbackVideo": true
+            }
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.450Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.450Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.450Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/geckoview-androidTest.apk",
+            "MOZHARNESS_ACTIONS": "get-secrets",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/geckoview-androidTest.apk\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/bemAkIsIRsOZG46_yE_UVQ/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "TASKCLUSTER_ROOT_URL": "https://taskcluster.net",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "android/androidx86_7_0.py web_platform_tests/prod_config_android.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-android-em-7.0-x86_64/debug-geckoview-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-android-em-7.0-x86_64/debug-geckoview-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "android-em-7-0-x86_64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "android-em-7-0-x86_64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "dip2m2bqTuq403Up4_8TSg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.438Z",
+        "expires": "2019-10-21T10:38:11.438Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.438Z",
+        "deadline": "2019-10-08T10:38:11.438Z",
+        "expires": "2019-10-21T10:38:11.438Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "dl4oH87iQR2XrMhWuA8UGQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.266Z",
+        "expires": "2019-11-04T10:38:09.266Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-0ba3c4e772808b51f",
+            "takenUntil": "2019-10-07T10:58:30.042Z",
+            "scheduled": "2019-10-07T10:38:29.410Z",
+            "started": "2019-10-07T10:38:30.127Z",
+            "resolved": "2019-10-07T10:45:06.054Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "HF7QfhcURQ2TdwiIHwTQzQ",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.266Z",
+        "deadline": "2019-10-08T10:38:09.266Z",
+        "expires": "2019-11-04T10:38:09.266Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 1800,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "HF7QfhcURQ2TdwiIHwTQzQ"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts"
+          },
+          "artifacts": {
+            "public/code-review/mozlint.json": {
+              "path": "/builds/worker/mozlint.json",
+              "expires": "2019-11-04T10:38:09.266Z",
+              "type": "file"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/checkouts/gecko",
+            "--fetch-hgfingerprint",
+            "--task-cwd",
+            "/builds/worker/checkouts/gecko",
+            "--",
+            "bash",
+            "-cx",
+            "./mach lint -l file-perm -f treeherder -f json:/builds/worker/mozlint.json"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "CARGO_HOME": "/build/rust",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "RUSTFMT": "/build/rust/bin/rustfmt",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts",
+            "RUSTUP_HOME": "/build/rust",
+            "MOZ_AUTOMATION": "1",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified"
+          },
+          "features": {
+            "taskclusterProxy": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/source-test",
+          "description": "Check for incorrect permissions on source files ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "source-test-mozlint-file-perm"
+        },
+        "tags": {
+          "kind": "source-test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "source-test-mozlint-file-perm",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "pedantic",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "lint"
+            },
+            "groupName": "pedantic checks",
+            "tier": 1,
+            "symbol": "file-perm"
+          },
+          "treeherder-platform": "lint/opt",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "dmxLnq_IT-qhf5giVRnEew",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.275Z",
+        "expires": "2019-11-04T10:38:09.275Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-west-1",
+            "workerId": "i-0d71dd7d524eeb717",
+            "takenUntil": "2019-10-07T10:58:29.742Z",
+            "scheduled": "2019-10-07T10:38:29.397Z",
+            "started": "2019-10-07T10:38:29.817Z",
+            "resolved": "2019-10-07T10:44:09.763Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "HF7QfhcURQ2TdwiIHwTQzQ",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.275Z",
+        "deadline": "2019-10-08T10:38:09.275Z",
+        "expires": "2019-11-04T10:38:09.275Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 1800,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "HF7QfhcURQ2TdwiIHwTQzQ"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts"
+          },
+          "artifacts": {
+            "public/code-review/mozlint.json": {
+              "path": "/builds/worker/mozlint.json",
+              "expires": "2019-11-04T10:38:09.275Z",
+              "type": "file"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/checkouts/gecko",
+            "--fetch-hgfingerprint",
+            "--task-cwd",
+            "/builds/worker/checkouts/gecko",
+            "--",
+            "bash",
+            "-cx",
+            "./mach lint -l codespell -f treeherder -f json:/builds/worker/mozlint.json"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "CARGO_HOME": "/build/rust",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "RUSTFMT": "/build/rust/bin/rustfmt",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts",
+            "RUSTUP_HOME": "/build/rust",
+            "MOZ_AUTOMATION": "1",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified"
+          },
+          "features": {
+            "taskclusterProxy": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/source-test",
+          "description": "Checks for misspellings in text files ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "source-test-mozlint-codespell"
+        },
+        "tags": {
+          "kind": "source-test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "source-test-mozlint-codespell",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "text",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "lint"
+            },
+            "groupName": "Check on texts",
+            "tier": 1,
+            "symbol": "spell"
+          },
+          "treeherder-platform": "lint/opt",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "ecJKzH14Q3il0WMcXmiS6A",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.418Z",
+        "expires": "2019-10-21T10:38:11.418Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "G_5hbYX5SveijqjP4khUiw"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.418Z",
+        "deadline": "2019-10-08T10:38:11.418Z",
+        "expires": "2019-10-21T10:38:11.418Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "G_5hbYX5SveijqjP4khUiw",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "epdfBuccSteK0fviA6-jRg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.476Z",
+        "expires": "2019-10-21T10:38:11.476Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-0b52e1822c3baf616",
+            "takenUntil": "2019-10-07T11:01:57.067Z",
+            "scheduled": "2019-10-07T10:41:55.895Z",
+            "started": "2019-10-07T10:41:57.140Z",
+            "resolved": "2019-10-07T10:46:50.035Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "RqrmC1TSTHWlnU-hT35Rpw",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.476Z",
+        "deadline": "2019-10-08T10:38:11.476Z",
+        "expires": "2019-10-21T10:38:11.476Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:11.476Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:11.476Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:11.476Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=\"dom.serviceWorkers.parent_intercept=true\"",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=18",
+            "--this-chunk=1",
+            "--download-symbols=true"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/RqrmC1TSTHWlnU-hT35Rpw/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run with serviceworker-e10s redesign enabled ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/debug-web-platform-tests-sw-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/debug-web-platform-tests-sw-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W-sw",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests with serviceworker redesign",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "f9m8FmeCTTa1B6OuH78Hbg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.457Z",
+        "expires": "2019-10-21T10:38:10.457Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.457Z",
+        "deadline": "2019-10-08T10:38:10.457Z",
+        "expires": "2019-10-21T10:38:10.457Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "fDgWbuGpTpig6kW9O_S9vQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.398Z",
+        "expires": "2019-10-21T10:38:12.398Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-0301c06da0b1394fb",
+            "takenUntil": "2019-10-07T11:02:14.144Z",
+            "scheduled": "2019-10-07T10:42:13.073Z",
+            "started": "2019-10-07T10:42:14.216Z",
+            "resolved": "2019-10-07T10:45:08.985Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-linux-xlarge",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "FJYMxdFvSJiFSlvAScx_yg",
+          "bUfsCA77RD-r2zlxW9kNzg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.398Z",
+        "deadline": "2019-10-08T10:38:12.398Z",
+        "expires": "2019-10-21T10:38:12.398Z",
+        "scopes": [
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "docker-worker:feature:allowPtrace",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "bUfsCA77RD-r2zlxW9kNzg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs/": {
+              "path": "/builds/worker/workspace/logs/",
+              "expires": "2019-10-21T10:38:12.398Z",
+              "type": "directory"
+            },
+            "public/test": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-10-21T10:38:12.398Z",
+              "type": "directory"
+            },
+            "public/test_info/": {
+              "path": "/builds/worker/workspace/build/blobber_upload_dir/",
+              "expires": "2019-10-21T10:38:12.398Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/bin/test-linux.sh",
+            "--test-type=testharness",
+            "--setpref=media.peerconnection.mtransport_process=false",
+            "--setpref=network.process.enabled=false",
+            "--allow-software-gl-layers",
+            "--total-chunk=12",
+            "--this-chunk=1",
+            "--download-symbols=ondemand"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "MOZHARNESS_SCRIPT": "web_platform_tests.py",
+            "MOZ_NODE_PATH": "/usr/local/bin/node",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZILLA_BUILD_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2",
+            "GECKO_PATH": "/builds/worker/checkouts/gecko",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/.cache;/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/target.tar.bz2\"}",
+            "SCCACHE_DISABLE": "1",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "NEED_COMPIZ": "false",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "MOZHARNESS_URL": "https://queue.taskcluster.net/v1/task/FJYMxdFvSJiFSlvAScx_yg/artifacts/public/build/mozharness.zip",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "TRY_COMMIT_MSG": "",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "WORKING_DIR": "/builds/worker",
+            "NEED_PULSEAUDIO": "true",
+            "ENABLE_E10S": "true",
+            "NEED_WINDOW_MANAGER": "true",
+            "MOZHARNESS_CONFIG": "web_platform_tests/prod_config.py remove_executables.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "allowPtrace": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-linux64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-linux64/opt-web-platform-tests-e10s-1",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "linux64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "linux64/opt"
+        }
+      }
+    }
+  ]
+}

--- a/test/sample-data/taskcluster/taskgroup-no-tests-build-failed.json
+++ b/test/sample-data/taskcluster/taskgroup-no-tests-build-failed.json
@@ -1,0 +1,5351 @@
+{
+  "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+  "tasks": [
+    {
+      "status": {
+        "taskId": "B8ReNvxoTFyIzBCfTn4yxQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.460Z",
+        "expires": "2019-10-21T10:38:11.460Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "KDHFLbeATKSQUE_3WHG_iQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.460Z",
+        "deadline": "2019-10-08T10:38:11.460Z",
+        "expires": "2019-10-21T10:38:11.460Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "KDHFLbeATKSQUE_3WHG_iQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "BnBtdjcORKmsHADUdEIhfQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.283Z",
+        "expires": "2019-10-21T10:38:12.283Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.283Z",
+        "deadline": "2019-10-08T10:38:12.283Z",
+        "expires": "2019-10-21T10:38:12.283Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Cqs6gH-JTzCZGQyVbbUJlA",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.432Z",
+        "expires": "2019-10-21T10:38:11.432Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.432Z",
+        "deadline": "2019-10-08T10:38:11.432Z",
+        "expires": "2019-10-21T10:38:11.432Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "D3_DBGbhTSO6fm9TsSWFkw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.445Z",
+        "expires": "2019-10-21T10:38:10.445Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.445Z",
+        "deadline": "2019-10-08T10:38:10.445Z",
+        "expires": "2019-10-21T10:38:10.445Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "EMiNbI-lQ0a_NqpPhrlF_Q",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.450Z",
+        "expires": "2019-10-21T10:38:10.450Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.450Z",
+        "deadline": "2019-10-08T10:38:10.450Z",
+        "expires": "2019-10-21T10:38:10.450Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "FJYMxdFvSJiFSlvAScx_yg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.269Z",
+        "expires": "2019-11-04T10:38:09.269Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-west-2",
+            "workerId": "i-0544e3c6c78c0e138",
+            "takenUntil": "2019-10-07T10:58:29.693Z",
+            "scheduled": "2019-10-07T10:38:29.382Z",
+            "started": "2019-10-07T10:38:29.773Z",
+            "resolved": "2019-10-07T10:42:09.366Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Ly_R3E7nTKW8x40QXRLEPg",
+          "M5STQbxiRnGt4aSmWdp7Dg",
+          "MaEB78HGTw6Dp7AqnvDM1Q",
+          "MgI2k6kxSmi3SKyM8rc7UA",
+          "O-KYVZ5DQU636BcrE5Uanw",
+          "U4Ceoc56ShGNbHW71ZsQ-w",
+          "Uai_mGbWQ5ahVemoAWeuJg",
+          "bCS0hW_8SmWeIID2GP6Ktg",
+          "cMItT5VOTluDKPjeW1VHOg",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.firefox.linux64-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.firefox.linux64-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.firefox.linux64-opt",
+          "index.gecko.v2.try.pushlog-id.432115.firefox.linux64-opt",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.linux64-opt",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.269Z",
+        "deadline": "2019-10-08T10:38:09.269Z",
+        "expires": "2019-11-04T10:38:09.269Z",
+        "scopes": [
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets",
+          "auth:gcp:access-token:sccache-3/tc-l1*",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "Ly_R3E7nTKW8x40QXRLEPg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs": {
+              "path": "/builds/worker/logs/",
+              "expires": "2019-11-04T10:38:09.269Z",
+              "type": "directory"
+            },
+            "public/build": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-11-04T10:38:09.269Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/workspace/build/src",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/workspace/build/src/taskcluster/scripts/builder/build-linux.sh"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/binutils.tar.xz\", \"extract\": true, \"task\": \"M5STQbxiRnGt4aSmWdp7Dg\"}, {\"artifact\": \"public/build/clang.tar.xz\", \"extract\": true, \"task\": \"MgI2k6kxSmi3SKyM8rc7UA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"bCS0hW_8SmWeIID2GP6Ktg\"}, {\"artifact\": \"public/build/rust-size.tar.xz\", \"extract\": true, \"task\": \"Uai_mGbWQ5ahVemoAWeuJg\"}, {\"artifact\": \"public/build/cbindgen.tar.xz\", \"extract\": true, \"task\": \"MaEB78HGTw6Dp7AqnvDM1Q\"}, {\"artifact\": \"public/build/sccache.tar.xz\", \"extract\": true, \"task\": \"cMItT5VOTluDKPjeW1VHOg\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"U4Ceoc56ShGNbHW71ZsQ-w\"}, {\"artifact\": \"public/build/node.tar.xz\", \"extract\": true, \"task\": \"O-KYVZ5DQU636BcrE5Uanw\"}]",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "PYTHONUNBUFFERED": "1",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZHARNESS_SCRIPT": "mozharness/scripts/fx_desktop_build.py",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "MH_BUILD_POOL": "taskcluster",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZHARNESS_ACTIONS": "get-secrets build",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\", \"mozconfig_variant\": \"nightly\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "NEED_XVFB": "true",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "",
+            "UPLOAD_DIR": "/builds/worker/artifacts/",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GECKO_PATH": "/builds/worker/workspace/build/src",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "MOZHARNESS_CONFIG": "builds/releng_base_firefox.py builds/releng_base_linux_64_builds.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Linux64 Opt ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-linux64/opt"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-linux64/opt",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "chainOfTrust": {
+            "inputs": {
+              "docker-image": "Ly_R3E7nTKW8x40QXRLEPg"
+            }
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "linux64"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "opt": true
+            }
+          },
+          "treeherder-platform": "linux64/opt",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "G_5hbYX5SveijqjP4khUiw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.278Z",
+        "expires": "2019-11-04T10:38:09.278Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-08cb4ca677811893a",
+            "takenUntil": "2019-10-07T11:21:44.698Z",
+            "scheduled": "2019-10-07T10:38:29.401Z",
+            "started": "2019-10-07T10:44:44.256Z",
+            "resolved": "2019-10-07T11:02:56.873Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "CDAcPFmBTbC4GRVbyfjrVg",
+          "CVde5A_JQa-i_bwib7x-Jg",
+          "PXqEh8AZRgGQuCsvEFls3A",
+          "RTF-ZEqwSG2ELmfXX-CAzA",
+          "WAEzVS1TT9ywiINxBj6DHw",
+          "YBeMzVRcQ_mkBaQQPe1e-A",
+          "eaBNHA-USOe-AuI2BXsUxA",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.firefox.win32-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.firefox.win32-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.firefox.win32-opt",
+          "index.gecko.v2.try.pushlog-id.432115.firefox.win32-opt",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.win32-opt",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.278Z",
+        "deadline": "2019-10-08T10:38:09.278Z",
+        "expires": "2019-11-04T10:38:09.278Z",
+        "scopes": [
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "public/build",
+              "type": "directory",
+              "name": "public/build"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            ":: sccache currently uses the full compiler commandline as input to the\n:: cache hash key, so create a symlink to the task dir and build from\n:: the symlink dir to get consistent paths.\nif exist z:\\build rmdir z:\\build",
+            "mklink /d z:\\build %cd%",
+            "icacls z:\\build /grant *S-1-1-0:D /L",
+            "cd /d z:\\build",
+            "C:/mozilla-build/python3/python3.exe run-task --gecko-checkout=./build/src -- c:/mozilla-build/python/python.exe %GECKO_PATH%/testing/mozharness/scripts/fx_desktop_build.py --config builds/releng_base_firefox.py --config builds/taskcluster_base_windows.py --config builds/taskcluster_base_win32.py --branch try --work-dir %cd:Z:=z:%\\build --append-env-variables-from-configs"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZ_SIMPLE_PACKAGE_NAME": "target",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "HG_STORE_PATH": "y:/hg-shared",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\", \"stage_platform\": \"win32\", \"mozconfig_variant\": \"nightly\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "PYTHONPATH": "./build/src/testing/mozbase/manifestparser;./build/src/testing/mozbase/mozinfo;./build/src/testing/mozbase/mozfile;./build/src/testing/mozbase/mozprocess;./build/src/third_party/python/six",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/clang.tar.bz2\", \"extract\": true, \"task\": \"eaBNHA-USOe-AuI2BXsUxA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"CVde5A_JQa-i_bwib7x-Jg\"}, {\"artifact\": \"public/build/rust-size.tar.bz2\", \"extract\": true, \"task\": \"CDAcPFmBTbC4GRVbyfjrVg\"}, {\"artifact\": \"public/build/cbindgen.tar.bz2\", \"extract\": true, \"task\": \"WAEzVS1TT9ywiINxBj6DHw\"}, {\"artifact\": \"public/build/sccache.tar.bz2\", \"extract\": true, \"task\": \"PXqEh8AZRgGQuCsvEFls3A\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"YBeMzVRcQ_mkBaQQPe1e-A\"}, {\"artifact\": \"public/build/node.tar.bz2\", \"extract\": true, \"task\": \"RTF-ZEqwSG2ELmfXX-CAzA\"}]",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "no commit message",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GECKO_PATH": "./build/src",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TOOLTOOL_MANIFEST": "browser/config/tooltool-manifests/win32/releng.manifest"
+          },
+          "mounts": [
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/misc/fetch-content"
+              },
+              "file": "./fetch-content"
+            }
+          ],
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Win32 Opt ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-win32/opt"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-win32/opt",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "windows2012-32"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "opt": true
+            }
+          },
+          "treeherder-platform": "windows2012-32/opt",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "HPYneNXbR0msImxF7QBzgQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.453Z",
+        "expires": "2019-10-21T10:38:10.453Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.453Z",
+        "deadline": "2019-10-08T10:38:10.453Z",
+        "expires": "2019-10-21T10:38:10.453Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "HpLD9XGAQdeowl-0tccv5A",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.460Z",
+        "expires": "2019-10-21T10:38:10.460Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.460Z",
+        "deadline": "2019-10-08T10:38:10.460Z",
+        "expires": "2019-10-21T10:38:10.460Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "KDHFLbeATKSQUE_3WHG_iQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.291Z",
+        "expires": "2019-11-04T10:38:09.291Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-08695eda0e792529f",
+            "takenUntil": "2019-10-07T11:21:34.558Z",
+            "scheduled": "2019-10-07T10:38:29.400Z",
+            "started": "2019-10-07T10:44:33.953Z",
+            "resolved": "2019-10-07T11:02:20.732Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "CDAcPFmBTbC4GRVbyfjrVg",
+          "CVde5A_JQa-i_bwib7x-Jg",
+          "PXqEh8AZRgGQuCsvEFls3A",
+          "RTF-ZEqwSG2ELmfXX-CAzA",
+          "WAEzVS1TT9ywiINxBj6DHw",
+          "YBeMzVRcQ_mkBaQQPe1e-A",
+          "eaBNHA-USOe-AuI2BXsUxA",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.firefox.win32-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.firefox.win32-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.firefox.win32-debug",
+          "index.gecko.v2.try.pushlog-id.432115.firefox.win32-debug",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.win32-debug",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.291Z",
+        "deadline": "2019-10-08T10:38:09.291Z",
+        "expires": "2019-11-04T10:38:09.291Z",
+        "scopes": [
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "public/build",
+              "type": "directory",
+              "name": "public/build"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            ":: sccache currently uses the full compiler commandline as input to the\n:: cache hash key, so create a symlink to the task dir and build from\n:: the symlink dir to get consistent paths.\nif exist z:\\build rmdir z:\\build",
+            "mklink /d z:\\build %cd%",
+            "icacls z:\\build /grant *S-1-1-0:D /L",
+            "cd /d z:\\build",
+            "C:/mozilla-build/python3/python3.exe run-task --gecko-checkout=./build/src -- c:/mozilla-build/python/python.exe %GECKO_PATH%/testing/mozharness/scripts/fx_desktop_build.py --config builds/releng_base_firefox.py --config builds/taskcluster_base_windows.py --config builds/taskcluster_base_win32.py --config builds/taskcluster_sub_win32/debug.py --branch try --work-dir %cd:Z:=z:%\\build --append-env-variables-from-configs"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZ_SIMPLE_PACKAGE_NAME": "target",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "HG_STORE_PATH": "y:/hg-shared",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\", \"mozconfig_variant\": \"debug\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "PYTHONPATH": "./build/src/testing/mozbase/manifestparser;./build/src/testing/mozbase/mozinfo;./build/src/testing/mozbase/mozfile;./build/src/testing/mozbase/mozprocess;./build/src/third_party/python/six",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/clang.tar.bz2\", \"extract\": true, \"task\": \"eaBNHA-USOe-AuI2BXsUxA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"CVde5A_JQa-i_bwib7x-Jg\"}, {\"artifact\": \"public/build/rust-size.tar.bz2\", \"extract\": true, \"task\": \"CDAcPFmBTbC4GRVbyfjrVg\"}, {\"artifact\": \"public/build/cbindgen.tar.bz2\", \"extract\": true, \"task\": \"WAEzVS1TT9ywiINxBj6DHw\"}, {\"artifact\": \"public/build/sccache.tar.bz2\", \"extract\": true, \"task\": \"PXqEh8AZRgGQuCsvEFls3A\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"YBeMzVRcQ_mkBaQQPe1e-A\"}, {\"artifact\": \"public/build/node.tar.bz2\", \"extract\": true, \"task\": \"RTF-ZEqwSG2ELmfXX-CAzA\"}]",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "no commit message",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GECKO_PATH": "./build/src",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TOOLTOOL_MANIFEST": "browser/config/tooltool-manifests/win32/releng.manifest"
+          },
+          "mounts": [
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/misc/fetch-content"
+              },
+              "file": "./fetch-content"
+            }
+          ],
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Win32 Debug ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-win32/debug"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-win32/debug",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "windows2012-32"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "debug": true
+            }
+          },
+          "treeherder-platform": "windows2012-32/debug",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "MMXOahgdROGE9lqNp12K2g",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.434Z",
+        "expires": "2019-10-21T10:38:11.434Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.434Z",
+        "deadline": "2019-10-08T10:38:11.434Z",
+        "expires": "2019-10-21T10:38:11.434Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Mm13JLTfTyOhwL6S_f_JVA",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.416Z",
+        "expires": "2019-10-21T10:38:11.416Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "G_5hbYX5SveijqjP4khUiw"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.416Z",
+        "deadline": "2019-10-08T10:38:11.416Z",
+        "expires": "2019-10-21T10:38:11.416Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "G_5hbYX5SveijqjP4khUiw",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "N2Sfz1VNSrq_S4wTiBslAA",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.270Z",
+        "expires": "2019-10-21T10:38:12.270Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.270Z",
+        "deadline": "2019-10-08T10:38:12.270Z",
+        "expires": "2019-10-21T10:38:12.270Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "NL-I5-UFTOC9mXXpHRoPoA",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.436Z",
+        "expires": "2019-10-21T10:38:11.436Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.436Z",
+        "deadline": "2019-10-08T10:38:11.436Z",
+        "expires": "2019-10-21T10:38:11.436Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.273Z",
+        "expires": "2019-11-04T10:38:09.273Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-west-1",
+            "workerId": "i-0899741bb27792f19",
+            "takenUntil": "2019-10-07T11:22:57.195Z",
+            "scheduled": "2019-10-07T10:38:29.419Z",
+            "started": "2019-10-07T10:45:57.122Z",
+            "resolved": "2019-10-07T11:04:42.580Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "CDAcPFmBTbC4GRVbyfjrVg",
+          "CVde5A_JQa-i_bwib7x-Jg",
+          "PXqEh8AZRgGQuCsvEFls3A",
+          "RTF-ZEqwSG2ELmfXX-CAzA",
+          "WAEzVS1TT9ywiINxBj6DHw",
+          "YBeMzVRcQ_mkBaQQPe1e-A",
+          "eaBNHA-USOe-AuI2BXsUxA",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.firefox.win64-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.firefox.win64-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.firefox.win64-opt",
+          "index.gecko.v2.try.pushlog-id.432115.firefox.win64-opt",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.win64-opt",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.273Z",
+        "deadline": "2019-10-08T10:38:09.273Z",
+        "expires": "2019-11-04T10:38:09.273Z",
+        "scopes": [
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "public/build",
+              "type": "directory",
+              "name": "public/build"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            ":: sccache currently uses the full compiler commandline as input to the\n:: cache hash key, so create a symlink to the task dir and build from\n:: the symlink dir to get consistent paths.\nif exist z:\\build rmdir z:\\build",
+            "mklink /d z:\\build %cd%",
+            "icacls z:\\build /grant *S-1-1-0:D /L",
+            "cd /d z:\\build",
+            "C:/mozilla-build/python3/python3.exe run-task --gecko-checkout=./build/src -- c:/mozilla-build/python/python.exe %GECKO_PATH%/testing/mozharness/scripts/fx_desktop_build.py --config builds/releng_base_firefox.py --config builds/taskcluster_base_windows.py --config builds/taskcluster_base_win64.py --branch try --work-dir %cd:Z:=z:%\\build --append-env-variables-from-configs"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZ_SIMPLE_PACKAGE_NAME": "target",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "HG_STORE_PATH": "y:/hg-shared",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\", \"stage_platform\": \"win64\", \"mozconfig_variant\": \"nightly\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "PYTHONPATH": "./build/src/testing/mozbase/manifestparser;./build/src/testing/mozbase/mozinfo;./build/src/testing/mozbase/mozfile;./build/src/testing/mozbase/mozprocess;./build/src/third_party/python/six",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/clang.tar.bz2\", \"extract\": true, \"task\": \"eaBNHA-USOe-AuI2BXsUxA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"CVde5A_JQa-i_bwib7x-Jg\"}, {\"artifact\": \"public/build/rust-size.tar.bz2\", \"extract\": true, \"task\": \"CDAcPFmBTbC4GRVbyfjrVg\"}, {\"artifact\": \"public/build/cbindgen.tar.bz2\", \"extract\": true, \"task\": \"WAEzVS1TT9ywiINxBj6DHw\"}, {\"artifact\": \"public/build/sccache.tar.bz2\", \"extract\": true, \"task\": \"PXqEh8AZRgGQuCsvEFls3A\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"YBeMzVRcQ_mkBaQQPe1e-A\"}, {\"artifact\": \"public/build/node.tar.bz2\", \"extract\": true, \"task\": \"RTF-ZEqwSG2ELmfXX-CAzA\"}]",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "no commit message",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GECKO_PATH": "./build/src",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TOOLTOOL_MANIFEST": "browser/config/tooltool-manifests/win64/releng.manifest"
+          },
+          "mounts": [
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/misc/fetch-content"
+              },
+              "file": "./fetch-content"
+            }
+          ],
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Win64 Opt ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-win64/opt"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-win64/opt",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "windows2012-64"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "opt": true
+            }
+          },
+          "treeherder-platform": "windows2012-64/opt",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Plzbf0xoQxi8w_FJ0ErYxw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.320Z",
+        "expires": "2019-10-21T10:38:12.320Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.320Z",
+        "deadline": "2019-10-08T10:38:12.320Z",
+        "expires": "2019-10-21T10:38:12.320Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "QUJ-OsS6RqmqMcjsRjmVBQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.332Z",
+        "expires": "2019-10-21T10:38:12.332Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.332Z",
+        "deadline": "2019-10-08T10:38:12.332Z",
+        "expires": "2019-10-21T10:38:12.332Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.279Z",
+        "expires": "2019-11-04T10:38:09.279Z",
+        "retriesLeft": 5,
+        "state": "failed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "failed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "failed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-090cc1f0a8776a897",
+            "takenUntil": "2019-10-07T11:05:26.981Z",
+            "scheduled": "2019-10-07T10:38:29.411Z",
+            "started": "2019-10-07T10:45:27.057Z",
+            "resolved": "2019-10-07T10:59:44.379Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-win2012",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "CDAcPFmBTbC4GRVbyfjrVg",
+          "CVde5A_JQa-i_bwib7x-Jg",
+          "PXqEh8AZRgGQuCsvEFls3A",
+          "RTF-ZEqwSG2ELmfXX-CAzA",
+          "WAEzVS1TT9ywiINxBj6DHw",
+          "YBeMzVRcQ_mkBaQQPe1e-A",
+          "eaBNHA-USOe-AuI2BXsUxA",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.firefox.win64-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.firefox.win64-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.firefox.win64-debug",
+          "index.gecko.v2.try.pushlog-id.432115.firefox.win64-debug",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.win64-debug",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.279Z",
+        "deadline": "2019-10-08T10:38:09.279Z",
+        "expires": "2019-11-04T10:38:09.279Z",
+        "scopes": [
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "public/build",
+              "type": "directory",
+              "name": "public/build"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            ":: sccache currently uses the full compiler commandline as input to the\n:: cache hash key, so create a symlink to the task dir and build from\n:: the symlink dir to get consistent paths.\nif exist z:\\build rmdir z:\\build",
+            "mklink /d z:\\build %cd%",
+            "icacls z:\\build /grant *S-1-1-0:D /L",
+            "cd /d z:\\build",
+            "C:/mozilla-build/python3/python3.exe run-task --gecko-checkout=./build/src -- c:/mozilla-build/python/python.exe %GECKO_PATH%/testing/mozharness/scripts/fx_desktop_build.py --config builds/releng_base_firefox.py --config builds/taskcluster_base_windows.py --config builds/taskcluster_base_win64.py --config builds/taskcluster_sub_win64/debug.py --branch try --work-dir %cd:Z:=z:%\\build --append-env-variables-from-configs"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZ_SIMPLE_PACKAGE_NAME": "target",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "HG_STORE_PATH": "y:/hg-shared",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\", \"mozconfig_variant\": \"debug\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "PYTHONPATH": "./build/src/testing/mozbase/manifestparser;./build/src/testing/mozbase/mozinfo;./build/src/testing/mozbase/mozfile;./build/src/testing/mozbase/mozprocess;./build/src/third_party/python/six",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/clang.tar.bz2\", \"extract\": true, \"task\": \"eaBNHA-USOe-AuI2BXsUxA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"CVde5A_JQa-i_bwib7x-Jg\"}, {\"artifact\": \"public/build/rust-size.tar.bz2\", \"extract\": true, \"task\": \"CDAcPFmBTbC4GRVbyfjrVg\"}, {\"artifact\": \"public/build/cbindgen.tar.bz2\", \"extract\": true, \"task\": \"WAEzVS1TT9ywiINxBj6DHw\"}, {\"artifact\": \"public/build/sccache.tar.bz2\", \"extract\": true, \"task\": \"PXqEh8AZRgGQuCsvEFls3A\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"YBeMzVRcQ_mkBaQQPe1e-A\"}, {\"artifact\": \"public/build/node.tar.bz2\", \"extract\": true, \"task\": \"RTF-ZEqwSG2ELmfXX-CAzA\"}]",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "no commit message",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GECKO_PATH": "./build/src",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TOOLTOOL_MANIFEST": "browser/config/tooltool-manifests/win64/releng.manifest"
+          },
+          "mounts": [
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/misc/fetch-content"
+              },
+              "file": "./fetch-content"
+            }
+          ],
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Win64 Debug ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-win64/debug"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-win64/debug",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "windows2012-64"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "debug": true
+            }
+          },
+          "treeherder-platform": "windows2012-64/debug",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "R4oRDJ67RUa3K5P54z1CZw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:12.292Z",
+        "expires": "2019-10-21T10:38:12.292Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:12.292Z",
+        "deadline": "2019-10-08T10:38:12.292Z",
+        "expires": "2019-10-21T10:38:12.292Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Rnv-2SRaStqG9gPAlhyMfg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.430Z",
+        "expires": "2019-10-21T10:38:11.430Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.430Z",
+        "deadline": "2019-10-08T10:38:11.430Z",
+        "expires": "2019-10-21T10:38:11.430Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "RqrmC1TSTHWlnU-hT35Rpw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.284Z",
+        "expires": "2019-11-04T10:38:09.284Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-west-1",
+            "workerId": "i-07eda4edae7afb760",
+            "takenUntil": "2019-10-07T10:58:29.695Z",
+            "scheduled": "2019-10-07T10:38:29.388Z",
+            "started": "2019-10-07T10:38:29.774Z",
+            "resolved": "2019-10-07T10:41:53.153Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Ly_R3E7nTKW8x40QXRLEPg",
+          "M5STQbxiRnGt4aSmWdp7Dg",
+          "MaEB78HGTw6Dp7AqnvDM1Q",
+          "MgI2k6kxSmi3SKyM8rc7UA",
+          "O-KYVZ5DQU636BcrE5Uanw",
+          "U4Ceoc56ShGNbHW71ZsQ-w",
+          "Uai_mGbWQ5ahVemoAWeuJg",
+          "bCS0hW_8SmWeIID2GP6Ktg",
+          "cMItT5VOTluDKPjeW1VHOg",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.firefox.linux64-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.firefox.linux64-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.firefox.linux64-debug",
+          "index.gecko.v2.try.pushlog-id.432115.firefox.linux64-debug",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.linux64-debug",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.284Z",
+        "deadline": "2019-10-08T10:38:09.284Z",
+        "expires": "2019-11-04T10:38:09.284Z",
+        "scopes": [
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets",
+          "auth:gcp:access-token:sccache-3/tc-l1*",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 5400,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "Ly_R3E7nTKW8x40QXRLEPg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs": {
+              "path": "/builds/worker/logs/",
+              "expires": "2019-11-04T10:38:09.284Z",
+              "type": "directory"
+            },
+            "public/build": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-11-04T10:38:09.284Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/workspace/build/src",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/workspace/build/src/taskcluster/scripts/builder/build-linux.sh"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/binutils.tar.xz\", \"extract\": true, \"task\": \"M5STQbxiRnGt4aSmWdp7Dg\"}, {\"artifact\": \"public/build/clang.tar.xz\", \"extract\": true, \"task\": \"MgI2k6kxSmi3SKyM8rc7UA\"}, {\"artifact\": \"public/build/cbindgen.tar.xz\", \"extract\": true, \"task\": \"MaEB78HGTw6Dp7AqnvDM1Q\"}, {\"artifact\": \"public/build/sccache.tar.xz\", \"extract\": true, \"task\": \"cMItT5VOTluDKPjeW1VHOg\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"bCS0hW_8SmWeIID2GP6Ktg\"}, {\"artifact\": \"public/build/rust-size.tar.xz\", \"extract\": true, \"task\": \"Uai_mGbWQ5ahVemoAWeuJg\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"U4Ceoc56ShGNbHW71ZsQ-w\"}, {\"artifact\": \"public/build/node.tar.xz\", \"extract\": true, \"task\": \"O-KYVZ5DQU636BcrE5Uanw\"}]",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "PYTHONUNBUFFERED": "1",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZHARNESS_SCRIPT": "mozharness/scripts/fx_desktop_build.py",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "MH_BUILD_POOL": "taskcluster",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MH_CUSTOM_BUILD_VARIANT_CFG": "debug",
+            "MOZHARNESS_ACTIONS": "get-secrets build",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\", \"mozconfig_variant\": \"debug\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "NEED_XVFB": "true",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "",
+            "UPLOAD_DIR": "/builds/worker/artifacts/",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GECKO_PATH": "/builds/worker/workspace/build/src",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "MOZHARNESS_CONFIG": "builds/releng_base_firefox.py builds/releng_base_linux_64_builds.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Linux64 Debug ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-linux64/debug"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-linux64/debug",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "chainOfTrust": {
+            "inputs": {
+              "docker-image": "Ly_R3E7nTKW8x40QXRLEPg"
+            }
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "linux64"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "debug": true
+            }
+          },
+          "treeherder-platform": "linux64/debug",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "RwgfXweRR-mxRSRYAY--lg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.458Z",
+        "expires": "2019-10-21T10:38:10.458Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.458Z",
+        "deadline": "2019-10-08T10:38:10.458Z",
+        "expires": "2019-10-21T10:38:10.458Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Sx3QOoliRg-81JMSzPxMWg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.290Z",
+        "expires": "2019-11-04T10:38:09.290Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-040d494e94663fc73",
+            "takenUntil": "2019-10-07T10:58:29.751Z",
+            "scheduled": "2019-10-07T10:38:29.416Z",
+            "started": "2019-10-07T10:38:29.825Z",
+            "resolved": "2019-10-07T10:45:03.634Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "G2uFNVJQS--ciKaLRwkCwQ",
+          "MaEB78HGTw6Dp7AqnvDM1Q",
+          "MgI2k6kxSmi3SKyM8rc7UA",
+          "O-KYVZ5DQU636BcrE5Uanw",
+          "QOzMv9PzRsCaahfKO3GFhw",
+          "U4Ceoc56ShGNbHW71ZsQ-w",
+          "Uai_mGbWQ5ahVemoAWeuJg",
+          "V_Yy47svRwav6uPUv4J9ZA",
+          "aNZB8MtiT6yDsqDHEdfggQ",
+          "bT6TwSGUS2uA5gAwnB3ULQ",
+          "cMItT5VOTluDKPjeW1VHOg",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.mobile.android-x86_64-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.mobile.android-x86_64-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.mobile.android-x86_64-opt",
+          "index.gecko.v2.try.pushlog-id.432115.mobile.android-x86_64-opt",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.mobile.android-x86_64-opt",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.290Z",
+        "deadline": "2019-10-08T10:38:09.290Z",
+        "expires": "2019-11-04T10:38:09.290Z",
+        "scopes": [
+          "queue:get-artifact:project/gecko/android-ndk/*",
+          "queue:get-artifact:project/gecko/android-sdk/*",
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "project:releng:services/tooltool/api/download/internal",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets",
+          "auth:gcp:access-token:sccache-3/tc-l1*",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "QOzMv9PzRsCaahfKO3GFhw"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/build/maven": {
+              "path": "/builds/worker/workspace/build/src/obj-firefox/gradle/build/mobile/android/geckoview/maven/",
+              "expires": "2019-11-04T10:38:09.290Z",
+              "type": "directory"
+            },
+            "public/build/geckoview_example.apk": {
+              "path": "/builds/worker/workspace/build/src/obj-firefox/gradle/build/mobile/android/geckoview_example/outputs/apk/withGeckoBinaries/debug/geckoview_example-withGeckoBinaries-debug.apk",
+              "expires": "2019-11-04T10:38:09.290Z",
+              "type": "file"
+            },
+            "public/build": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-11-04T10:38:09.290Z",
+              "type": "directory"
+            },
+            "public/logs": {
+              "path": "/builds/worker/logs/",
+              "expires": "2019-11-04T10:38:09.290Z",
+              "type": "directory"
+            },
+            "public/build/geckoview-androidTest.apk": {
+              "path": "/builds/worker/workspace/build/src/obj-firefox/gradle/build/mobile/android/geckoview/outputs/apk/androidTest/withGeckoBinaries/debug/geckoview-withGeckoBinaries-debug-androidTest.apk",
+              "expires": "2019-11-04T10:38:09.290Z",
+              "type": "file"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/workspace/build/src",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/workspace/build/src/taskcluster/scripts/builder/build-linux.sh"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/android-gradle-dependencies.tar.xz\", \"extract\": true, \"task\": \"aNZB8MtiT6yDsqDHEdfggQ\"}, {\"artifact\": \"project/gecko/android-ndk/android-ndk.tar.xz\", \"extract\": true, \"task\": \"G2uFNVJQS--ciKaLRwkCwQ\"}, {\"artifact\": \"project/gecko/android-sdk/android-sdk-linux.tar.xz\", \"extract\": true, \"task\": \"V_Yy47svRwav6uPUv4J9ZA\"}, {\"artifact\": \"public/build/clang.tar.xz\", \"extract\": true, \"task\": \"MgI2k6kxSmi3SKyM8rc7UA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"bT6TwSGUS2uA5gAwnB3ULQ\"}, {\"artifact\": \"public/build/rust-size.tar.xz\", \"extract\": true, \"task\": \"Uai_mGbWQ5ahVemoAWeuJg\"}, {\"artifact\": \"public/build/cbindgen.tar.xz\", \"extract\": true, \"task\": \"MaEB78HGTw6Dp7AqnvDM1Q\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"U4Ceoc56ShGNbHW71ZsQ-w\"}, {\"artifact\": \"public/build/node.tar.xz\", \"extract\": true, \"task\": \"O-KYVZ5DQU636BcrE5Uanw\"}, {\"artifact\": \"public/build/sccache.tar.xz\", \"extract\": true, \"task\": \"cMItT5VOTluDKPjeW1VHOg\"}]",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "PYTHONUNBUFFERED": "1",
+            "MH_CUSTOM_BUILD_VARIANT_CFG": "x86_64",
+            "MOZHARNESS_SCRIPT": "mozharness/scripts/fx_desktop_build.py",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "MH_BUILD_POOL": "taskcluster",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZHARNESS_ACTIONS": "get-secrets build",
+            "GECKO_PATH": "/builds/worker/workspace/build/src",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\"}",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "NEED_XVFB": "false",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "",
+            "UPLOAD_DIR": "/builds/worker/artifacts/",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GRADLE_USER_HOME": "/builds/worker/workspace/build/src/mobile/android/gradle/dotgradle-offline",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "TOOLTOOL_MANIFEST": "mobile/android/config/tooltool-manifests/android-x86/releng.manifest",
+            "MOZHARNESS_CONFIG": "builds/releng_base_android_64_builds.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Android 5.0 x86-64 Opt ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-android-x86_64/opt"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-android-x86_64/opt",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "chainOfTrust": {
+            "inputs": {
+              "docker-image": "QOzMv9PzRsCaahfKO3GFhw"
+            }
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "android-5-0-x86_64"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "opt": true
+            }
+          },
+          "treeherder-platform": "android-5-0-x86_64/opt",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "TQHdkUHRT969iu-C07zm7Q",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.468Z",
+        "expires": "2019-10-21T10:38:11.468Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "KDHFLbeATKSQUE_3WHG_iQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.468Z",
+        "deadline": "2019-10-08T10:38:11.468Z",
+        "expires": "2019-10-21T10:38:11.468Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "KDHFLbeATKSQUE_3WHG_iQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "TiDyXxa5RyyV_bnlTtoFZg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.467Z",
+        "expires": "2019-10-21T10:38:11.467Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "KDHFLbeATKSQUE_3WHG_iQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.467Z",
+        "deadline": "2019-10-08T10:38:11.467Z",
+        "expires": "2019-10-21T10:38:11.467Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "KDHFLbeATKSQUE_3WHG_iQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "U6NnV5QUTm6Z5jAVZj5sLw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.449Z",
+        "expires": "2019-10-21T10:38:10.449Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.449Z",
+        "deadline": "2019-10-08T10:38:10.449Z",
+        "expires": "2019-10-21T10:38:10.449Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "WVoDCLXmSh-KAGBA8pKkSw",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.458Z",
+        "expires": "2019-10-21T10:38:11.458Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "KDHFLbeATKSQUE_3WHG_iQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.458Z",
+        "deadline": "2019-10-08T10:38:11.458Z",
+        "expires": "2019-10-21T10:38:11.458Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "KDHFLbeATKSQUE_3WHG_iQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "X4wdBGlHSEOK68lG0AdlDQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.267Z",
+        "expires": "2019-11-04T10:38:09.267Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-0e96a5b732cd2acd5",
+            "takenUntil": "2019-10-07T10:58:29.747Z",
+            "scheduled": "2019-10-07T10:38:29.414Z",
+            "started": "2019-10-07T10:38:29.824Z",
+            "resolved": "2019-10-07T10:48:31.148Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Ly_R3E7nTKW8x40QXRLEPg",
+          "M5STQbxiRnGt4aSmWdp7Dg",
+          "MaEB78HGTw6Dp7AqnvDM1Q",
+          "MgI2k6kxSmi3SKyM8rc7UA",
+          "O-KYVZ5DQU636BcrE5Uanw",
+          "U4Ceoc56ShGNbHW71ZsQ-w",
+          "Uai_mGbWQ5ahVemoAWeuJg",
+          "bCS0hW_8SmWeIID2GP6Ktg",
+          "cMItT5VOTluDKPjeW1VHOg",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.firefox.linux64-asan-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.firefox.linux64-asan-opt",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.firefox.linux64-asan-opt",
+          "index.gecko.v2.try.pushlog-id.432115.firefox.linux64-asan-opt",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.firefox.linux64-asan-opt",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.267Z",
+        "deadline": "2019-10-08T10:38:09.267Z",
+        "expires": "2019-11-04T10:38:09.267Z",
+        "scopes": [
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets",
+          "auth:gcp:access-token:sccache-3/tc-l1*",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 5400,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "Ly_R3E7nTKW8x40QXRLEPg"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/logs": {
+              "path": "/builds/worker/logs/",
+              "expires": "2019-11-04T10:38:09.267Z",
+              "type": "directory"
+            },
+            "public/build": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-11-04T10:38:09.267Z",
+              "type": "directory"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/workspace/build/src",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/workspace/build/src/taskcluster/scripts/builder/build-linux.sh"
+          ],
+          "env": {
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/binutils.tar.xz\", \"extract\": true, \"task\": \"M5STQbxiRnGt4aSmWdp7Dg\"}, {\"artifact\": \"public/build/clang.tar.xz\", \"extract\": true, \"task\": \"MgI2k6kxSmi3SKyM8rc7UA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"bCS0hW_8SmWeIID2GP6Ktg\"}, {\"artifact\": \"public/build/rust-size.tar.xz\", \"extract\": true, \"task\": \"Uai_mGbWQ5ahVemoAWeuJg\"}, {\"artifact\": \"public/build/cbindgen.tar.xz\", \"extract\": true, \"task\": \"MaEB78HGTw6Dp7AqnvDM1Q\"}, {\"artifact\": \"public/build/sccache.tar.xz\", \"extract\": true, \"task\": \"cMItT5VOTluDKPjeW1VHOg\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"U4Ceoc56ShGNbHW71ZsQ-w\"}, {\"artifact\": \"public/build/node.tar.xz\", \"extract\": true, \"task\": \"O-KYVZ5DQU636BcrE5Uanw\"}]",
+            "PERFHERDER_EXTRA_OPTIONS": "opt asan",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "PYTHONUNBUFFERED": "1",
+            "TRY_COMMIT_MSG": "",
+            "MH_CUSTOM_BUILD_VARIANT_CFG": "asan-tc",
+            "MOZHARNESS_SCRIPT": "mozharness/scripts/fx_desktop_build.py",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "MH_BUILD_POOL": "taskcluster",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZHARNESS_ACTIONS": "get-secrets build",
+            "GECKO_PATH": "/builds/worker/workspace/build/src",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\", \"mozconfig_variant\": \"nightly-asan\"}",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "NEED_XVFB": "true",
+            "USE_SCCACHE": "1",
+            "MOZ_DISABLE_FULL_SYMBOLS": "1",
+            "UPLOAD_DIR": "/builds/worker/artifacts/",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "MOZHARNESS_CONFIG": "builds/releng_base_firefox.py builds/releng_base_linux_64_builds.py",
+            "ASAN_OPTIONS": "detect_leaks=0"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Linux64 Opt ASAN ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-linux64-asan/opt"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-linux64-asan/opt",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "chainOfTrust": {
+            "inputs": {
+              "docker-image": "Ly_R3E7nTKW8x40QXRLEPg"
+            }
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "linux64"
+            },
+            "tier": 1,
+            "symbol": "Bo",
+            "jobKind": "build",
+            "collection": {
+              "asan": true
+            }
+          },
+          "treeherder-platform": "linux64/asan",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "XA-_TkI8RMS0As1zCv2FPA",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.412Z",
+        "expires": "2019-10-21T10:38:11.412Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "G_5hbYX5SveijqjP4khUiw"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.412Z",
+        "deadline": "2019-10-08T10:38:11.412Z",
+        "expires": "2019-10-21T10:38:11.412Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "G_5hbYX5SveijqjP4khUiw",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "XY5abAV2R7yMzl4C55KR0w",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.454Z",
+        "expires": "2019-10-21T10:38:10.454Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.454Z",
+        "deadline": "2019-10-08T10:38:10.454Z",
+        "expires": "2019-10-21T10:38:10.454Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "Xxv6k8CDRZ61ZFQ5298Mgg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.447Z",
+        "expires": "2019-10-21T10:38:10.447Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.447Z",
+        "deadline": "2019-10-08T10:38:10.447Z",
+        "expires": "2019-10-21T10:38:10.447Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --enable-webrender --setpref=layers.d3d11.enable-blacklist=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64-qr/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64-qr/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 0
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64-qr"
+            },
+            "groupName": "Web platform tests",
+            "tier": 2,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64-qr/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "YkmiIfY_SH2BGn0Qjf4BAA",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.411Z",
+        "expires": "2019-10-21T10:38:11.411Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "G_5hbYX5SveijqjP4khUiw"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.411Z",
+        "deadline": "2019-10-08T10:38:11.411Z",
+        "expires": "2019-10-21T10:38:11.411Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "G_5hbYX5SveijqjP4khUiw",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "ZF_zVK1fSGyYna3ceaoV8Q",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.456Z",
+        "expires": "2019-10-21T10:38:10.456Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.456Z",
+        "deadline": "2019-10-08T10:38:10.456Z",
+        "expires": "2019-10-21T10:38:10.456Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "bemAkIsIRsOZG46_yE_UVQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:09.287Z",
+        "expires": "2019-11-04T10:38:09.287Z",
+        "retriesLeft": 5,
+        "state": "completed",
+        "runs": [
+          {
+            "runId": 0,
+            "state": "completed",
+            "reasonCreated": "scheduled",
+            "reasonResolved": "completed",
+            "workerGroup": "us-east-1",
+            "workerId": "i-02a66959428ebaa56",
+            "takenUntil": "2019-10-07T10:58:29.749Z",
+            "scheduled": "2019-10-07T10:38:29.418Z",
+            "started": "2019-10-07T10:38:29.823Z",
+            "resolved": "2019-10-07T10:47:13.057Z"
+          }
+        ]
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-1-b-linux",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "G2uFNVJQS--ciKaLRwkCwQ",
+          "MaEB78HGTw6Dp7AqnvDM1Q",
+          "MgI2k6kxSmi3SKyM8rc7UA",
+          "O-KYVZ5DQU636BcrE5Uanw",
+          "QOzMv9PzRsCaahfKO3GFhw",
+          "U4Ceoc56ShGNbHW71ZsQ-w",
+          "Uai_mGbWQ5ahVemoAWeuJg",
+          "V_Yy47svRwav6uPUv4J9ZA",
+          "aNZB8MtiT6yDsqDHEdfggQ",
+          "bT6TwSGUS2uA5gAwnB3ULQ",
+          "cMItT5VOTluDKPjeW1VHOg",
+          "DswJgYaPSuio6XPITUB9Lg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "index.gecko.v2.try.latest.mobile.android-x86_64-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.20191007103556.mobile.android-x86_64-debug",
+          "index.gecko.v2.try.pushdate.2019.10.07.latest.mobile.android-x86_64-debug",
+          "index.gecko.v2.try.pushlog-id.432115.mobile.android-x86_64-debug",
+          "index.gecko.v2.try.revision.0b445bf4228a963505183b157758c37664921791.mobile.android-x86_64-debug",
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:09.287Z",
+        "deadline": "2019-10-08T10:38:09.287Z",
+        "expires": "2019-11-04T10:38:09.287Z",
+        "scopes": [
+          "queue:get-artifact:project/gecko/android-ndk/*",
+          "queue:get-artifact:project/gecko/android-sdk/*",
+          "secrets:get:project/releng/gecko/build/level-1/*",
+          "secrets:get:project/taskcluster/gecko/hgfingerprint",
+          "secrets:get:project/taskcluster/gecko/hgmointernal",
+          "project:releng:services/tooltool/api/download/public",
+          "project:releng:services/tooltool/api/download/internal",
+          "assume:project:taskcluster:gecko:level-1-sccache-buckets",
+          "auth:gcp:access-token:sccache-3/tc-l1*",
+          "docker-worker:cache:gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5",
+          "docker-worker:cache:gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5"
+        ],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              4,
+              72
+            ],
+            "purgeCaches": [
+              72
+            ]
+          },
+          "maxRunTime": 7200,
+          "image": {
+            "path": "public/image.tar.zst",
+            "type": "task-image",
+            "taskId": "QOzMv9PzRsCaahfKO3GFhw"
+          },
+          "cache": {
+            "gecko-level-1-checkouts-v3-c69f9ae1494ced424fb5": "/builds/worker/checkouts",
+            "gecko-level-1-tooltool-cache-v3-c69f9ae1494ced424fb5": "/builds/worker/tooltool-cache"
+          },
+          "artifacts": {
+            "public/build/maven": {
+              "path": "/builds/worker/workspace/build/src/obj-firefox/gradle/build/mobile/android/geckoview/maven/",
+              "expires": "2019-11-04T10:38:09.287Z",
+              "type": "directory"
+            },
+            "public/build/geckoview_example.apk": {
+              "path": "/builds/worker/workspace/build/src/obj-firefox/gradle/build/mobile/android/geckoview_example/outputs/apk/withGeckoBinaries/debug/geckoview_example-withGeckoBinaries-debug.apk",
+              "expires": "2019-11-04T10:38:09.287Z",
+              "type": "file"
+            },
+            "public/build": {
+              "path": "/builds/worker/artifacts/",
+              "expires": "2019-11-04T10:38:09.287Z",
+              "type": "directory"
+            },
+            "public/logs": {
+              "path": "/builds/worker/logs/",
+              "expires": "2019-11-04T10:38:09.287Z",
+              "type": "directory"
+            },
+            "public/build/geckoview-androidTest.apk": {
+              "path": "/builds/worker/workspace/build/src/obj-firefox/gradle/build/mobile/android/geckoview/outputs/apk/androidTest/withGeckoBinaries/debug/geckoview-withGeckoBinaries-debug-androidTest.apk",
+              "expires": "2019-11-04T10:38:09.287Z",
+              "type": "file"
+            }
+          },
+          "command": [
+            "/builds/worker/bin/run-task",
+            "--gecko-checkout=/builds/worker/workspace/build/src",
+            "--fetch-hgfingerprint",
+            "--",
+            "/builds/worker/workspace/build/src/taskcluster/scripts/builder/build-linux.sh"
+          ],
+          "env": {
+            "USE_ARTIFACT": "1",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "MOZ_AUTOMATION": "1",
+            "MOZ_SOURCE_CHANGESET": "0b445bf4228a963505183b157758c37664921791",
+            "ACCEPTED_MAR_CHANNEL_IDS": "firefox-mozilla-central",
+            "MOZ_FETCHES": "[{\"artifact\": \"public/build/android-gradle-dependencies.tar.xz\", \"extract\": true, \"task\": \"aNZB8MtiT6yDsqDHEdfggQ\"}, {\"artifact\": \"project/gecko/android-ndk/android-ndk.tar.xz\", \"extract\": true, \"task\": \"G2uFNVJQS--ciKaLRwkCwQ\"}, {\"artifact\": \"project/gecko/android-sdk/android-sdk-linux.tar.xz\", \"extract\": true, \"task\": \"V_Yy47svRwav6uPUv4J9ZA\"}, {\"artifact\": \"public/build/clang.tar.xz\", \"extract\": true, \"task\": \"MgI2k6kxSmi3SKyM8rc7UA\"}, {\"artifact\": \"public/build/rustc.tar.xz\", \"extract\": true, \"task\": \"bT6TwSGUS2uA5gAwnB3ULQ\"}, {\"artifact\": \"public/build/rust-size.tar.xz\", \"extract\": true, \"task\": \"Uai_mGbWQ5ahVemoAWeuJg\"}, {\"artifact\": \"public/build/cbindgen.tar.xz\", \"extract\": true, \"task\": \"MaEB78HGTw6Dp7AqnvDM1Q\"}, {\"artifact\": \"public/build/nasm.tar.bz2\", \"extract\": true, \"task\": \"U4Ceoc56ShGNbHW71ZsQ-w\"}, {\"artifact\": \"public/build/node.tar.xz\", \"extract\": true, \"task\": \"O-KYVZ5DQU636BcrE5Uanw\"}, {\"artifact\": \"public/build/sccache.tar.xz\", \"extract\": true, \"task\": \"cMItT5VOTluDKPjeW1VHOg\"}]",
+            "TOOLTOOL_CACHE": "/builds/worker/tooltool-cache",
+            "PYTHONUNBUFFERED": "1",
+            "MH_CUSTOM_BUILD_VARIANT_CFG": "x86_64-debug",
+            "MOZHARNESS_SCRIPT": "mozharness/scripts/fx_desktop_build.py",
+            "MOZ_BUILD_DATE": "20191007103556",
+            "MH_BUILD_POOL": "taskcluster",
+            "HG_STORE_PATH": "/builds/worker/checkouts/hg-store",
+            "MOZ_FETCHES_DIR": "fetches",
+            "MOZHARNESS_ACTIONS": "get-secrets build",
+            "GECKO_PATH": "/builds/worker/workspace/build/src",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"update_channel\": \"nightly-try\"}",
+            "MOZ_SOURCE_REPO": "https://hg.mozilla.org/try",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MH_BRANCH": "try",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "GECKO_BASE_REPOSITORY": "https://hg.mozilla.org/mozilla-unified",
+            "SCCACHE_GCS_PROJECT": "sccache-3",
+            "NEED_XVFB": "false",
+            "USE_SCCACHE": "1",
+            "TRY_COMMIT_MSG": "",
+            "UPLOAD_DIR": "/builds/worker/artifacts/",
+            "TASKCLUSTER_CACHES": "/builds/worker/checkouts;/builds/worker/tooltool-cache",
+            "TASKCLUSTER_UNTRUSTED_CACHES": "1",
+            "MAR_CHANNEL_ID": "firefox-mozilla-central",
+            "GRADLE_USER_HOME": "/builds/worker/workspace/build/src/mobile/android/gradle/dotgradle-offline",
+            "SCCACHE_IDLE_TIMEOUT": "0",
+            "TASKCLUSTER_VOLUMES": "/builds/worker/checkouts;/builds/worker/tooltool-cache;/builds/worker/workspace",
+            "TOOLTOOL_MANIFEST": "mobile/android/config/tooltool-manifests/android-x86/releng.manifest",
+            "MOZHARNESS_CONFIG": "builds/releng_base_android_64_builds.py"
+          },
+          "features": {
+            "taskclusterProxy": true,
+            "chainOfTrust": true
+          }
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/build",
+          "description": "Android 5.0 x86-64 Debug ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "build-android-x86_64/debug"
+        },
+        "tags": {
+          "kind": "build",
+          "worker-implementation": "docker-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "false",
+          "label": "build-android-x86_64/debug",
+          "os": "linux"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "chainOfTrust": {
+            "inputs": {
+              "docker-image": "QOzMv9PzRsCaahfKO3GFhw"
+            }
+          },
+          "treeherder": {
+            "machine": {
+              "platform": "android-5-0-x86_64"
+            },
+            "tier": 1,
+            "symbol": "Ba",
+            "jobKind": "build",
+            "collection": {
+              "debug": true
+            }
+          },
+          "treeherder-platform": "android-5-0-x86_64/debug",
+          "parent": "DswJgYaPSuio6XPITUB9Lg"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "c23T7EnvQmy5Wqnr7zVHzQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.460Z",
+        "expires": "2019-10-21T10:38:11.460Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "KDHFLbeATKSQUE_3WHG_iQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.460Z",
+        "deadline": "2019-10-08T10:38:11.460Z",
+        "expires": "2019-10-21T10:38:11.460Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/KDHFLbeATKSQUE_3WHG_iQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "KDHFLbeATKSQUE_3WHG_iQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "c6VFEE-6T_ezUQfKDRTXrQ",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.414Z",
+        "expires": "2019-10-21T10:38:11.414Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "G_5hbYX5SveijqjP4khUiw"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.414Z",
+        "deadline": "2019-10-08T10:38:11.414Z",
+        "expires": "2019-10-21T10:38:11.414Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "G_5hbYX5SveijqjP4khUiw",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "dip2m2bqTuq403Up4_8TSg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.438Z",
+        "expires": "2019-10-21T10:38:11.438Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "QjuGVUyvTfK7uGT3EUa2yQ"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.438Z",
+        "deadline": "2019-10-08T10:38:11.438Z",
+        "expires": "2019-10-21T10:38:11.438Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols true --total-chunk=18 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/QjuGVUyvTfK7uGT3EUa2yQ/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "QjuGVUyvTfK7uGT3EUa2yQ",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/debug-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/debug-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 18
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "debug": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/debug"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "ecJKzH14Q3il0WMcXmiS6A",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:11.418Z",
+        "expires": "2019-10-21T10:38:11.418Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win7-32",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "G_5hbYX5SveijqjP4khUiw"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:11.418Z",
+        "deadline": "2019-10-08T10:38:11.418Z",
+        "expires": "2019-10-21T10:38:11.418Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/G_5hbYX5SveijqjP4khUiw/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "G_5hbYX5SveijqjP4khUiw",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows7-32/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows7-32/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows7-32"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows7-32/opt"
+        }
+      }
+    },
+    {
+      "status": {
+        "taskId": "f9m8FmeCTTa1B6OuH78Hbg",
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "deadline": "2019-10-08T10:38:10.457Z",
+        "expires": "2019-10-21T10:38:10.457Z",
+        "retriesLeft": 5,
+        "state": "unscheduled",
+        "runs": []
+      },
+      "task": {
+        "provisionerId": "aws-provisioner-v1",
+        "workerType": "gecko-t-win10-64",
+        "schedulerId": "gecko-level-1",
+        "taskGroupId": "DswJgYaPSuio6XPITUB9Lg",
+        "dependencies": [
+          "Oo9lKlLJQUe5AWYjYQLULg"
+        ],
+        "requires": "all-completed",
+        "routes": [
+          "tc-treeherder.v2.try.0b445bf4228a963505183b157758c37664921791.432115"
+        ],
+        "priority": "very-low",
+        "retries": 5,
+        "created": "2019-10-07T10:38:10.457Z",
+        "deadline": "2019-10-08T10:38:10.457Z",
+        "expires": "2019-10-21T10:38:10.457Z",
+        "scopes": [],
+        "payload": {
+          "onExitStatus": {
+            "retry": [
+              1073807364,
+              3221225786
+            ]
+          },
+          "artifacts": [
+            {
+              "path": "logs",
+              "type": "directory",
+              "name": "public/logs"
+            },
+            {
+              "path": "build/blobber_upload_dir",
+              "type": "directory",
+              "name": "public/test_info"
+            }
+          ],
+          "maxRunTime": 7200,
+          "command": [
+            "C:/mozilla-build/python3/python3.exe run-task -- c:\\mozilla-build\\python\\python.exe -u mozharness\\scripts\\web_platform_tests.py --cfg mozharness\\configs\\web_platform_tests\\prod_config_windows_taskcluster.py --test-type=testharness --setpref=media.peerconnection.mtransport_process=false --setpref=network.process.enabled=false --download-symbols ondemand --total-chunk=12 --this-chunk=1"
+          ],
+          "env": {
+            "SCCACHE_DISABLE": "1",
+            "TRY_COMMIT_MSG": "",
+            "MOZHARNESS_TEST_PATHS": "{\"web-platform-tests-testharness\": [\"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/invalid-content-type.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/module.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/non-object.tentative.any.js\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/parse-error.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/utf8.tentative.html\", \"testing/web-platform/tests/html/semantics/scripting-1/the-script-element/json-module/valid-content-type.tentative.html\"]}",
+            "GECKO_HEAD_REV": "0b445bf4228a963505183b157758c37664921791",
+            "MOZ_SCM_LEVEL": "1",
+            "TRY_SELECTOR": "fuzzy",
+            "EXTRA_MOZHARNESS_CONFIG": "{\"test_packages_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.test_packages.json\", \"installer_url\": \"https://queue.taskcluster.net/v1/task/Oo9lKlLJQUe5AWYjYQLULg/artifacts/public/build/target.zip\"}",
+            "GECKO_HEAD_REPOSITORY": "https://hg.mozilla.org/try",
+            "MOZ_AUTOMATION": "1"
+          },
+          "mounts": [
+            {
+              "directory": ".",
+              "content": {
+                "taskId": "Oo9lKlLJQUe5AWYjYQLULg",
+                "artifact": "public/build/mozharness.zip"
+              },
+              "format": "zip"
+            },
+            {
+              "content": {
+                "url": "https://hg.mozilla.org/try/raw-file/0b445bf4228a963505183b157758c37664921791/taskcluster/scripts/run-task"
+              },
+              "file": "./run-task"
+            }
+          ]
+        },
+        "metadata": {
+          "owner": "wptsync@mozilla.com",
+          "source": "https://hg.mozilla.org/try/file/0b445bf4228a963505183b157758c37664921791/taskcluster/ci/test",
+          "description": "Web platform test run ([Treeherder push](https://treeherder.mozilla.org/#/jobs?repo=try&revision=0b445bf4228a963505183b157758c37664921791))",
+          "name": "test-windows10-64/opt-web-platform-tests-e10s-1"
+        },
+        "tags": {
+          "kind": "test",
+          "worker-implementation": "generic-worker",
+          "createdForUser": "wptsync@mozilla.com",
+          "retrigger": "true",
+          "label": "test-windows10-64/opt-web-platform-tests-e10s-1",
+          "os": "windows"
+        },
+        "extra": {
+          "index": {
+            "rank": 1570444556
+          },
+          "parent": "DswJgYaPSuio6XPITUB9Lg",
+          "chunks": {
+            "current": 1,
+            "total": 12
+          },
+          "suite": "web-platform-tests",
+          "treeherder": {
+            "jobKind": "test",
+            "groupSymbol": "W",
+            "collection": {
+              "opt": true
+            },
+            "machine": {
+              "platform": "windows10-64"
+            },
+            "groupName": "Web platform tests",
+            "tier": 1,
+            "symbol": "wpt1"
+          },
+          "treeherder-platform": "windows10-64/opt"
+        }
+      }
+    }
+  ]
+}

--- a/test/test_tc.py
+++ b/test/test_tc.py
@@ -1,15 +1,8 @@
-import requests_mock
-
 from sync import tc
 
 
-def test_taskgroup(tc_response):
-    with tc_response("taskgroup-wpt-complete.json") as f:
-        with requests_mock.Mocker() as m:
-            taskgroup_id = "test"
-            m.register_uri("GET", "%stask-group/%s/list" % (tc.QUEUE_BASE, taskgroup_id), body=f)
-            taskgroup = tc.TaskGroup(taskgroup_id)
-            taskgroup.refresh()
+def test_taskgroup(mock_taskgroup):
+    taskgroup = mock_taskgroup("taskgroup-wpt-complete.json")
 
     assert len(taskgroup.tasks) == 20
     tasks = taskgroup.view()
@@ -28,13 +21,8 @@ def test_taskgroup(tc_response):
     assert len(failures) == 1
 
 
-def test_taskgroup_unscheduled(tc_response):
-    with tc_response("taskgroup-build-failed.json") as f:
-        with requests_mock.Mocker() as m:
-            taskgroup_id = "test"
-            m.register_uri("GET", "%stask-group/%s/list" % (tc.QUEUE_BASE, taskgroup_id), body=f)
-            taskgroup = tc.TaskGroup(taskgroup_id)
-            taskgroup.refresh()
+def test_taskgroup_unscheduled(mock_taskgroup):
+    taskgroup = mock_taskgroup("taskgroup-build-failed.json")
 
     tasks = taskgroup.view()
     assert not tasks.is_complete()


### PR DESCRIPTION
If we have build failures, we should notify the bug. We should also not flag the try push for manual fix if we have some builds and subsequent tests that completed. 

Should also add build failure notification in `try_notify` but will probably do that in another PR. 