### PR TITLE
Store the bugs that we file during notifications

### DIFF
--- a/sync/base.py
+++ b/sync/base.py
@@ -1,6 +1,6 @@
 import json
 import weakref
-from collections import defaultdict
+from collections import defaultdict, Mapping
 
 import git
 import pygit2
@@ -625,6 +625,31 @@ class ProcessData(object):
     @mut()
     def delete(self):
         self._delete = True
+
+
+class FrozenDict(Mapping):
+    def __init__(self, *args, **kwargs):
+        self._data = dict(*args, **kwargs)
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __contains__(self, key):
+        return key in self._data
+
+    def copy(self, **kwargs):
+        new_data = self._data.copy()
+        new_data.update(kwargs)
+        self.__class__(**new_data)
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
+
+    def as_dict(self):
+        return self._data.copy()
 
 
 class entry_point(object):

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -23,7 +23,7 @@ import log
 import notify
 import trypush
 import commit as sync_commit
-from base import entry_point
+from base import FrozenDict, entry_point
 from env import Environment
 from errors import AbortError
 from gitutils import update_repositories
@@ -139,6 +139,15 @@ class DownstreamSync(SyncProcess):
     @mut()
     def pr_status(self, value):
         self.data["pr-status"] = value
+
+    @property
+    def notify_bugs(self):
+        return FrozenDict(**self.data.get("notify-bugs", {}))
+
+    @notify_bugs.setter
+    @mut()
+    def notify_bugs(self, value):
+        self.data["notify-bugs"] = value.as_dict()
 
     @property
     def next_action(self):


### PR DESCRIPTION
This makes the process more idempotent as we can rerun it without refiling
bugs in the same components