### PR TITLE
Improve the error handling for updating try pushes after landing.

### DIFF
--- a/config/dev/sync.ini
+++ b/config/dev/sync.ini
@@ -32,6 +32,7 @@ logs.max-count = 20
 try.max-tests = 500
 try.stability_count = 5
 upstream.needinfo-users=example@example.org,
+landing.needinfo-users=example@example.org,
 
 [web-platform-tests]
 repo.url = %ROOT%/remotes/web-platform-tests

--- a/config/dev/sync.ini
+++ b/config/dev/sync.ini
@@ -31,8 +31,8 @@ worktree.max-count = 10
 logs.max-count = 20
 try.max-tests = 500
 try.stability_count = 5
-upstream.needinfo-users=example@example.org,
-landing.needinfo-users=example@example.org,
+needinfo.upstream=example@example.org,
+needinfo.landing=example@example.org,
 
 [web-platform-tests]
 repo.url = %ROOT%/remotes/web-platform-tests

--- a/sync/bug.py
+++ b/sync/bug.py
@@ -400,9 +400,12 @@ class MockBugContext(object):
     def __init__(self, bugzilla, bug_id):
         self.bugzilla = bugzilla
         self.bug_id = bug_id
+        self.changes = None
+        self.comment = None
 
     def __enter__(self):
         self.changes = []
+        self.comment = None
         return self
 
     def __exit__(self, *args, **kwargs):

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -1082,8 +1082,8 @@ def try_push_complete(git_gecko, git_wpt, try_push, sync, allow_push=True,
 
 def needinfo_users():
     needinfo_users = [item.strip() for item in
-                      (env.config["gecko"]["landing"]
-                       .get("needinfo-users", "")
+                      (env.config["gecko"]["needinfo"]
+                       .get("landing", "")
                        .split(","))]
     return [item for item in needinfo_users if item]
 

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -616,7 +616,6 @@ MANUAL PUSH: wpt sync bot
             return
         sync_point["upstream"] = new_sha1
         gecko_work = self.gecko_worktree.get()
-        sync_point["local"] = gecko_work.head.commit.hexsha
         with open(os.path.join(gecko_work.working_dir,
                                env.config["gecko"]["path"]["meta"],
                                "mozilla-sync"), "w") as f:

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -796,8 +796,8 @@ def update_modified_sync(git_gecko, git_wpt, sync):
                                           "merge conflicts. This requires fixup from a wpt sync "
                                           "admin.")
                         needinfo_users = [item.strip() for item in
-                                          (env.config["gecko"]["upstream"]
-                                           .get("needinfo-users", "")
+                                          (env.config["gecko"]["needinfo"]
+                                           .get("upstream", "")
                                            .split(","))]
                         needinfo_users = [item for item in needinfo_users if item]
                         bug.needinfo(*needinfo_users)

--- a/sync_prod.ini
+++ b/sync_prod.ini
@@ -43,13 +43,18 @@ enabled.landing=
 repo.autoland=
 repo.mozilla-inbound=
 repo.mozilla-central=
-landing = mozilla-inbound
+landing = autoland
 refs.central = mozilla/central
 refs.mozilla-inbound = mozilla/inbound
 refs.autoland = autoland/branches/default/tip
 path.wpt = testing/web-platform/tests
 path.meta = testing/web-platform/meta
+worktree.max-count = 10
+logs.max-count = 20
 try.stability_count = 5
+try.max-tests = 500
+upstream.needinfo-users=wptsync@mozilla.bugs,
+landing.needinfo-users=wptsync@mozilla.bugs,
 
 [web-platform-tests]
 # See also wpt_config file

--- a/sync_prod.ini
+++ b/sync_prod.ini
@@ -53,8 +53,8 @@ worktree.max-count = 10
 logs.max-count = 20
 try.stability_count = 5
 try.max-tests = 500
-upstream.needinfo-users=wptsync@mozilla.bugs,
-landing.needinfo-users=wptsync@mozilla.bugs,
+needinfo.upstream=wptsync@mozilla.bugs,
+needinfo.landing=wptsync@mozilla.bugs,
 
 [web-platform-tests]
 # See also wpt_config file

--- a/test/config/sync.ini
+++ b/test/config/sync.ini
@@ -28,6 +28,8 @@ refs.autoland = mozilla/bookmarks/mozilla/autoland
 path.wpt = testing/web-platform/tests
 path.meta = testing/web-platform/meta
 try.stability_count = 5
+upstream.needinfo-users=example@example.org,
+landing.needinfo-users=example@example.org,
 
 [web-platform-tests]
 repo.url = %ROOT%/remotes/web-platform-tests

--- a/test/config/sync.ini
+++ b/test/config/sync.ini
@@ -28,8 +28,8 @@ refs.autoland = mozilla/bookmarks/mozilla/autoland
 path.wpt = testing/web-platform/tests
 path.meta = testing/web-platform/meta
 try.stability_count = 5
-upstream.needinfo-users=example@example.org,
-landing.needinfo-users=example@example.org,
+oneedinfo.upstream=example@example.org,
+needinfo.landing=example@example.org,
 
 [web-platform-tests]
 repo.url = %ROOT%/remotes/web-platform-tests

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -108,7 +108,6 @@ def test_land_commit(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, se
     assert "Update web-platform-tests to %s" % head_rev in new_head.message
     assert new_head.tree["testing/web-platform/tests/README"].data_stream.read() == "example_change"
     sync_point = landing.load_sync_point(git_gecko, git_wpt)
-    assert sync_point["local"] == new_head.parents[0].hexsha
     assert sync_point["upstream"] == head_rev
     # Update central to contain the landing
     git_gecko.refs["mozilla/bookmarks/mozilla/central"].commit = new_head


### PR DESCRIPTION
Don't abort early in case we have a complete try push, and ensure that
in the case of error we always add a comment to the bug so that it's
clear something has gone wrong.