### PR TITLE
Add NR application context to custom event

### DIFF
--- a/sync/phab/listen.py
+++ b/sync/phab/listen.py
@@ -113,7 +113,7 @@ class PhabEventListener(object):
         newrelic.agent.record_custom_event("unknown_phabricator_event", params={
             "event_text": event_text,
             "event": event,
-        })
+        }, application=newrelic.agent.application())
 
     @staticmethod
     def map_feed_tuple(feed_tuple):


### PR DESCRIPTION
The custom events aren't showing up in Insights, reading the documentation it seems to be because it is missing application context according to this: https://docs.newrelic.com/docs/agents/python-agent/python-agent-api/record_custom_event

Hopefully this should fix it