### PR TITLE
Check for taskgroup completion when tasks finish

### DIFF
--- a/sync/listen.py
+++ b/sync/listen.py
@@ -229,4 +229,4 @@ class TaskFilter(Filter):
     name = "task"
 
     def accept(self, body):
-        return True
+        return body.get("task", {}).get("tags", {}).get("createdForUser") == "wptsync@mozilla.com"

--- a/sync/update.py
+++ b/sync/update.py
@@ -267,6 +267,7 @@ def update_taskgroup_ids(git_gecko, git_wpt, try_push=None):
                                   "taskGroupId": taskgroup_id,
                                   "state": state,
                                   "runs": runs},
+                       "task": {"tags": {"kind": "decision-task"}},
                        "runId": len(runs) - 1,
                        "version": 1}
                 handle_sync("task", msg)


### PR DESCRIPTION
There is a failure mode we've encountered where we get some builds failing,
and the resulting taskgroup doesn't complete until all the unscheduled tasks
time out a day later. But we want to handle that case upfront, as soon as we
can know that the remaining tasks aren't going to run.

To do this, we process all tasks rather than just decision tasks. When a
non-decision task completes, we load all the tasks from the taskgroup and
check for completeness ignoring anything that's unscheduled. This has some
performance cost, so we are careful to only look at tasks we scheduled
ourselves.