### PR TITLE
Assert the wpt checkout is clean after applying commit

### DIFF
--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -282,6 +282,7 @@ class UpstreamSync(SyncProcess):
                                        metadata=metadata,
                                        msg_filter=commit_message_filter,
                                        src_prefix=env.config["gecko"]["path"]["wpt"])
+        assert not git_work.is_dirty()
         if wpt_commit:
             self.wpt_commits.head = wpt_commit
 


### PR DESCRIPTION
We hit a case where we were getting a merge conflict and for some reason
the process continued. This clearly doesn't always happen, but add an
extra assert to help debug next time