### PR TITLE
File bugs for failing tests

### DIFF
--- a/sync/bug.py
+++ b/sync/bug.py
@@ -91,8 +91,10 @@ class Bugzilla(object):
     def bugzilla_url(self, bug_id):
         return "%s/show_bug.cgi?id=%s" % (self.bz_url, bug_id)
 
-    def id_from_url(self, url):
-        if not url.startswith(self.bz_url):
+    def id_from_url(self, url, bz_url=None):
+        if bz_url is None:
+            bz_url = self.bz_url
+        if not url.startswith(bz_url):
             return None
         parts = urlparse.urlsplit(url)
         query = urlparse.parse_qs(parts.query)

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -850,6 +850,10 @@ class DownstreamSync(SyncProcess):
                                    comment=truncated)
             else:
                 env.bz.comment(self.bug, message, is_markdown=True)
+
+        bugs = notify.bugs.bugs_for_sync(self, results)
+        notify.bugs.update_metadata(self, bugs)
+
         self.results_notified = True
 
         with SyncLock.for_process(self.process_name) as lock:

--- a/sync/meta.py
+++ b/sync/meta.py
@@ -6,7 +6,7 @@ import worktree
 import wptmeta
 
 from env import Environment
-from base import CommitBuilder
+from base import CommitBuilder, iter_tree
 from lock import mut, MutGuard
 
 
@@ -29,6 +29,11 @@ class GitReader(wptmeta.Reader):
     def read_path(self, rel_path):
         entry = self.rev.tree[rel_path]
         return self.pygit2_repo[entry.id].read_raw()
+
+    def walk(self, rel_path):
+        for path, obj in iter_tree(self.pygit2_repo, rel_path, rev=self.rev):
+            if obj.type == "blob" and obj.name == "META.yml":
+                yield "/".join(path[:-1])
 
 
 class GitWriter(wptmeta.Writer):

