### PR TITLE
Always fetch from autoland when updating repos

### DIFF
--- a/sync/command.py
+++ b/sync/command.py
@@ -345,7 +345,7 @@ def do_pr(git_gecko, git_wpt, pr_ids, *args, **kwargs):
         pr_ids = [sync_from_path(git_gecko, git_wpt).pr]
     for pr_id in pr_ids:
         pr = env.gh_wpt.get_pull(int(pr_id))
-        update_repositories(git_gecko, git_wpt, True)
+        update_repositories(git_gecko, git_wpt)
         update.update_pr(git_gecko, git_wpt, pr, kwargs["rebase"])
 
 
@@ -573,7 +573,7 @@ def do_retrigger(git_gecko, git_wpt, **kwargs):
     import upstream
     from landing import current, load_sync_point, unlanded_with_type
 
-    update_repositories(git_gecko, git_wpt, True)
+    update_repositories(git_gecko, git_wpt)
 
     if kwargs["upstream"]:
         print("Retriggering upstream syncs with errors")

--- a/sync/gitutils.py
+++ b/sync/gitutils.py
@@ -21,16 +21,16 @@ def have_gecko_hg_commit(git_gecko, hg_rev):
     return True
 
 
-def update_repositories(git_gecko, git_wpt, include_autoland=False, wait_gecko_commit=None):
+def update_repositories(git_gecko, git_wpt, wait_gecko_commit=None):
     if git_gecko is not None:
         if wait_gecko_commit is not None:
-            success = until(lambda: _update_gecko(git_gecko, include_autoland),
+            success = until(lambda: _update_gecko(git_gecko),
                             lambda: have_gecko_hg_commit(git_gecko, wait_gecko_commit))
             if not success:
                 raise RetryableError(
                     ValueError("Failed to fetch gecko commit %s" % wait_gecko_commit))
         else:
-            _update_gecko(git_gecko, include_autoland)
+            _update_gecko(git_gecko)
 
     if git_wpt is not None:
         _update_wpt(git_wpt)
@@ -47,14 +47,13 @@ def until(func, cond, max_tries=5):
     return True
 
 
-def _update_gecko(git_gecko, include_autoland):
+def _update_gecko(git_gecko):
     with RepoLock(git_gecko):
         logger.info("Fetching mozilla-unified")
         # Not using the built in fetch() function since that tries to parse the output
         # and sometimes fails
         git_gecko.git.fetch("mozilla")
-
-        if include_autoland and "autoland" in [item.name for item in git_gecko.remotes]:
+        if "autoland" in [item.name for item in git_gecko.remotes]:
             logger.info("Fetching autoland")
             git_gecko.git.fetch("autoland")
 

--- a/sync/handlers.py
+++ b/sync/handlers.py
@@ -123,7 +123,7 @@ def handle_status(git_gecko, git_wpt, event):
 
 def handle_push(git_gecko, git_wpt, event):
     newrelic.agent.set_transaction_name("handle_push")
-    update_repositories(None, git_wpt, False)
+    update_repositories(None, git_wpt)
     landing.wpt_push(git_gecko, git_wpt, [item["id"] for item in event["commits"]])
 
 
@@ -165,7 +165,7 @@ class PushHandler(Handler):
         newrelic.agent.add_custom_parameter("repo", repo)
         newrelic.agent.add_custom_parameter("rev", rev)
 
-        update_repositories(git_gecko, git_wpt, include_autoland=True, wait_gecko_commit=rev)
+        update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
         try:
             git_rev = git_gecko.cinnabar.hg2git(rev)
         except ValueError:

--- a/sync/update.py
+++ b/sync/update.py
@@ -232,7 +232,7 @@ def update_bug(git_gecko, git_wpt, bug):
 def update_from_github(git_gecko, git_wpt, sync_classes, statuses=None):
     if statuses is None:
         statuses = ["*"]
-    update_repositories(git_gecko, git_wpt, True)
+    update_repositories(git_gecko, git_wpt)
     for cls in sync_classes:
         for status in statuses:
             if status != "*" and status not in cls.statuses:

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -849,7 +849,7 @@ def update_sync(git_gecko, git_wpt, sync, raise_on_error=True, repo_update=True)
         return set(), set(), set()
 
     if repo_update:
-        update_repositories(git_gecko, git_wpt, sync.repository == "autoland")
+        update_repositories(git_gecko, git_wpt)
     assert isinstance(sync, UpstreamSync)
     update_syncs = {sync.bug: (sync, sync.gecko_commits.head.sha1)}
     pushed_syncs, failed_syncs = update_sync_prs(sync._lock,


### PR DESCRIPTION
When pushes to autoland were rare and we didn't need to push to
autoland it made sense to optimise this out. Now it doesn't
any more