### PR TITLE
Don't mark failures as unacceptable if there are retriggers

### DIFF
--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -370,6 +370,15 @@ class TryPush(base.ProcessData):
         if value:
             self.notify_failed_builds()
 
+    @property
+    def accept_failures(self):
+        return self.get("accept-failures", False)
+
+    @accept_failures.setter
+    @mut()
+    def accept_failures(self, value):
+        self["accept-failures"] = value
+
     def tasks(self):
         """Get a list of all the taskcluster tasks for web-platform-tests
         jobs associated with the current try push.


### PR DESCRIPTION
Presumably in this case we already accepted the failures when the
retriggers were scheduled. Of course this could break if it happens
that someone manually retriggered some jobs, but that seems like a
smaller risk.