### PR TITLE
Configure metamerge as a mergetool

### DIFF
--- a/ansible/roles/wptsync_host/tasks/main.yml
+++ b/ansible/roles/wptsync_host/tasks/main.yml
@@ -122,31 +122,9 @@
   with_items:
     - "{{ mount_workspace| mandatory }}/logs/rabbitmq"
 
-- name: ensure git mergedriver name is added to git config
-  git_config:
-    repo: "{{ mount_repos }}/gecko"
-    scope: local
-    name: merge.metamerge.name
-    value: Automatic meta merge
-
 - name: Ensure git config has the correct owner
   file:
     path: "{{ mount_repos }}/gecko/config"
-    owner: wptsync
-    group: wptsync
-    mode: 0644
-
-- name: ensure git mergedriver driver is added to git config
-  git_config:
-    repo: "{{ mount_repos }}/gecko"
-    scope: local
-    name: merge.metamerge.driver
-    value: ./mach wpt-metadata-merge %O %A %B %A || git-merge-file -q --marker-size=%L %A %O %B
-
-- name: ensure git mergedriver is configured in git attributes
-  copy:
-    src: "{{ host_config }}/gitattributes"
-    dest: "{{ mount_repos }}/gecko/info/attributes"
     owner: wptsync
     group: wptsync
     mode: 0644

--- a/config/gecko_config
+++ b/config/gecko_config
@@ -17,3 +17,8 @@
 [remote "autoland"]
     url = hg::https://hg.mozilla.org/integration/autoland
     fetch = +refs/heads/*:refs/remotes/autoland/*
+[merge]
+    tool = metamerge
+[mergetool "metamerge"]
+    cmd = ./mach wpt-metadata-merge \"$BASE\" \"$LOCAL\" \"$REMOTE\" \"$MERGED\"
+    trustExitCode = true


### PR DESCRIPTION
The previous setup as a mergedriver didn't work well since the tool should only
be used in some cases but not all. This approach is a good start but does require
extra code (not implemented) to use the mergetool at the correct times