### PR TITLE
Better handle failed decision tasks

### DIFF
--- a/sync/handlers.py
+++ b/sync/handlers.py
@@ -250,7 +250,7 @@ class TaskHandler(Handler):
                     task = tc.get_task(task_id)
                     taskgroup = tc.TaskGroup(task["taskGroupId"])
                     if len(taskgroup.view(
-                            lambda x: x["metadata"]["name"] == "Gecko Decision Task")) > 5:
+                            lambda x: x["task"]["metadata"]["name"] == "Gecko Decision Task")) > 5:
                         try_push.status = "complete"
                         try_push.infra_fail = True
                         if sync and sync.bug:

--- a/sync/tc.py
+++ b/sync/tc.py
@@ -427,7 +427,7 @@ def lookup_treeherder(project, revision):
     property_names = jobs_data["job_property_names"]
     idx_name = property_names.index("job_type_name")
     idx_task = property_names.index("task_id")
-    decision_tasks = [item for item in jobs_data.get("results", [])
+    decision_tasks = [item for item in jobs_data["results"]
                       if item[idx_name] == "Gecko Decision Task"]
     return decision_tasks[-1][idx_task]
 

--- a/sync/tc.py
+++ b/sync/tc.py
@@ -417,7 +417,8 @@ def lookup_treeherder(project, revision):
     push_data = fetch_json(TREEHERDER_BASE + "api/project/%s/push/" % (project,),
                            params={"revision": revision})
 
-    push_id = push_data.get("results", {})[0].get("id")
+    pushes = push_data.get("results", [])
+    push_id = pushes[0].get("id") if pushes else None
     if push_id is None:
         return
 

--- a/sync/update.py
+++ b/sync/update.py
@@ -176,6 +176,7 @@ def update_pr(git_gecko, git_wpt, pr, force_rebase=False, repo_update=True):
                         schedule_pr_task("push", pr, repo_update=repo_update)
 
                     elif sync.latest_valid_try_push:
+                        logger.info("Treeherder url %s" % sync.latest_valid_try_push.treeherder_url)
                         if not sync.latest_valid_try_push.taskgroup_id:
                             update_taskgroup_ids(git_gecko, git_wpt,
                                                  sync.latest_valid_try_push)
@@ -184,6 +185,9 @@ def update_pr(git_gecko, git_wpt, pr, force_rebase=False, repo_update=True):
                             not sync.latest_valid_try_push.status == "complete"):
                             update_tasks(git_gecko, git_wpt, sync=sync)
 
+                        if not sync.latest_valid_try_push.taskgroup_id:
+                            logger.info("Try push doesn't have a complete decision task")
+                            return
                 if not pr.merged:
                     update_for_status(pr, repo_update=repo_update)
                 else:


### PR DESCRIPTION
This prevents a number of errors we experience when the decision task fails. It doesn't quite provide the optimal solution to the problem which is to rebase and start a new try push (since usually a failed decision task is a problem in the gecko code).