### PR TITLE
Add support for accessing wpt-metadata repo directly

### DIFF
--- a/sync/meta.py
+++ b/sync/meta.py
@@ -1,0 +1,157 @@
+import git
+
+import log
+import repos
+import worktree
+import wptmeta
+
+from env import Environment
+from base import CommitBuilder
+from lock import mut, MutGuard
+
+
+env = Environment()
+logger = log.get_logger(__name__)
+
+
+class GitReader(wptmeta.Reader):
+    """Reader that works with a Git repository (without a worktree)"""
+
+    def __init__(self, repo):
+        self.repo = repo
+        self.repo.remotes.origin.fetch()
+        self.pygit2_repo = repos.pygit2_get(repo)
+        self.rev = self.pygit2_repo.revparse_single("origin/master")
+
+    def exists(self, rel_path):
+        return rel_path in self.rev.tree
+
+    def read_path(self, rel_path):
+        entry = self.rev.tree[rel_path]
+        return self.pygit2_repo[entry.id].read_raw()
+
+
+class GitWriter(wptmeta.Writer):
+    """Writer that works with a Git repository (without a worktree)"""
+
+    def __init__(self, builder):
+        self.builder = builder
+
+    def write(self, rel_path, data):
+        self.builder.add_tree({rel_path: data})
+
+
+class NullWriter(object):
+    def write(self, rel_path):
+        raise NotImplementedError
+
+
+class Metadata(object):
+    def __init__(self, process_name):
+        """Object for working with a wpt-metadata repository without requiring
+        a worktree.
+
+        Data is read directly from blobs and changes are represented
+        as commits to the master branch. On update changes are
+        automatically pushed to the remote origin, and conflicts are
+        automatically handled with a retry algorithm.
+
+        This implements the usual locking mechanism and writes occur
+        when leaving the mutable scope.
+
+        :param process_name: ProcessName object for the metadata. This
+                             will typically be the process name of an
+                             in-progress sync, used to lock the
+                             metadata for update."""
+
+        self.process_name = process_name
+        self._lock = None
+        meta_repo = repos.WptMetadata(env.config)
+        self.repo = meta_repo.repo()
+        self.pygit2_repo = repos.pygit2_get(self.repo)
+
+        self.git_reader = GitReader(self.repo)
+        self.null_writer = NullWriter()
+        self.metadata = wptmeta.WptMetadata(self.git_reader,
+                                            self.null_writer)
+
+        self.worktree = worktree.Worktree(self.repo, self.process_name)
+        self.git_work = None
+
+    def _push(self):
+        raise NotImplementedError
+
+    def as_mut(self, lock):
+        return MutGuard(lock, self)
+
+    @classmethod
+    def for_sync(cls, sync):
+        return cls(sync.process_name)
+
+    @property
+    def lock_key(self):
+        return (self.process_name.subtype, self.process_name.obj_id)
+
+    def exit_mut(self):
+        ref_name = str(self.process_name)
+        message = "Gecko sync update"
+        retry = 0
+        MAX_RETRY = 5
+        while retry < MAX_RETRY:
+            self.repo.remotes.origin.fetch()
+            self.pygit2_repo.create_reference(ref_name,
+                                              self.pygit2_repo.revparse_single(
+                                                  "origin/master").id,
+                                              True)
+            commit_builder = CommitBuilder(self.repo,
+                                           message,
+                                           ref=ref_name)
+            with commit_builder as builder:
+                self.metadata.writer = GitWriter(builder)
+                self.metadata.write()
+            logger.info("Created metadata commit %s" % commit_builder.commit.sha1)
+            try:
+                self.repo.remotes.origin.push("%s:master" % ref_name)
+            except git.GitCommandError as e:
+                changes = self.repo.remotes.origin.fetch()
+                err = "Pushing update to remote failed:\n%s" % e
+                if not changes:
+                    logger.error(err)
+                    raise
+            else:
+                break
+            retry += 1
+
+        if retry == MAX_RETRY:
+            logger.error("Updating metdata failed")
+            raise
+        self.pygit2_repo.references.delete(ref_name)
+        self.metadata.writer = NullWriter
+
+    @mut()
+    def link_bug(self, test_id, bug_url, product="firefox", subtest=None, status=None):
+        """Add a link to a bug to the metadata
+
+        :param test_id: id of the test for which the link applies
+        :param bug_url: url of the bug to link to
+        "param product: product for which the link applies
+        :param subtest: optional subtest for which the link applies
+        :param status: optional status for which the link applies"""
+        self.metadata.append_link(bug_url,
+                                  product=product,
+                                  test_id=test_id,
+                                  subtest=subtest,
+                                  status=status)
+
+    def iterbugs(self,
+                 test_id,
+                 product="firefox",
+                 prefixes=("https://bugzilla.mozilla.org",
+                           "https://github.com/wpt/web-platform-tests"),
+                 subtest=None, status=None):
+        for item in self.metadata.iterlinks(test_id=test_id,
+                                            product=product,
+                                            subtest=subtest,
+                                            status=status):
+            if any(item.url.startswith(prefix) for prefix in prefixes):
+                yield item

