### PR TITLE
Don't fail if we didn't get any result statuses in the summary

### DIFF
--- a/sync/notify/msg.py
+++ b/sync/notify/msg.py
@@ -115,7 +115,7 @@ def summary_message(results):
 
     data.append("## Status Summary\n")
 
-    max_width = max(len(status) for status in result_statuses)
+    max_width = len(max(result_statuses, key=len))
     for browser in browsers:
         if not job_names[browser]:
             continue

--- a/sync/notify/msg.py
+++ b/sync/notify/msg.py
@@ -109,11 +109,14 @@ def summary_message(results):
         data[-1] += " and %s subtests" % subtests
     data[-1] += "\n"
 
+    result_statuses = [status for status in statuses if status in summary]
+    if not result_statuses:
+        return data
+
     data.append("## Status Summary\n")
 
-    max_width = max(len(status) for status in statuses if status in summary)
+    max_width = max(len(status) for status in result_statuses)
     for browser in browsers:
-
         if not job_names[browser]:
             continue
 


### PR DESCRIPTION
It seems like there's an occasional issue where we fail to get result statuses in the summary
and we call max() on an empty sequence. It's not quite clear how this happens, but we can at least
avoid throwing in that case.