### PR TITLE
Create PRs when pushing to wpt-metadata repo

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -577,7 +577,7 @@ class DownstreamSync(SyncProcess):
                     import traceback
                     error = e
                     logger.error("Applying with %s errored" % fn.__name__)
-                    logger.error(traceback.format_exc(e))
+                    logger.error(traceback.format_exc())
 
             if error is not None:
                 raise error
@@ -955,7 +955,6 @@ def commit_status_changed(git_gecko, git_wpt, sync, context, status, url, head_s
         sync.error = e
         if raise_on_error:
             raise
-        traceback.print_exc()
         logger.error(e)
 
 

--- a/sync/gh.py
+++ b/sync/gh.py
@@ -1,9 +1,9 @@
 import itertools
 import random
 import re
-import sys
 import time
 import urlparse
+from cStringIO import StringIO
 
 import github
 import newrelic
@@ -307,7 +307,7 @@ class MockGitHub(GitHub):
         self.prs = {}
         self.commit_prs = {}
         self._id = itertools.count(1)
-        self.output = sys.stdout
+        self.output = StringIO()
         self.checks = {}
 
     def _log(self, data):

--- a/sync/notify/bugs.py
+++ b/sync/notify/bugs.py
@@ -80,7 +80,16 @@ def fallback_test_ids_to_paths(test_ids):
 
 @mut('sync')
 def for_sync(sync, results):
-    # TODO: file bugs for things in the results that require a bug and don't have one
+    """Create the bugs for followup work for test problems found in a sync.
+
+    This creates bugs that will be owned by the triage owner of the component
+    for any followup work that's revealed by the changes in a sync. Currently
+    this is for crashes and certain kinds of failures e.g. Firefox-only failures
+    that are not already known in the wpt metadata.
+
+    :returns: A dict {bug_id: bug_info} where bug_info is a list of test results
+              that are included in the bug, each represented as a tuple
+              (test_id, subtest, results, status)"""
     rv = {}
 
     new_crashes = list(results.iter_filter(lambda _test, _subtest, result:
@@ -225,7 +234,7 @@ def update_metadata(sync, bugs):
     if not bugs:
         return
 
-    metadata = Metadata.for_sync(sync)
+    metadata = Metadata.for_sync(sync, create_pr=True)
     with metadata.as_mut(sync._lock):
         for bug_id, test_results in iteritems(bugs):
             for (test_id, subtest, results, status) in test_results:

--- a/sync_prod.ini
+++ b/sync_prod.ini
@@ -63,6 +63,10 @@ github.token = %SECRET%
 github.user = moz-wptsync-bot
 landing = master
 
+[metadata]
+repo.url = https://github.com/jgraham/wpt-metadata
+# We end up using the same credentials as [web-platform-tests]
+
 [bugzilla]
 apikey = %SECRET%
 url = https://bugzilla.mozilla.org/rest

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -91,7 +91,6 @@ def env(request, mock_mach, mock_wpt):
     from sync import bug, gh
 
     gh_wpt = gh.MockGitHub()
-    gh_wpt.output = StringIO()
 
     bz = bug.MockBugzilla(config)
     bz.output = StringIO()


### PR DESCRIPTION
We were previously doing metadata updates by pushing directly to
master in (a fork of) the wpt-metadata repository. However because the
repo has CI checks that must pass before merging PRs to ensure that
the data is valid we actually want to create a PR first. This adds an
(optional) PR creation step when writing metadata.