--- a/sync/repos.py
+++ b/sync/repos.py
@@ -78,6 +78,11 @@ class WebPlatformTests(GitSettings):
     fetch_args = ["origin", "master", "--no-tags"]
 
 
+class WptMetadata(GitSettings):
+    name = "wpt-metadata"
+    fetch_args = ["origin", "master", "--no-tags"]
+
+
 class Cinnabar(object):
     hg2git_cache = {}
     git2hg_cache = {}
@@ -105,6 +110,7 @@ class Cinnabar(object):
 wrappers = {
     "gecko": Gecko,
     "web-platform-tests": WebPlatformTests,
+    "wpt-metadata": WptMetadata,
 }
 
 

--- a/sync/wptmeta/__init__.py
+++ b/sync/wptmeta/__init__.py
@@ -1,0 +1,345 @@
+import urlparse
+import os
+from abc import ABCMeta, abstractmethod
+from collections import OrderedDict, namedtuple
+from copy import deepcopy
+
+import yaml
+from six import iteritems, itervalues
+
+"""Module for interacting with a web-platform-tests metadata repository"""
+
+
+class DeleteTrackingList(list):
+    """A list that holds a reference to any elements that are removed"""
+
+    def __init__(self, *args, **kwargs):
+        self._deleted = []
+        super(DeleteTrackingList, self).__init__(*args, **kwargs)
+
+    def __setitem__(self, index, value):
+        self._dirty = True
+        super(DeleteTrackingList, self).__setitem__(index, value)
+
+    def __setslice__(self, index0, index1, value):
+        self.deleted.extend(self[index0:index1])
+        super(DeleteTrackingList, self).__setslice__(index0, index1, value)
+
+    def __delitem__(self, index):
+        self.deleted.append(self[index]._initial_state)
+        super(DeleteTrackingList, self).__delitem__(index)
+
+    def __delslice__(self, index0, index1):
+        self.deleted.extend(self[index0:index1])
+        super(DeleteTrackingList, self).__delslice__(index0, index1)
+
+    def pop(self):
+        rv = super(DeleteTrackingList, self).pop()
+        self._deleted.append(rv)
+        return rv
+
+    def remove(self, item):
+        try:
+            return super(DeleteTrackingList, self).remove(item)
+        finally:
+            self._deleted.append(item)
+
+
+def parse_test(test_id):
+    id_parts = urlparse.urlsplit(test_id)
+    dir_name, test_file = id_parts.path.rsplit("/", 1)
+    if dir_name[0] == "/":
+        dir_name = dir_name[1:]
+    test_name = urlparse.urlunsplit((None, None, test_file, id_parts.query,
+                                     id_parts.fragment))
+    return dir_name, test_name
+
+
+class Reader(object):
+    __metaclass__ = ABCMeta
+
+    """Class implementing read operations on paths"""
+
+    @abstractmethod
+    def read_path(self, rel_path):
+        """Read the contents of `rel_path` as a bytestring
+
+        :param rel_path` Relative path to read
+        :returns: Bytes containing path contents
+        """
+        pass
+
+    @abstractmethod
+    def exists(self, rel_path):
+        """Determine if `rel_path` is a valid path
+
+        :param rel_path` Relative path
+        :returns: Boolean indicating if `rel_path` is a valid path"""
+        pass
+
+
+class Writer(object):
+    __metaclass__ = ABCMeta
+
+    """Class implementing write operations on paths"""
+
+    def write(self, rel_path, data):
+        """Write `data` to the object at `rel_path`
+
+        :param rel_path` Relative path to object
+        :param data: Bytes containing data to write
+        """
+        pass
+
+
+class FilesystemReader(Reader):
+    """Reader implementation operating on filesystem files"""
+
+    def __init__(self, root):
+        self.root = root
+
+    def read_path(self, rel_path):
+        path = os.path.join(self.root, rel_path)
+        with open(path) as f:
+            return f.read()
+
+    def exists(self, rel_path):
+        return os.path.exists(os.path.join(self.root, rel_path))
+
+
+class FilesystemWriter(Writer):
+    """Writer implementation operating on filesystem files"""
+
+    def __init__(self, root):
+        self.root = root
+
+    def write(self, rel_path, data):
+        path = os.path.join(self.root, rel_path)
+        with open(path, "w") as f:
+            return f.write(data)
+
+
+def metadata_directory(root):
+    reader = FilesystemReader(root)
+    writer = FilesystemWriter(root)
+    return WptMetadata(reader, writer)
+
+
+class WptMetadata(object):
+    def __init__(self, reader, writer):
+        """Object for working with a wpt-metadata tree
+
+        :param reader: Object implementing Reader
+        :param writer: Object implementing Writer"""
+        self.reader = reader
+        self.writer = writer
+        self.loaded = {}
+
+    def iterlinks(self, test_id, product=None, subtest=None, status=None):
+        """Get the metadata for a specific test"""
+        assert test_id.startswith("/")
+        dir_name, _ = parse_test(test_id)
+        if dir_name not in self.loaded:
+            self.loaded[dir_name] = MetaFile(self, dir_name)
+
+        return self.loaded[dir_name].iterlinks(product=product,
+                                               test_id=test_id,
+                                               subtest=None,
+                                               status=None)
+
+    def write(self):
+        """Write any updated metadata to the metadata tree"""
+        rv = []
+        for meta_file in itervalues(self.loaded):
+            if meta_file.write():
+                rv.append(meta_file.rel_path)
+        return rv
+
+    def append_link(self, url, product, test_id, subtest=None, status=None):
+        """Add a link to the metadata tree
+
+        :param url: URL to link to
+        :param product: Product for which the link is relevant
+        :param test_id: Full test id for which the link is relevant
+        :param subtest: Subtest for which the link is relevant or
+                        None to apply to parent/all tests
+        :param status: Result status for which the link is relevant or
+                       None to apply to all statuses"""
+        assert test_id.startswith("/")
+        dir_name, test_name = parse_test(test_id)
+        if dir_name not in self.loaded:
+            self.loaded[dir_name] = MetaFile(self, dir_name)
+        meta_file = self.loaded[dir_name]
+        link = MetaLink(meta_file, url, product, test_id, subtest, status)
+        meta_file.links.append(link)
+
+
+class MetaFile(object):
+    def __init__(self, owner, dir_name):
+        """Object representing a single META.yml file
+
+        This uses an unusual algorithm for updated; first we reread
+        the underlying data, then we apply changes that have been made
+        locally on top of the re-read data. This allows the changes to
+        be applied in the face of multiple writers without locking or
+        generating conflicts that require human resolution. However
+        the algorithm is not perfect; for example an entry that's
+        deleted remotely may be readded if it has local modifications;
+        that may or may not be correct depending on the situation.
+
+        :param owner: The parent WptMetadata object
+        :param dir_name: The relative path to the directory containing the
+                         META.yml file
+        """
+
+        self.owner = owner
+        self._file_data = None
+
+        self.dir_name = dir_name
+        dir_path = dir_name.replace("/", os.path.sep)
+        self.rel_path = os.path.join(dir_path, "META.yml")
+
+        self.links = DeleteTrackingList()
+
+        self._file_data = self._load_file(self.rel_path)
+
+        for link in self._file_data.get("links", []):
+            for result in link.get("results", []):
+                self.links.append(MetaLink.from_file_data(self, link, result))
+
+    def _load_file(self, rel_path):
+        if self.owner.reader.exists(rel_path):
+            data = yaml.safe_load(self.owner.reader.read_path(rel_path))
+        else:
+            data = {}
+        return data
+
+    def iterlinks(self, product=None, test_id=None, subtest=None, status=None):
+        """Iterator over all links in the file, filtered by arguments"""
+        for item in self.links:
+            if ((product is None or
+                 item.product.startswith(product)) and
+                (test_id is None or
+                 item.test_id == test_id) and
+                (subtest is None or
+                 item.subtest == subtest) and
+                (status is None or
+                 item.status == status)):
+                yield item
+
+    def write(self, reread=True):
+        """Write the updated data to the underlying META.yml
+
+        :param reread: Reread the underlying data before applying changes
+        """
+        data = self._get_data(reread)
+        self._update_data(data)
+
+        self.owner.writer.write(self.rel_path, yaml.safe_dump(data))
+
+        self._file_data = data
+        self.links._deleted = []
+        for link in self.links:
+            link._initial_state = link.state
+        return True
+
+    def _get_data(self, reread=True):
+        if not reread:
+            data = deepcopy(self._file_data)
+        else:
+            data = self._load_file(self.rel_path)
+
+        return data
+
+    def _update_data(self, data):
+        links_by_state = OrderedDict()
+
+        for item in data.get("links", []):
+            url = item.get("url")
+            product = item.get("product")
+            for result in item["results"]:
+                test_id = "/%s/%s" % (self.dir_name, result.get("test"))
+                subtest = result.get("subtest")
+                status = result.get("status")
+                links_by_state[LinkState(url, product, test_id, subtest, status)] = (
+                    LinkState(url, product, test_id, subtest, status))
+
+        # Remove deletions first so that delete and readd works
+        for item in self.links._deleted:
+            if item._initial_state in links_by_state:
+                del links_by_state[item._initial_state]
+
+        for item in self.links:
+            if item._initial_state in links_by_state:
+                links_by_state[item._initial_state] = item.state
+            else:
+                links_by_state[item.state] = item.state
+
+        by_link = OrderedDict()
+        for link in itervalues(links_by_state):
+            result = {}
+            test_id = link.test_id
+            if test_id is not None:
+                _, test = parse_test(test_id)
+                result["test"] = test
+            for prop in ["subtest", "status"]:
+                value = getattr(link, prop)
+                if value is not None:
+                    result[prop] = value
+            key = (link.url, link.product)
+            if key not in by_link:
+                by_link[key] = []
+            by_link[key].append(result)
+
+        links = []
+
+        for (url, product), results in iteritems(by_link):
+            links.append({"url": url,
+                          "product": product,
+                          "results": results})
+        data["links"] = links
+
+        return data
+
+
+LinkState = namedtuple("LinkState", ["url", "product", "test_id", "subtest", "status"])
+
+
+class MetaLink(object):
+    def __init__(self, meta_file, url, product, test_id=None, subtest=None, status=None):
+        """A single link object"""
+        assert test_id.startswith("/")
+        self.meta_file = meta_file
+        self.url = url
+        self.product = product
+        self.test_id = test_id
+        self.subtest = subtest
+        self.status = status
+        self._initial_state = None
+
+    @classmethod
+    def from_file_data(cls, meta_file, link, result):
+        url = link.get("url")
+        product = link.get("product")
+        test_id = "/%s/%s" % (meta_file.dir_name, result.get("test"))
+        status = result.get("status")
+        subtest = result.get("subtest")
+        self = cls(meta_file, url, product, test_id, subtest, status)
+        self._initial_state = self.state
+        return self
+
+    @property
+    def state(self):
+        return LinkState(self.url,
+                         self.product,
+                         self.test_id,
+                         self.subtest,
+                         self.status)
+
+    def __repr__(self):
+        data = (self.__class__.__name__,) + self.state
+        return "<%s url:%s product:%s test:%s subtest:%s status:%s>" % data
+
+    def delete(self):
+        """Remove the link from the owning file"""
+        self.meta_file.links.remove(self)

