### PR TITLE
Ensure that all lookups in ProcessNameIndex are done with strings

### DIFF
--- a/sync/base.py
+++ b/sync/base.py
@@ -163,7 +163,7 @@ class ProcessNameIndex(object):
         for key in [obj_type, subtype, obj_id]:
             if key is None:
                 break
-            target = target[key]
+            target = target[str(key)]
 
         rv = set()
         stack = [target]

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -40,3 +40,13 @@ def test_processname_seq_id(git_gecko, local_gecko_commit):
                                                        "upstream",
                                                        "1234")
     assert process_name_seq_id.seq_id == 1
+
+
+def test_processname_idx_type(git_gecko, local_gecko_commit):
+    process_name = base.ProcessName("sync", "upstream", "1234", "0")
+    idx = base.ProcessNameIndex(git_gecko)
+    idx.build()
+    idx.insert(process_name)
+
+    assert idx.get("sync", "upstream", "1234") == {process_name}
+    assert idx.get("sync", "upstream", 1234) == {process_name}


### PR DESCRIPTION
There's a general confusion in the codebase about whether
obj_ids (i.e. PR numbers and bug numbers) are represented by integers
or strings. In ProcessName objects they are always strings, but
sometimes in other contexts they aren't. This warrants a general
solution, but there was a specific problem with lookups in the
ProcessNameIndex passing in an integer obj_id and not finding
anything, so force the type to be str inside the get() function.