### PR TITLE
Don't pass same test id to test_ids_to_paths multiple times.

### DIFF
--- a/sync/notify/bugs.py
+++ b/sync/notify/bugs.py
@@ -110,7 +110,7 @@ def for_sync(sync, results):
 
         seen |= set((item[0], item[1]) for item in test_results)
 
-        test_ids = [test_id for test_id, _subtest, _result in test_results]
+        test_ids = list(set(test_id for test_id, _subtest, _result in test_results))
         test_id_by_path = test_ids_to_paths(git_work, test_ids)
         test_path_by_id = {}
         for path, ids in iteritems(test_id_by_path):


### PR DESCRIPTION
In cases where multiple subtests were in the results we were passing in the
same test_id many times, making for more slowness in the commands