### PR TITLE
Don't exclude logs from metadata update for landing

### DIFF
--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -411,7 +411,7 @@ class TryPush(base.ProcessData):
                             "try", self.try_rev)
 
     @mut()
-    def download_logs(self, wpt_tasks, raw=True, report=True, exclude=None, first_only=False):
+    def download_logs(self, wpt_tasks, raw=True, report=True, first_only=False):
         """Download all the logs for the current try push
 
         :return: List of paths to raw logs
@@ -420,8 +420,7 @@ class TryPush(base.ProcessData):
         if hasattr(wpt_tasks, "wpt_tasks"):
             wpt_tasks = wpt_tasks.wpt_tasks
 
-        if exclude is None:
-            exclude = []
+        exclude = set()
 
         def included(t):
             # if a name is on the excluded list, only download SUCCESS job logs
@@ -432,7 +431,7 @@ class TryPush(base.ProcessData):
             # Add this name to exclusion list, so that we don't download the repeated run
             # logs in a stability try run
             if first_only and name is not None and name not in exclude:
-                exclude.append(name)
+                exclude.add(name)
 
             return output
 

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -175,7 +175,7 @@ def test_download_logs_after_retriggers_complete(git_gecko, git_wpt, landing_wit
                 try_push.download_logs = Mock(return_value=[])
                 try_push["stability"] = True
                 landing.try_push_complete(git_gecko, git_wpt, try_push, sync)
-        try_push.download_logs.assert_called_with(ANY, raw=False, report=True, exclude=["foo"])
+        try_push.download_logs.assert_called_with(ANY, raw=False, report=True)
         assert sync.status == "open"
         assert try_push.status == "complete"
 

--- a/test/test_try.py
+++ b/test/test_try.py
@@ -53,7 +53,7 @@ def test_retrigger_failures(mock_tasks, try_push):
     assert jobs == retrigger_count * len(set(failed + ex))
 
 
-def test_download_logs_excluded(mock_tasks, try_push):
+def test_download_logs(mock_tasks, try_push):
     failed = ["foo", "foo", "bar", "baz"]
     ex = ["bar", "boo"]
     tasks = Mock(return_value=mock_tasks(
@@ -65,12 +65,11 @@ def test_download_logs_excluded(mock_tasks, try_push):
             with patch.object(tc.TaskGroup, "tasks", property(tasks)):
                 with patch.object(tc.TaskGroupView, "download_logs", Mock()):
                     tasks = try_push.tasks()
-                    download_tasks = try_push.download_logs(tasks, exclude=["foo"])
+                    download_tasks = try_push.download_logs(tasks)
                     task_names = [t["task"]["metadata"]["name"] for t in download_tasks]
-                    assert task_names.count("foo") == 5
+                    assert task_names.count("foo") == 7
                     assert task_names.count("bar") == 7
                     assert task_names.count("woo") == 5
                     assert task_names.count("boo") == 1
                     assert task_names.count("baz") == 1
-                    assert len(task_names) == 19
-                    assert task_names.count("foo") == 5
+                    assert len(task_names) == 21


### PR DESCRIPTION
Previously we could exclude downloading logs for intermittent tests
because we didn't handle multiple results for the same test well. But
with --update-intermittents, we really want to download all the
logs. So remove the exclude list from the final metadata update.