### PR TITLE
Don't do an artifact build for final try push

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -680,6 +680,7 @@ MANUAL PUSH: wpt sync bot
             rebuild_count=0,
             try_cls=trypush.TryFuzzyCommit,
             disable_target_task_filter=True,
+            artifact=not stability,
             queries=["web-platform-tests !ccov !shippable",
                      "web-platform-tests linux-32 shippable",
                      "web-platform-tests mac !debug shippable"])

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -109,6 +109,7 @@ class TryFuzzyCommit(TryCommit):
             self.queries = [self.queries]
         self.full = self.extra_args.get("full", False)
         self.disable_target_task_filter = self.extra_args.get("disable_target_task_filter", False)
+        self.artifact = self.extra_args.get("artifact", True)
 
     def create(self):
         if self.hacks:
@@ -137,7 +138,7 @@ class TryFuzzyCommit(TryCommit):
 
         can_push_routes = "--route " in mach.try_("fuzzy", "--help")
 
-        args = ["fuzzy", "--artifact"] + query_args
+        args = ["fuzzy"] + query_args
         if self.rebuild:
             args.append("--rebuild")
             args.append(str(self.rebuild))
@@ -147,6 +148,10 @@ class TryFuzzyCommit(TryCommit):
             args.append("--disable-target-task-filter")
         if can_push_routes:
             args.append("--route=notify.pulse.wptsync.try-task.on-any")
+        if self.artifact:
+            args.append("--artifact")
+        else:
+            args.append("--no-artifact")
 
         if self.tests_by_type is not None:
             paths = []

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -62,14 +62,14 @@ def test_land_try(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_p
     assert mach_command["command"] == "mach"
     assert mach_command["args"] == ("try",
                                     "fuzzy",
-                                    "--artifact",
                                     "-q",
                                     "web-platform-tests !ccov !shippable",
                                     "-q",
                                     "web-platform-tests linux-32 shippable",
                                     "-q",
                                     "web-platform-tests mac !debug shippable",
-                                    "--disable-target-task-filter")
+                                    "--disable-target-task-filter",
+                                    "--artifact")
 
 
 def test_land_commit(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_pr_status,


### PR DESCRIPTION
This will make this try push slower, but avoids breakage caused by artifact builds
not working, which happens quite often