### PR TITLE
Try preventing celery setting up its own logging.

### DIFF
--- a/sync/worker.py
+++ b/sync/worker.py
@@ -1,5 +1,14 @@
 import celery
 from celery.beat import crontab
+from celery.signals import setup_logging
+
+
+@setup_logging.connect
+def config_loggers(*args, **kwags):
+    # This prevents celery reconfiguring the logging
+    import log
+    log.setup()
+
 
 beat_schedule = {
     # Try to retrigger anything we missed once a day
@@ -18,7 +27,6 @@ worker = celery.Celery('sync',
                        broker='pyamqp://guest:guest@rabbitmq',
                        include=['sync.tasks'])
 
-worker.conf.worker_hijack_root_logger = False
 worker.conf.beat_schedule = beat_schedule
 worker.conf.broker_transport_options = {
     "max_retries": 1,


### PR DESCRIPTION
We aren't seeing logging to sync.ini, presumably because the celery logging setup
isn't interacting well with our setup. Try just disabling all the celery setup