### PR TITLE
Quick hack to stop retriggering aarch64 jobs

### DIFF
--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -491,7 +491,11 @@ class TryPushTasks(object):
             states = task_data["states"]
             return states[tc.FAIL] > 0 or states[tc.EXCEPTION] > 0
 
-        failures = [data["task_id"] for name, data in task_states.iteritems() if is_failure(data)]
+        def is_excluded(name):
+            return "-aarch64" in name
+
+        failures = [data["task_id"] for name, data in task_states.iteritems()
+                    if is_failure(data) and not is_excluded(name)]
         retriggered_count = 0
         for task_id in failures:
             jobs = auth_tc.retrigger(task_id, count=count)

--- a/test/test_try.py
+++ b/test/test_try.py
@@ -37,7 +37,7 @@ def test_try_task_states_all_success(mock_tasks, try_push):
 
 
 def test_retrigger_failures(mock_tasks, try_push):
-    failed = ["foo", "foo", "bar", "baz"]
+    failed = ["foo", "foo", "bar", "baz", "foo-aarch64"]
     ex = ["bar", "boo", "bork"]
     tasks = Mock(return_value=mock_tasks(
         completed=["foo", "bar"] * 5, failed=failed, exception=ex
@@ -50,7 +50,7 @@ def test_retrigger_failures(mock_tasks, try_push):
                            return_value=["job"] * retrigger_count):
                     tasks = try_push.tasks()
                     jobs = tasks.retrigger_failures(count=retrigger_count)
-    assert jobs == retrigger_count * len(set(failed + ex))
+    assert jobs == retrigger_count * (len(set(failed + ex)) - 1)
 
 
 def test_download_logs(mock_tasks, try_push):


### PR DESCRIPTION
This platform is very capacity limited and Tier2 so we should be less worried about intermittents there.
To improve our e2e time, don't do multiple retriggers on that platform but just use a single result.