--- a/test/config/sync.ini
+++ b/test/config/sync.ini
@@ -38,6 +38,15 @@ github.user = moz-wptsync-bot
 path = %ROOT%/remotes/web-platform-tests
 github.checks.enabled=1
 
+[wpt-metadata]
+repo.url = %ROOT%/remotes/wpt-metadata
+repo.remote.origin = %ROOT%/remotes/wpt-metadata
+github.token = blah
+github.user = moz-wptsync-bot
+# for testing only
+path = %ROOT%/remotes/wpt-metadata
+github.checks.enabled=1
+
 [bugzilla]
 url = https://bugzilla-dev.allizom.org/rest
 

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -1,0 +1,84 @@
+from sync import wptmeta
+from sync.base import ProcessName
+from sync.meta import GitReader, NullWriter, Metadata
+from sync.lock import SyncLock
+
+
+def test_read(git_wpt_metadata):
+    reader = GitReader(git_wpt_metadata)
+    writer = NullWriter()
+
+    meta = wptmeta.WptMetadata(reader, writer)
+    links = list(meta.iterlinks("/example/test.html"))
+    assert len(links) == 1
+
+    assert links[0].url.startswith("https://bugzilla.mozilla.org")
+    assert links[0].product == "firefox"
+    assert links[0].test_id == "/example/test.html"
+    assert links[0].subtest is None
+    assert links[0].status is None
+
+
+def test_add(git_wpt_metadata):
+    process_name = ProcessName("sync", "downstream", "1234", 0)
+    meta = Metadata(process_name)
+    assert len(list(meta.metadata.iterlinks("/example/test.html"))) == 1
+
+    with SyncLock.for_process(process_name) as lock:
+        with meta.as_mut(lock):
+            meta.link_bug("/example/test.html",
+                          "https://bugzilla.mozilla.org/show_bug.cgi?id=2345",
+                          product="firefox")
+            meta.link_bug("/example-1/test.html",
+                          "https://bugzilla.mozilla.org/show_bug.cgi?id=3456",
+                          product="firefox")
+
+    assert len(list(meta.iterbugs("/example/test.html"))) == 2
+    assert len(list(meta.iterbugs("/example-1/test.html"))) == 1
+
+    # Arrange to reread the metadata from origin/master
+    meta = Metadata(process_name)
+    links = list(meta.iterbugs("/example/test.html"))
+    assert len(links) == 2
+    assert links[0].test_id == "/example/test.html"
+    assert links[0].url == "https://bugzilla.mozilla.org/show_bug.cgi?id=1234"
+    assert links[1].test_id == "/example/test.html"
+    assert links[1].url == "https://bugzilla.mozilla.org/show_bug.cgi?id=2345"
+
+    links_1 = list(meta.iterbugs("/example-1/test.html"))
+    assert len(links_1) == 1
+    assert links_1[0].test_id == "/example-1/test.html"
+    assert links_1[0].url == "https://bugzilla.mozilla.org/show_bug.cgi?id=3456"
+
+
+def test_update(git_wpt_metadata):
+    process_name = ProcessName("sync", "downstream", "1234", 0)
+    meta = Metadata(process_name)
+    links = list(meta.metadata.iterlinks("/example/test.html"))
+    assert len(links) == 1
+    assert links[0].url == "https://bugzilla.mozilla.org/show_bug.cgi?id=1234"
+
+    with SyncLock.for_process(process_name) as lock:
+        with meta.as_mut(lock):
+            links[0].url = "https://bugzilla.mozilla.org/show_bug.cgi?id=2345"
+
+    meta = Metadata(process_name)
+    links = list(meta.iterbugs("/example/test.html"))
+    assert links[0].test_id == "/example/test.html"
+    assert links[0].url == "https://bugzilla.mozilla.org/show_bug.cgi?id=2345"
+
+
+def test_delete(git_wpt_metadata):
+    process_name = ProcessName("sync", "downstream", "1234", 0)
+    meta = Metadata(process_name)
+    links = list(meta.metadata.iterlinks("/example/test.html"))
+    assert len(links) == 1
+    assert links[0].url == "https://bugzilla.mozilla.org/show_bug.cgi?id=1234"
+
+    with SyncLock.for_process(process_name) as lock:
+        with meta.as_mut(lock):
+            links[0].delete()
+
+    meta = Metadata(process_name)
+    links = list(meta.iterbugs("/example/test.html"))
+    len(links) == 0

--- a/test/testdata/wpt_metadata_config
+++ b/test/testdata/wpt_metadata_config
@@ -1,0 +1,8 @@
+[core]
+    repositoryformatversion = 0
+    filemode = true
+    bare = true
+[remote "origin"]
+    url = /app/testdata/remotes/wpt-metadata
+    fetch = +refs/heads/*:refs/remotes/origin/*
+    fetch = +refs/pull/*/head:refs/remotes/origin/pr/*


### PR DESCRIPTION
wpt-metadata is a repo containing YAML files. Since we already have
good support for working with git repos, it makes sense to expediate
our ability to edit this data by supporting direct reads and writes
from the repository rather than needing to go via a wpt.fyi API.

The write support is designed to commit changes lazilly. This means
that we should be able to avoid text-based merge resolution by running
an algorithm where we pull the latest version of the upstream, apply
our edits, and then push. If the push fails due to conflicts we pull
again and retry.

So far this isn't wired up to any users in the repository; it will
eventually be used to support filing bugs for untriaged failures, and
for ensuring that the triage data is kept up to date with bugzilla
changes.