### PR TITLE
Enable Phab Listener

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -163,4 +163,4 @@ WORKDIR /app/wpt-sync
 VOLUME ["/app/wpt-sync", "/app/workspace", "/app/repos", "/app/config"]
 
 ENTRYPOINT ["/tini", "-v", "-g", "--", "/app/start_wptsync.sh"]
-CMD ["--worker"]
+CMD ["--worker", "--phab"]


### PR DESCRIPTION
forgot to add the flag to enable the listener in the Dockerfile. Could also have the phab listener started by default with the `--worker` flag