### PR TITLE
Support getting data from old TaskCluster

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -673,6 +673,9 @@ def mock_taskgroup(tc_response):
             with requests_mock.Mocker() as m:
                 taskgroup_id = "test"
                 m.register_uri("GET",
+                               "%stask/%s" % (tc.QUEUE_BASE, taskgroup_id),
+                               body=None)
+                m.register_uri("GET",
                                "%stask-group/%s/list" % (tc.QUEUE_BASE, taskgroup_id),
                                body=f)
                 taskgroup = tc.TaskGroup(taskgroup_id)


### PR DESCRIPTION
When migrating to the new taskcluster, I forgot that we still needed read access to the
old taskcluster for try jobs that have already run. This patch adds a check that a given taskId
is accessible on each TaskCluster instance before deciding which queue or index to use.