--- a/sync/notify/bugs.py
+++ b/sync/notify/bugs.py
@@ -1,0 +1,228 @@
+import json
+import re
+import os
+import subprocess
+from collections import defaultdict
+
+import newrelic
+from six import iteritems, itervalues
+
+from .msg import detail_part
+from .. import log
+from ..bugcomponents import components_for_wpt_paths
+from ..env import Environment
+from ..lock import mut
+from ..meta import Metadata
+from ..projectutil import Mach
+
+logger = log.get_logger(__name__)
+env = Environment()
+
+postscript = """Note: this bug is for tracking fixing the issues and is not
+owned by the wpt sync bot. It is associated with the test failures via metadata
+stored in https://github.com/web-platform-tests/wpt-metadata.
+
+If this bug is split into multiple bugs, please also update the
+relevant metadata, otherwise we are unable to track which wpt issues
+are triaged. The metadata link will be automatically removed when this
+bug is resolved.
+"""
+
+
+def test_ids_to_paths(git_work, test_ids):
+    mach = Mach(git_work.working_dir)
+    data = {}
+    min_idx = 0
+    group = 100
+    try:
+        while min_idx < len(test_ids):
+            data_str = mach.wpt_test_paths("--json", *test_ids[min_idx:min_idx + group])
+            data.update(json.loads(data_str))
+            min_idx += group
+    except subprocess.CalledProcessError:
+        newrelic.agent.record_exception()
+        # Fall back to a manual mapping of test ids to paths
+        data = fallback_test_ids_to_paths(test_ids)
+    return data
+
+
+def fallback_test_ids_to_paths(test_ids):
+    """Fallback for known rules mapping test_id to path, for cases where we
+    can't read the manifest"""
+    data = defaultdict(list)
+    any_re = re.compile(r"(.*)\.any.(?:[^\.]*\.)?html$")
+    for test_id in test_ids:
+        prefix = env.config["gecko"]["path"]["wpt"]
+        suffix = test_id
+
+        if test_id.startswith("/_mozilla/"):
+            prefix = os.path.normpath(
+                os.path.join(env.config["gecko"]["path"]["wpt"], "..", "mozilla", "tests"))
+            suffix = suffix[len("/_mozilla"):]
+        m = any_re.match(test_id)
+        if m:
+            suffix = m.groups()[0] + ".any.js"
+        elif test_id.endswith(".worker.html"):
+            suffix = test_id.rsplit(".", 1)[0] + ".js"
+        elif test_id.endswith(".sharedworker.html"):
+            suffix = test_id.rsplit(".", 1)[0] + ".js"
+        elif test_id.endswith(".window.html"):
+            suffix = test_id.rsplit(".", 1)[0] + ".js"
+
+        path = prefix + suffix
+        data[path].append(test_id)
+    return data
+
+
+@mut('sync')
+def for_sync(sync, results):
+    # TODO: file bugs for things in the results that require a bug and don't have one
+    rv = {}
+
+    new_crashes = list(results.iter_filter(lambda _test, _subtest, result:
+                                           (result.has_crash("firefox") and
+                                            not result.has_link(status="CRASH"))))
+
+    new_failures = list(results.iter_filter(lambda _test, _subtest, result:
+                                            ((result.has_regression("firefox") or
+                                              result.has_new_non_passing("firefox") or
+                                              result.is_browser_only_failure("firefox")) and
+                                             not result.has_link())))
+
+    if not new_failures and not new_crashes:
+        return rv
+
+    git_work = sync.gecko_worktree.get()
+    path_prefix = env.config["gecko"]["path"]["wpt"]
+
+    seen = set()
+
+    for test_results, bug_data, link_status, require_opt_in in [
+            (new_crashes, bug_data_crash, "CRASH", False),
+            (new_failures, bug_data_failure, None, True)]:
+
+        # Tests excluding those for which we already generated a bug
+        test_results = [item for item in test_results
+                        if (item[0], item[1]) not in seen]
+
+        seen |= set((item[0], item[1]) for item in test_results)
+
+        test_ids = [test_id for test_id, _subtest, _result in test_results]
+        test_id_by_path = test_ids_to_paths(git_work, test_ids)
+        test_path_by_id = {}
+        for path, ids in iteritems(test_id_by_path):
+            for test_id in ids:
+                assert test_id not in test_path_by_id
+                test_path_by_id[test_id] = os.path.relpath(path, path_prefix)
+
+        components = components_for_wpt_paths(git_work,
+                                              set(itervalues(test_path_by_id)))
+
+        components_by_path = {}
+        for component, paths in iteritems(components):
+            for path in paths:
+                components_by_path[path] = component
+
+        test_results_by_component = defaultdict(list)
+
+        for test_id, subtest, test_result in test_results:
+            component = components_by_path[test_path_by_id[test_id]]
+            test_results_by_component[component].append((test_id, subtest, test_result))
+
+        opt_in_components = set(item.strip()
+                                for item in
+                                env.config["notify"].get("components", "").split(","))
+
+        for component, test_results in iteritems(test_results_by_component):
+            if component == "UNKNOWN":
+                # For things with no component don't file a bug
+                continue
+
+            if require_opt_in and component not in opt_in_components:
+                logger.info("Not filing bugs for component %s" % component)
+                continue
+
+            product, component = component.split(" :: ")
+            summary, comment = bug_data(sync, test_results)
+            bug_id = make_bug(summary, comment, product, component, [sync.bug])
+            rv[bug_id] = [item + (link_status,) for item in test_results]
+
+    return rv
+
+
+def bug_data_crash(sync, test_results):
+    summary = "New wpt crashes from PR %s" % sync.pr
+
+    comment = """The following tests have crashes in the CI runs for wpt PR %s:
+%s
+
+(getting the crash signature into these bug reports is a TODO; sorry)
+
+These updates will be on mozilla-central once bug %s lands.
+
+""" % (sync.pr,
+       detail_part(None, test_results, None, "head", False),
+       sync.bug)
+
+    comment += postscript
+
+    return summary, comment
+
+
+def bug_data_failure(sync, test_results):
+    summary = "New wpt failures from PR %s" % sync.pr
+
+    by_type = defaultdict(list)
+    for (test, subtest, result) in test_results:
+        if result.is_browser_only_failure("firefox"):
+            by_type["firefox-only"].append((test, subtest, result))
+        elif result.has_regression("firefox"):
+            by_type["regression"].append((test, subtest, result))
+        elif result.has_new_non_passing("firefox"):
+            by_type["new-non-passing"].append((test, subtest, result))
+
+    detail_msg = []
+    for (details_type, test_results, include_other_browser) in [
+            ("Firefox-only failures", by_type["firefox-only"], False),
+            ("Tests with a Worse Result After Changes", by_type["regression"], True),
+            ("New Tests That Don't Pass", by_type["new-non-passing"], True)]:
+        if not test_results:
+            continue
+        detail_msg.append(detail_part(details_type, test_results, None, "head",
+                                      include_other_browser))
+
+    comment = """The following tests have untriaged failures in the CI runs for wpt PR %s:
+
+%s
+These updates will be on mozilla-central once bug %s lands.
+
+""" % (sync.pr, "\n".join(detail_msg), sync.bug)
+
+    comment += postscript
+
+    return summary, comment
+
+
+def make_bug(summary, comment, product, component, depends):
+    bug_id = env.bz.new(summary, comment, product, component, whiteboard="[wpt]")
+    with env.bz.bug_ctx(bug_id) as bug:
+        for item in depends:
+            bug.add_depends(item)
+    return bug_id
+
+
+@mut('sync')
+def update_metadata(sync, bugs):
+    # TODO: Ensure that the metadata is added to the meta repo
+    if not bugs:
+        return
+
+    metadata = Metadata.for_sync(sync)
+    with metadata.as_mut(sync._lock):
+        for bug_id, test_results in iteritems(bugs):
+            for (test_id, subtest, results, status) in test_results:
+                metadata.link_bug(test_id,
+                                  env.bz.bugzilla_url(bug_id),
+                                  product="firefox",
+                                  subtest=subtest,
+                                  status=status)

