### PR TITLE
Enable pushing to phabriactor using moz-phab

### DIFF
--- a/config/dev/sync.ini
+++ b/config/dev/sync.ini
@@ -32,6 +32,7 @@ logs.max-count = 20
 try.max-tests = 500
 try.stability_count = 5
 upstream.needinfo-users=example@example.org,
+landing.needinfo-users=example@example.org,
 
 [web-platform-tests]
 repo.url = %ROOT%/remotes/web-platform-tests

--- a/config/dev/sync.ini
+++ b/config/dev/sync.ini
@@ -31,8 +31,8 @@ worktree.max-count = 10
 logs.max-count = 20
 try.max-tests = 500
 try.stability_count = 5
-upstream.needinfo-users=example@example.org,
-landing.needinfo-users=example@example.org,
+needinfo.upstream=example@example.org,
+needinfo.landing=example@example.org,
 
 [web-platform-tests]
 repo.url = %ROOT%/remotes/web-platform-tests

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -27,10 +27,13 @@ RUN set -eux; \
         python \
         python-virtualenv \
         python-pip \
+        python3 \
+        python3-pip \
         sudo \
         wget \
         ;\
-    pip install --upgrade pip
+    pip install --upgrade pip;\
+    pip3 install --upgrade pip
 
 RUN set -eux; \
     count=0; \
@@ -115,6 +118,10 @@ RUN git clone https://github.com/glandium/git-cinnabar.git . \
     && git checkout origin/release; \
     pip install --user requests \
     && git cinnabar download
+
+# Install mozphab
+RUN pip3 install --user MozPhab
+ENV PATH=/app/.local/bin:$PATH
 
 # Install fzf for mach try fuzzy
 WORKDIR /app/fzf

--- a/docker/start_wptsync.sh
+++ b/docker/start_wptsync.sh
@@ -89,6 +89,15 @@ elif [ "$1" == "--worker" ]; then
     set -x
     export NEW_RELIC_CONFIG_FILE=/app/config/newrelic.ini
 
+    echo '{
+  "hosts": {
+    "https://phabricator.services.mozilla.com/api/": {
+      "token": "'$(/app/get_ini.py /app/config/prod/credentials.ini phabricator token)'"
+    }
+  }
+}' > ~/.arcrc
+
+
     # TODO: need to configure the API key correctly to record deploys
     # newrelic-admin record-deploy ${NEW_RELIC_CONFIG_FILE} $(git --git-dir=/app/wpt-sync/.git rev-parse HEAD)
 

--- a/sync/bug.py
+++ b/sync/bug.py
@@ -400,9 +400,12 @@ class MockBugContext(object):
     def __init__(self, bugzilla, bug_id):
         self.bugzilla = bugzilla
         self.bug_id = bug_id
+        self.changes = None
+        self.comment = None
 
     def __enter__(self):
         self.changes = []
+        self.comment = None
         return self
 
     def __exit__(self, *args, **kwargs):

--- a/sync/command.py
+++ b/sync/command.py
@@ -280,7 +280,7 @@ def do_landing(git_gecko, git_wpt, *args, **kwargs):
             try_push = current_landing.latest_try_push
             logger.info("Found try push %s" % try_push.treeherder_url)
             if try_push.taskgroup_id is None:
-                update.update_taskgroup_ids(git_gecko, git_wpt)
+                update.update_taskgroup_ids(git_gecko, git_wpt, try_push)
                 assert try_push.taskgroup_id is not None
             with try_push.as_mut(lock), current_landing.as_mut(lock):
                 tasks = try_push.tasks()
@@ -303,13 +303,7 @@ def do_landing(git_gecko, git_wpt, *args, **kwargs):
                 elif try_push.status == "complete" and not try_push.infra_fail:
                     update_landing()
                     if current_landing.latest_try_push == try_push:
-                        landing.try_push_complete(git_gecko,
-                                                  git_wpt,
-                                                  try_push,
-                                                  current_landing,
-                                                  allow_push=kwargs["push"],
-                                                  accept_failures=accept_failures,
-                                                  tasks=tasks)
+                        landing.push_to_gecko(git_gecko, git_wpt, current_landing)
                 elif try_push.status == "complete":
                     if kwargs["retry"]:
                         update_landing()

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -1017,8 +1017,8 @@ def try_push_complete(git_gecko, git_wpt, try_push, sync, allow_push=True,
 
 def needinfo_users():
     needinfo_users = [item.strip() for item in
-                      (env.config["gecko"]["landing"]
-                       .get("needinfo-users", "")
+                      (env.config["gecko"]["needinfo"]
+                       .get("landing", "")
                        .split(","))]
     return [item for item in needinfo_users if item]
 

--- a/sync/projectutil.py
+++ b/sync/projectutil.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 import os
+import re
 import shutil
 import subprocess
 import types
@@ -77,6 +78,19 @@ class Mach(Command):
 class WPT(Command):
     def __init__(self, path):
         Command.__init__(self, "wpt", path)
+
+
+class MozPhab(Command):
+    def __init__(self, path):
+        Command.__init__(self, "moz-phab", path)
+
+    def find_url(self, data):
+        """Get the last phabricator URL from the output, on the basis that's likely the URL for the
+        review"""
+        phab_re = re.compile(r"https://phabricator.services.mozilla.com/D\d+")
+        matches = phab_re.findall(data)
+        if matches:
+            return matches[-1]
 
 
 def create_mock(name):

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -796,8 +796,8 @@ def update_modified_sync(git_gecko, git_wpt, sync):
                                           "merge conflicts. This requires fixup from a wpt sync "
                                           "admin.")
                         needinfo_users = [item.strip() for item in
-                                          (env.config["gecko"]["upstream"]
-                                           .get("needinfo-users", "")
+                                          (env.config["gecko"]["needinfo"]
+                                           .get("upstream", "")
                                            .split(","))]
                         needinfo_users = [item for item in needinfo_users if item]
                         bug.needinfo(*needinfo_users)

--- a/sync_prod.ini
+++ b/sync_prod.ini
@@ -43,13 +43,18 @@ enabled.landing=
 repo.autoland=
 repo.mozilla-inbound=
 repo.mozilla-central=
-landing = mozilla-inbound
+landing = autoland
 refs.central = mozilla/central
 refs.mozilla-inbound = mozilla/inbound
 refs.autoland = autoland/branches/default/tip
 path.wpt = testing/web-platform/tests
 path.meta = testing/web-platform/meta
+worktree.max-count = 10
+logs.max-count = 20
 try.stability_count = 5
+try.max-tests = 500
+upstream.needinfo-users=wptsync@mozilla.bugs,
+landing.needinfo-users=wptsync@mozilla.bugs,
 
 [web-platform-tests]
 # See also wpt_config file

--- a/sync_prod.ini
+++ b/sync_prod.ini
@@ -53,8 +53,8 @@ worktree.max-count = 10
 logs.max-count = 20
 try.stability_count = 5
 try.max-tests = 500
-upstream.needinfo-users=wptsync@mozilla.bugs,
-landing.needinfo-users=wptsync@mozilla.bugs,
+needinfo.upstream=wptsync@mozilla.bugs,
+needinfo.landing=wptsync@mozilla.bugs,
 
 [web-platform-tests]
 # See also wpt_config file

--- a/test/config/credentials.ini
+++ b/test/config/credentials.ini
@@ -11,3 +11,6 @@ apikey = whatever
 [taskcluster]
 client_id = wptsync
 token =  blah
+
+[phabricator]
+token = token

--- a/test/config/sync.ini
+++ b/test/config/sync.ini
@@ -28,6 +28,8 @@ refs.autoland = mozilla/bookmarks/mozilla/autoland
 path.wpt = testing/web-platform/tests
 path.meta = testing/web-platform/meta
 try.stability_count = 5
+upstream.needinfo-users=example@example.org,
+landing.needinfo-users=example@example.org,
 
 [web-platform-tests]
 repo.url = %ROOT%/remotes/web-platform-tests

--- a/test/config/sync.ini
+++ b/test/config/sync.ini
@@ -28,8 +28,8 @@ refs.autoland = mozilla/bookmarks/mozilla/autoland
 path.wpt = testing/web-platform/tests
 path.meta = testing/web-platform/meta
 try.stability_count = 5
-upstream.needinfo-users=example@example.org,
-landing.needinfo-users=example@example.org,
+oneedinfo.upstream=example@example.org,
+needinfo.landing=example@example.org,
 
 [web-platform-tests]
 repo.url = %ROOT%/remotes/web-platform-tests


### PR DESCRIPTION
Now that inbound is gone, we have to push to autoland. But pushing to
autoland is hard because we struggle to find a time when it's open and
we don't hit a conflict with lando. Instead what we'd like is to end
up in the lando queue, but so far lando only knows how to read from
phabricator. So as a temporary solution we adopt the following
process:

* Push the landing to Phabricator using moz-phab
* Needinfo the wpt sync user to manually push the commits to lando and
  invoke lando (ignoring all the warnings about unlanded code).