### PR TITLE
Set gecko_base when doing gecko_rebase

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -717,11 +717,10 @@ def push(landing):
         try:
             logger.info("Rebasing onto %s" % landing.gecko_integration_branch())
             landing.gecko_rebase(landing.gecko_integration_branch())
-        except git.GitCommandError as e:
-            err = "Rebase failed:\n%s" % e
-            logger.error(err)
-            env.bz.comment(landing.bug, err)
-            raise AbortError(err)
+        except AbortError as e:
+            logger.error(e)
+            env.bz.comment(landing.bug, e)
+            raise e
 
         if old_head == landing.gecko_commits.head.sha1:
             err = ("Landing push failed and rebase didn't change head:%s" %
@@ -1004,7 +1003,7 @@ def update_landing(git_gecko, git_wpt, prev_wpt_head=None, new_wpt_head=None,
             elif retry:
                 try:
                     landing.gecko_rebase(landing.gecko_landing_branch())
-                except git.GitCommandError:
+                except AbortError:
                     message = record_rebase_failure(landing)
                     raise AbortError(message)
 
@@ -1018,7 +1017,7 @@ def update_landing(git_gecko, git_wpt, prev_wpt_head=None, new_wpt_head=None,
                                                       accept_failures):
                     try:
                         landing.gecko_rebase(landing.gecko_landing_branch())
-                    except git.GitCommandError:
+                    except AbortError:
                         message = record_rebase_failure(landing)
                         raise AbortError(message)
 


### PR DESCRIPTION
The gecko_rebase() function previously forgot to set the
gecko-base property of the sync, so the commit range would
end up being too large. This only mattered in practice when there
were other wpt-sync commits on autoland, but not on central.

Change things so that when we do the rebase we always set the new base.
There is still a failure mode where the rebase fails and we don't
manually redo the rebase, so the stored base would end up as
autoland rather than central, but the actual base would be central.
Even in this pathological case it's pretty unlikely that anything
actually bad will happen; the worst cas scenario is that there are
commits on central that haven't been applied to autoland that look
like part of the sync.