### PR TITLE
Don't run aarch64 for initial landing try push.

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -630,6 +630,14 @@ MANUAL PUSH: wpt sync bot
             stability = (latest_try_push is not None and
                          not latest_try_push.infra_fail)
 
+        queries = ["web-platform-tests !devedition !ccov !fis",
+                   "web-platform-tests fis !devedition !ccov !asan !aarch64 "
+                   "windows10 | linux64"]
+
+        # aarch64 is very resource constrained so only run on stability push
+        if not stability:
+            queries[0] += " !aarch64"
+
         trypush.TryPush.create(self._lock,
                                self,
                                hacks=False,
@@ -637,9 +645,7 @@ MANUAL PUSH: wpt sync bot
                                rebuild_count=0,
                                try_cls=trypush.TryFuzzyCommit,
                                full=True,
-                               queries=["web-platform-tests !devedition !ccov !fis",
-                                        "web-platform-tests fis !devedition !ccov !asan !aarch64 "
-                                        "windows10 | linux64"])
+                               queries=queries)
 
 
 def push(landing):

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -61,7 +61,7 @@ def test_land_try(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_p
                                     "fuzzy",
                                     "--artifact",
                                     "-q",
-                                    "web-platform-tests !devedition !ccov !fis",
+                                    "web-platform-tests !devedition !ccov !fis !aarch64",
                                     "-q",
                                     "web-platform-tests fis !devedition !ccov !asan !aarch64 "
                                     "windows10 | linux64",


### PR DESCRIPTION
We are commonly waiting 5+ hours for these results, which delays landing
by a long time. Just doing a single run in this configuration should be enough