### PR TITLE
Use Trusty Ubuntu distribution to speed up tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 python:
   - "2.7.14"

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -61,6 +61,8 @@ mock==3.0.5 \
     --hash=sha256:d157e52d4e5b938c550f39eb2fd15610db062441a9c2747d3dbfa9298211d0f8
 mohawk==1.0.0 \
     --hash=sha256:aa57e6626a6ea323ab714779f23734de1d1feca8cb6fc00b65e65ce115c1696a
+more_itertools==5.0.0 \
+    --hash=sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc
 newrelic==5.2.1.129 \
     --hash=sha256:da9adab674d9fe7aa8fbabb6691b33fb7be94a32b6a80548ec7018be9df8ef65
 pathlib2==2.3.5 \


### PR DESCRIPTION
It seems as though the change to the Xenial distribution of Ubuntu as
the default distribution for Travis made our tests run slower. This
should resolve that issue by locking the Ubuntu version to the Trust
version.

(Also more_itertools seems to have become a dependency due to locking the version)