--- a/sync/notify/results.py
+++ b/sync/notify/results.py
@@ -129,6 +129,11 @@ class Result(object):
             lambda browser, _, status: (browser == target_browser and
                                         status.is_disabled())))
 
+    def has_link(self, status=None):
+        if status is None:
+            return len(self.bug_links) > 0
+        return any(item for item in self.bug_links if item.status == status)
+
 
 class TestResult(Result):
     def __init__(self):

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -92,6 +92,9 @@ def test_land_commit(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, se
     tree.is_open = lambda x: True
     sync = landing.update_landing(git_gecko, git_wpt)
 
+    assert ("Setting bug %s add_blocks %s" % (sync.bug, downstream_sync.bug)
+            in env.bz.output.getvalue())
+
     try_push = sync.latest_try_push
     with SyncLock.for_process(sync.process_name) as lock:
         with sync.as_mut(lock), try_push.as_mut(lock):

--- a/test/test_notify_bugs.py
+++ b/test/test_notify_bugs.py
@@ -1,0 +1,186 @@
+import json
+from mock import Mock, patch
+
+from sync import downstream, load, meta
+from sync.lock import SyncLock
+from sync.notify import results, bugs
+from sync.wptmeta import MetaLink
+
+
+def test_fallback_test_ids_to_paths(env):
+    test_ids = ["/IndexedDB/key-generators/reading-autoincrement-indexes.any.html",
+                "/IndexedDB/key-generators/reading-autoincrement-indexes.any.serviceworker.html",
+                "/cookie-store/cookieStore_event_arguments.tentative.https.window.html",
+                "/css/geometry/DOMMatrix-css-string.worker.html",
+                "/css/geometry/DOMMatrix-003.html",
+                "/_mozilla/tests/example.html"]
+    assert bugs.fallback_test_ids_to_paths(test_ids) == {
+        "testing/web-platform/tests/IndexedDB/key-generators/reading-autoincrement-indexes.any.js":
+        ["/IndexedDB/key-generators/reading-autoincrement-indexes.any.html",
+         "/IndexedDB/key-generators/reading-autoincrement-indexes.any.serviceworker.html"],
+        "testing/web-platform/tests/cookie-store/cookieStore_event_arguments."
+        "tentative.https.window.js":
+        ["/cookie-store/cookieStore_event_arguments.tentative.https.window.html"],
+        "testing/web-platform/tests/css/geometry/DOMMatrix-css-string.worker.js":
+        ["/css/geometry/DOMMatrix-css-string.worker.html"],
+        "testing/web-platform/tests/css/geometry/DOMMatrix-003.html":
+        ["/css/geometry/DOMMatrix-003.html"],
+        "testing/web-platform/mozilla/tests/tests/example.html":
+        ["/_mozilla/tests/example.html"]
+    }
+
+
+def fx_only_failure():
+    result = results.TestResult()
+    result.set_status("firefox", "GitHub", False, "PASS", ["PASS"])
+    result.set_status("firefox", "GitHub", True, "FAIL", ["PASS"])
+    result.set_status("chrome", "GitHub", False, "PASS", ["PASS"])
+    result.set_status("chrome", "GitHub", True, "PASS", ["PASS"])
+
+    results_obj = results.Results()
+    results_obj.test_results = {"/test/test.html": result}
+    results_obj.wpt_sha = "abcdef"
+    results_obj.treeherder_url = "https://treeherder.mozilla.org"
+
+    return results_obj
+
+
+def fx_crash():
+    result = results.TestResult()
+    result.set_status("firefox", "GitHub", False, "PASS", ["PASS"])
+    result.set_status("firefox", "GitHub", True, "CRASH", ["PASS"])
+
+    results_obj = results.Results()
+    results_obj.test_results = {"/test/test.html": result}
+    results_obj.wpt_sha = "abcdef"
+    results_obj.treeherder_url = "https://treeherder.mozilla.org"
+
+    return results_obj
+
+
+def test_msg_failure():
+    results_obj = fx_only_failure()
+
+    class Sync(object):
+        pr = "1234"
+        bug = "100000"
+
+    output = bugs.bug_data_failure(Sync(), [("/test/test.html",
+                                             None,
+                                             results_obj.test_results["/test/test.html"])])
+    assert output == (
+        'New wpt failures from PR 1234',
+        """The following tests have untriaged failures in the CI runs for wpt PR 1234:
+
+### Tests with a Worse Result After Changes
+/test/test.html: FAIL (Chrome: PASS)
+
+These updates will be on mozilla-central once bug 100000 lands.
+
+Note: this bug is for tracking fixing the issues and is not
+owned by the wpt sync bot. It is associated with the test failures via metadata
+stored in https://github.com/web-platform-tests/wpt-metadata.
+
+If this bug is split into multiple bugs, please also update the
+relevant metadata, otherwise we are unable to track which wpt issues
+are triaged. The metadata link will be automatically removed when this
+bug is resolved.
+""")
+
+
+def test_fx_only(env):
+    results_obj = fx_only_failure()
+    sync = Mock()
+    sync.lock_key = ("downstream", None)
+    env.config["notify"]["components"] = "Foo :: Bar, Testing :: web-platform-tests"
+    with patch("sync.notify.bugs.components_for_wpt_paths",
+               return_value={"Testing :: web-platform-tests": ["test/test.html"]}):
+        with patch("sync.notify.bugs.test_ids_to_paths",
+                   return_value={"testing/web-platform/tests/test/test.html":
+                                 ["/test/test.html"]}):
+            bug_data = bugs.for_sync(sync, results_obj)
+
+    assert list(bug_data.values()) == [[("/test/test.html",
+                                         None,
+                                         results_obj.test_results["/test/test.html"],
+                                         None)]]
+
+    assert "Creating a bug in component Testing :: web-platform-tests" in env.bz.output.getvalue()
+
+
+def test_crash(env):
+    results_obj = fx_crash()
+    sync = Mock()
+    sync.lock_key = ("downstream", None)
+    env.config["notify"]["components"] = "Foo :: Bar, Testing :: web-platform-tests"
+    with patch("sync.notify.bugs.components_for_wpt_paths",
+               return_value={"Testing :: web-platform-tests": ["test/test.html"]}):
+        with patch("sync.notify.bugs.test_ids_to_paths",
+                   return_value={"testing/web-platform/tests/test/test.html":
+                                 ["/test/test.html"]}):
+            bug_data = bugs.for_sync(sync, results_obj)
+
+    assert list(bug_data.values()) == [[("/test/test.html",
+                                         None,
+                                         results_obj.test_results["/test/test.html"],
+                                         "CRASH")]]
+
+    assert "Creating a bug in component Testing :: web-platform-tests" in env.bz.output.getvalue()
+
+
+def test_update_metadata(env, git_gecko, git_wpt, pull_request, git_wpt_metadata, mock_mach):
+    results_obj = fx_only_failure()
+
+    pr = pull_request([("Test commit", {"README": "Example change\n"})],
+                      "Test PR")
+
+    downstream.new_wpt_pr(git_gecko, git_wpt, pr)
+    sync = load.get_pr_sync(git_gecko, git_wpt, pr["number"])
+
+    mock_mach.set_data("wpt-test-paths",
+                       json.dumps(bugs.fallback_test_ids_to_paths(["/test/test.html"])))
+
+    with patch("sync.notify.bugs.components_for_wpt_paths",
+               return_value={"Testing :: web-platform-tests": ["test/test.html"]}):
+        with patch("sync.notify.bugs.Mach", return_value=mock_mach(None)):
+            with SyncLock.for_process(sync.process_name) as lock:
+                with sync.as_mut(lock):
+                    bug_data = bugs.for_sync(sync, results_obj)
+                    bugs.update_metadata(sync, bug_data)
+    bugs_filed = bug_data.keys()
+    assert len(bugs_filed) == 1
+    bug = bugs_filed[0]
+    metadata = meta.Metadata(sync.process_name)
+    links = list(metadata.iterbugs("/test/test.html"))
+    assert len(links) == 1
+    link = links[0]
+    assert link.url == "%s/show_bug.cgi?id=%s" % (env.bz.bz_url, bug)
+    assert link.test_id == "/test/test.html"
+    assert link.product == "firefox"
+    assert link.subtest is None
+    assert link.status is None
+
+
+def test_already_linked(env):
+    results_obj = fx_only_failure()
+    results_obj.test_results["/test/test.html"].bug_links.append(
+        MetaLink(None,
+                 "%s/show_bug.cgi?id=10000" % (env.bz.bz_url,),
+                 "firefox",
+                 "/test/test.html",
+                 None,
+                 None))
+    sync = Mock()
+    sync.lock_key = ("downstream", None)
+    env.config["notify"]["components"] = "Foo :: Bar, Testing :: web-platform-tests"
+    with patch("sync.notify.bugs.components_for_wpt_paths",
+               return_value={"Testing :: web-platform-tests": ["test/test.html"]}):
+        with patch("sync.notify.bugs.test_ids_to_paths",
+                   return_value={"testing/web-platform/tests/test/test.html":
+                                 ["/test/test.html"]}):
+            bug_data = bugs.for_sync(sync, results_obj)
+
+    assert len(bug_data) == 0
+
+    assert ("Creating a bug in component Testing :: web-platform-tests"
+            not in env.bz.output.getvalue())


### PR DESCRIPTION
This is the initial phase of this work and will probably initially only be turned on for `Testing :: web-platform-tests` components. For other components I may add some in-tree metadata that determines what to do for each component so it can be self-serve.