### PR TITLE
Don't start phabricator listener

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -163,4 +163,4 @@ WORKDIR /app/wpt-sync
 VOLUME ["/app/wpt-sync", "/app/workspace", "/app/repos", "/app/config"]
 
 ENTRYPOINT ["/tini", "-v", "-g", "--", "/app/start_wptsync.sh"]
-CMD ["--worker", "--phab"]
+CMD ["--worker"]


### PR DESCRIPTION
This isn't doing anything useful so there's no need to run it.