### PR TITLE
Remove the concept of expired try pushes

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -232,8 +232,6 @@ class DownstreamSync(SyncProcess):
         so we always assume that any try push is valid"""
 
         latest_try_push = self.latest_try_push
-        if latest_try_push and latest_try_push.expired():
-            latest_try_push = None
 
         # Check if the try push is for the current PR head
         if (latest_try_push and

--- a/sync/sync.py
+++ b/sync/sync.py
@@ -576,7 +576,7 @@ class SyncProcess(object):
         try_pushes = self.try_pushes(status="complete")
         busted = []
         for push in reversed(try_pushes):
-            if push.infra_fail and not push.expired():
+            if push.infra_fail:
                 busted.append(push)
             else:
                 break

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -4,7 +4,6 @@ import shutil
 import subprocess
 import traceback
 from collections import defaultdict
-from datetime import datetime, timedelta
 
 import newrelic
 import taskcluster
@@ -324,26 +323,6 @@ class TryPush(base.ProcessData):
             if item.status == "open":
                 return item
         raise ValueError("Got multiple syncs and none were open")
-
-    def expired(self):
-        now = taskcluster.fromNow("0 days")
-        created_date = None
-        is_expired = True
-        try:
-            if self.created:
-                created_date = datetime.strptime(self.created, tc._DATE_FMT)
-            else:
-                # for legacy pushes, save creation date from TaskCluster
-                task = tc.get_task(self.taskgroup_id)
-                if task and task.get("created"):
-                    self.created = task["created"]
-                    created_date = datetime.strptime(self.created, tc._DATE_FMT)
-        except ValueError:
-            logger.debug("Failed to determine creation date for %s" % self)
-        if created_date:
-            # try push created more than 14 days ago
-            is_expired = now > created_date + timedelta(days=14)
-        return is_expired
 
     @property
     def stability(self):


### PR DESCRIPTION
Now that we only do try pushes after the PR has merged, the idea of
expiring too-old try pushes doesn't make sense. This was also already
a bit broken since the expiration of the try push shouldn't matter
once we've started a landing, but we weren't considering that.