### PR TITLE
Update try strings for landing pushes

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -676,10 +676,9 @@ MANUAL PUSH: wpt sync bot
             stability=stability,
             rebuild_count=0,
             try_cls=trypush.TryFuzzyCommit,
-            full=True,
-            queries=["web-platform-tests !devedition !ccov !fis",
-                     "web-platform-tests fis !devedition !ccov !asan !aarch64 "
-                     "windows10 | linux64"])
+            disable_target_task_filter=True,
+            queries=["web-platform-tests !ccov !shippable",
+                     "web-platform-tests linux-32 shippable"])
 
     def try_result(self, try_push=None, tasks=None):
         """Determine whether a try push has infra failures, or an acceptable

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -107,6 +107,7 @@ class TryFuzzyCommit(TryCommit):
         if isinstance(self.queries, basestring):
             self.queries = [self.queries]
         self.full = self.extra_args.get("full", False)
+        self.disable_target_task_filter = self.extra_args.get("disable_target_task_filter", False)
 
     def create(self):
         if self.hacks:
@@ -139,6 +140,8 @@ class TryFuzzyCommit(TryCommit):
             args.append(str(self.rebuild))
         if self.full:
             args.append("--full")
+        if self.disable_target_task_filter:
+            args.append("--disable-target-task-filter")
 
         if self.tests_by_type is not None:
             paths = []

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -64,11 +64,10 @@ def test_land_try(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_p
                                     "fuzzy",
                                     "--artifact",
                                     "-q",
-                                    "web-platform-tests !devedition !ccov !fis",
+                                    "web-platform-tests !ccov !shippable",
                                     "-q",
-                                    "web-platform-tests fis !devedition !ccov !asan !aarch64 "
-                                    "windows10 | linux64",
-                                    "--full")
+                                    "web-platform-tests linux32 shippable",
+                                    "--disable-target-task-filter")
 
 
 def test_land_commit(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_pr_status,

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -66,7 +66,7 @@ def test_land_try(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_p
                                     "-q",
                                     "web-platform-tests !ccov !shippable",
                                     "-q",
-                                    "web-platform-tests linux32 shippable",
+                                    "web-platform-tests linux-32 shippable",
                                     "--disable-target-task-filter")
 
 


### PR DESCRIPTION
This does two things:
 * Passes --disable-target-task-filter from Bug 1618633, which means
 that we select all the jobs that might run on central, including
 things that are not part of the default try set, but not things
 that are only on try for experiments.

 * Updates the try selector to reflect the fact that the above change
 handles fission, the devedition jobs no longer exist, and we only
 need to run shippable builds on linux32 (since those are the only
 builds in that configuration).