### PR TITLE
Remove support for downloading raw logs

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -993,7 +993,7 @@ def try_push_complete(git_gecko, git_wpt, try_push, sync):
                 if tasks.has_failures():
                     if sync.affected_tests():
                         log_files = []
-                        wpt_tasks = try_push.download_logs(tasks.wpt_tasks, raw=False)
+                        wpt_tasks = try_push.download_logs(tasks.wpt_tasks)
                         for task in wpt_tasks:
                             for run in task.get("status", {}).get("runs", []):
                                 log = run.get("_log_paths", {}).get("wptreport.json")

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -1033,9 +1033,7 @@ def record_too_many_failures(sync, try_push):
 def update_metadata(sync, try_push, tasks=None):
     if tasks is None:
         tasks = try_push.tasks()
-    wpt_tasks = try_push.download_logs(tasks.wpt_tasks,
-                                       raw=False,
-                                       report=True)
+    wpt_tasks = try_push.download_logs(tasks.wpt_tasks)
     log_files = []
     for task in wpt_tasks:
         for run in task.get("status", {}).get("runs", []):

--- a/sync/notify/geckomsg.py
+++ b/sync/notify/geckomsg.py
@@ -321,8 +321,7 @@ def for_sync(sync):
     with try_push.as_mut(sync._lock):
         try_tasks = complete_try_push.tasks()
         try:
-            complete_try_push.download_logs(try_tasks.wpt_tasks, report=True, raw=False,
-                                            first_only=True)
+            complete_try_push.download_logs(try_tasks.wpt_tasks, first_only=True)
         except RetryableError:
             logger.warning("Downloading logs failed")
             return

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -390,10 +390,10 @@ class TryPush(base.ProcessData):
                             "try", self.try_rev)
 
     @mut()
-    def download_logs(self, wpt_tasks, raw=True, report=True, first_only=False):
-        """Download all the logs for the current try push
+    def download_logs(self, wpt_tasks, first_only=False):
+        """Download all the wptreport logs for the current try push
 
-        :return: List of paths to raw logs
+        :return: List of paths to logs
         """
         # Allow passing either TryPushTasks or the actual TaskGroupView
         if hasattr(wpt_tasks, "wpt_tasks"):
@@ -429,24 +429,9 @@ class TryPush(base.ProcessData):
 
         include_tasks = wpt_tasks.filter(included)
         logger.info("Downloading logs for try revision %s" % self.try_rev)
-        file_names = []
-        if raw:
-            file_names.append("wpt_raw.log")
-        if report:
-            file_names.append("wptreport.json")
+        file_names = ["wptreport.json"]
         include_tasks.download_logs(self.log_path(), file_names)
         return include_tasks
-
-    @mut()
-    def download_raw_logs(self, wpt_tasks, exclude=None):
-        wpt_tasks = self.download_logs(raw=True, report=True, exclude=exclude)
-        raw_logs = []
-        for task in wpt_tasks:
-            for run in task.get("status", {}).get("runs", []):
-                log = run.get("_log_paths", {}).get("wpt_raw.log")
-                if log:
-                    raw_logs.append(log)
-        return raw_logs
 
     @mut()
     def cleanup_logs(self):

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -175,7 +175,7 @@ def test_download_logs_after_retriggers_complete(git_gecko, git_wpt, landing_wit
                 try_push.download_logs = Mock(return_value=[])
                 try_push["stability"] = True
                 landing.try_push_complete(git_gecko, git_wpt, try_push, sync)
-        try_push.download_logs.assert_called_with(ANY, raw=False, report=True)
+        try_push.download_logs.assert_called_with(ANY)
         assert sync.status == "open"
         assert try_push.status == "complete"
 


### PR DESCRIPTION
These are giant and we now always use wptreport.json instead