### PR TITLE
Fix code to include mypy annotations and pass mypy type checks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,9 @@ ignore_missing_imports = True
 
 [mypy-mozautomation.*]
 ignore_missing_imports = True
+
+[mypy-kombu.*]
+ignore_missing_imports = True
+
+[mypy-filelock.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,6 @@ ignore_missing_imports = True
 
 [mypy-git.*]
 ignore_missing_imports = True
+
+[mypy-mozautomation.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,3 +32,6 @@ ignore_missing_imports = True
 
 [mypy-filelock.*]
 ignore_missing_imports = True
+
+[mypy-phabricator.*]
+ignore_missing_imports = True

--- a/sync/base.py
+++ b/sync/base.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import json
+import sys
 import weakref
 from collections import defaultdict, Mapping
 
@@ -259,12 +260,19 @@ class ProcessName(six.with_metaclass(IdentityMap, object)):
         return (obj_type, subtype, str(obj_id), str(seq_id) if seq_id is not None else None)
 
     def __str__(self):
-        # type: () -> Text
-        return "%s/%s/%s/%s" % self.as_tuple()
+        # type: () -> str
+        data = u"%s/%s/%s/%s" % self.as_tuple()
+        if sys.version_info[0] == 2:
+            data = data.encode("utf8")
+        return data
 
     def key(self):
         # type: () -> Tuple[str, str, str, str]
         return self._cache_key(self._obj_type, self._subtype, self._obj_id, self._seq_id)
+
+    def path(self):
+        # type: () -> Text
+        return u"%s/%s/%s/%s" % self.as_tuple()
 
     def __eq__(self, other):
         # type: (ProcessName) -> bool
@@ -633,8 +641,8 @@ class ProcessData(six.with_metaclass(IdentityMap, object)):
 
     @classmethod
     def get_path(self, process_name):
-        # type: (ProcessName) -> str
-        return str(process_name)
+        # type: (ProcessName) -> Text
+        return process_name.path()
 
     @classmethod
     def load_by_obj(cls, repo, subtype, obj_id, seq_id=None):

--- a/sync/base.py
+++ b/sync/base.py
@@ -33,7 +33,7 @@ if MYPY:
     from sync.trypush import TryPush
     from typing import Dict
     from typing import Set
-    from _pygit2 import TreeEntry
+    from pygit2 import TreeEntry
     from pygit2.repository import Repository
     from typing import Iterator
 

--- a/sync/bug.py
+++ b/sync/bug.py
@@ -62,7 +62,7 @@ def get_sync_data(whiteboard):
 
 
 def set_sync_data(whiteboard, subtype, status):
-    # type: (Text, Optional[Text], Optional[str]) -> Text
+    # type: (Text, Optional[Text], Optional[Text]) -> Text
     if subtype is None:
         raise ValueError
 
@@ -101,7 +101,7 @@ class Bugzilla(object):
         return BugContext(self, bug_id)
 
     def bugzilla_url(self, bug_id):
-        # type: (Text) -> Text
+        # type: (int) -> Text
         return "%s/show_bug.cgi?id=%s" % (self.bz_url, bug_id)
 
     def id_from_url(self, url, bz_url=None):
@@ -525,7 +525,7 @@ class MockBugContext(BugContext):
     def __exit__(self, *args, **kwargs):
         # type: (*Any, **Any) -> None
         for item in self.changes:
-            self.bugzilla._log("%s\n" % item)
+            self.bugzilla._log("%s\n" % item)  # type: ignore
 
     def __setitem__(self, name, value):
         # type: (Text, Text) -> None

--- a/sync/command.py
+++ b/sync/command.py
@@ -9,6 +9,7 @@ import subprocess
 import traceback
 
 import git
+import six
 from six import iteritems
 
 from . import listen
@@ -20,6 +21,12 @@ from .gitutils import update_repositories
 from .load import get_syncs
 from .lock import RepoLock, SyncLock
 
+MYPY = False
+if MYPY:
+    from typing import Any, Iterable, List, Optional, Set, Text, Type, Union, cast
+    from git.repo.base import Repo
+    from sync.sync import SyncProcess
+    from sync.trypush import TryPush
 
 logger = log.get_logger(__name__)
 env = Environment()
@@ -30,6 +37,7 @@ if "SHELL" not in os.environ:
 
 
 def get_parser():
+    # type () -> argparse.ArgumentParser
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers()
     parser.add_argument("--pdb", action="store_true", help="Run in pdb")
@@ -46,7 +54,8 @@ def get_parser():
 
     parser_update_tasks = subparsers.add_parser("update-tasks",
                                                 help="Update the state of try pushes")
-    parser_update_tasks.add_argument("pr_id", nargs="?", help="Downstream PR id for sync to update")
+    parser_update_tasks.add_argument("pr_id", nargs="?", type=int,
+                                     help="Downstream PR id for sync to update")
     parser_update_tasks.set_defaults(func=do_update_tasks)
 
     parser_list = subparsers.add_parser("list", help="List all in-progress syncs")
@@ -56,7 +65,7 @@ def get_parser():
 
     parser_detail = subparsers.add_parser("detail", help="List all in-progress syncs")
     parser_detail.add_argument("sync_type", help="Type of sync")
-    parser_detail.add_argument("obj_id", help="Bug or PR id for the sync")
+    parser_detail.add_argument("obj_id", type=int, help="Bug or PR id for the sync")
     parser_detail.set_defaults(func=do_detail)
 
     parser_landing = subparsers.add_parser("landing", help="Trigger the landing code")
@@ -78,10 +87,6 @@ def get_parser():
     parser_fetch.add_argument('repo', choices=['gecko', 'web-platform-tests', 'wpt-metadata'])
     parser_fetch.add_argument('config_file', help="Path to git config file to copy.")
 
-    parser_fetch = subparsers.add_parser("fetch", help="Fetch from repo.")
-    parser_fetch.set_defaults(func=do_fetch)
-    parser_fetch.add_argument('repo', choices=['gecko', 'web-platform-tests'])
-
     parser_listen = subparsers.add_parser("listen", help="Start pulse listener")
     parser_listen.set_defaults(func=do_start_listener)
 
@@ -89,7 +94,7 @@ def get_parser():
     parser_listen.set_defaults(func=do_start_phab_listener)
 
     parser_pr = subparsers.add_parser("pr", help="Update the downstreaming for a specific PR")
-    parser_pr.add_argument("pr_ids", default=None, nargs="*", help="PR numbers")
+    parser_pr.add_argument("pr_ids", default=None, type=int, nargs="*", help="PR numbers")
     parser_pr.add_argument("--rebase", default=False, action="store_true",
                            help="Force the PR to be rebase onto the integration branch")
     parser_pr.set_defaults(func=do_pr)
@@ -110,16 +115,18 @@ def get_parser():
     parser_delete = subparsers.add_parser("delete", help="Delete a sync by bug number or pr")
     parser_delete.add_argument("sync_type", choices=["downstream", "upstream", "landing"],
                                help="Type of sync to delete")
-    parser_delete.add_argument("obj_ids", nargs="+", help="Bug or PR id for the sync(s)")
-    parser_delete.add_argument("--seq-id", help="Sync sequence id")
-    parser_delete.add_argument("--all", action="store_true",
+    parser_delete.add_argument("obj_ids", nargs="+", type=int,
+                               help="Bug or PR id for the sync(s)")
+    parser_delete.add_argument("--seq-id", default=None, type=int, help="Sync sequence id")
+    parser_delete.add_argument("--all", dest="delete_all", action="store_true",
                                help="Delete all matches, not just most recent")
-    parser_delete.add_argument("--try", action="store_true", help="Delete try pushes for a sync")
+    parser_delete.add_argument("--try", dest="try_push",
+                               action="store_true", help="Delete try pushes for a sync")
     parser_delete.set_defaults(func=do_delete)
 
     parser_worktree = subparsers.add_parser("worktree", help="Create worktree for a sync")
     parser_worktree.add_argument("sync_type", help="Type of sync")
-    parser_worktree.add_argument("obj_id", help="Bug or PR id for the sync")
+    parser_worktree.add_argument("obj_id", type=int, help="Bug or PR id for the sync")
     parser_worktree.add_argument("worktree_type", choices=["gecko", "wpt"],
                                  help="Repo type of worktree")
     parser_worktree.set_defaults(func=do_worktree)
@@ -129,10 +136,10 @@ def get_parser():
                                help="Object type")
     parser_status.add_argument("sync_type", choices=["downstream", "upstream", "landing"],
                                help="Sync type")
-    parser_status.add_argument("obj_id", help="Object id (pr number or bug)")
+    parser_status.add_argument("obj_id", type=int, help="Object id (pr number or bug)")
     parser_status.add_argument("new_status", help="Status to set")
     parser_status.add_argument("--old-status", help="Current status")
-    parser_status.add_argument("--seq-id", nargs="?", help="Sequence number")
+    parser_status.add_argument("--seq-id", default=None, type=int, help="Sequence number")
     parser_status.set_defaults(func=do_status)
 
     parser_test = subparsers.add_parser("test", help="Run the tests with pytest")
@@ -153,13 +160,13 @@ def get_parser():
     parser_skip = subparsers.add_parser("skip",
                                         help="Mark the sync for a PR as skip so that "
                                         "it doesn't have to complete before a landing")
-    parser_skip.add_argument("pr_ids", nargs="*", help="PR ids for which to skip")
+    parser_skip.add_argument("pr_ids", type=int, nargs="*", help="PR ids for which to skip")
     parser_skip.set_defaults(func=do_skip)
 
     parser_notify = subparsers.add_parser("notify",
                                           help="Try to perform results notification "
                                           "for specified PRs")
-    parser_notify.add_argument("pr_ids", nargs="*", help="PR ids for which to notify "
+    parser_notify.add_argument("pr_ids", nargs="*", type=int, help="PR ids for which to notify "
                                "(tries to use the PR for the current working directory "
                                "if not specified)")
     parser_notify.add_argument("--force", action="store_true",
@@ -170,7 +177,7 @@ def get_parser():
                                             help="Display commits from upstream "
                                             "that are able to land")
     parser_landable.add_argument("--prev-wpt-head", help="First commit to use as the base")
-    parser_landable.add_argument("--all", action="store_true", default=False,
+    parser_landable.add_argument("--all", action="store_true", dest="include_all", default=False,
                                  help="Print the status of all unlandable PRs")
     parser_landable.add_argument("--retrigger", action="store_true", default=False,
                                  help="Try to update all unlanded PRs that aren't Ready "
@@ -192,7 +199,7 @@ def get_parser():
     parser_try_push_add.add_argument("try_rev", help="Revision on try")
     parser_try_push_add.add_argument("sync_type", nargs="?", choices=["downstream", "landing"],
                                      help="Revision on try")
-    parser_try_push_add.add_argument("sync_id", nargs="?",
+    parser_try_push_add.add_argument("sync_id", nargs="?", type=int,
                                      help="PR id for downstream sync or bug number "
                                      "for upstream sync")
     parser_try_push_add.add_argument("--stability", action="store_true",
@@ -226,6 +233,7 @@ def get_parser():
 
 
 def sync_from_path(git_gecko, git_wpt):
+    # type: (Repo, Repo) -> Optional[SyncProcess]
     from . import base
     git_work = git.Repo(os.curdir)
     branch = git_work.active_branch.name
@@ -234,7 +242,7 @@ def sync_from_path(git_gecko, git_wpt):
         return None
     if parts[1] == "downstream":
         from . import downstream
-        cls = downstream.DownstreamSync
+        cls = downstream.DownstreamSync  # type: Type[SyncProcess]
     elif parts[1] == "upstream":
         from . import upstream
         cls = upstream.UpstreamSync
@@ -244,17 +252,20 @@ def sync_from_path(git_gecko, git_wpt):
     else:
         raise ValueError
     process_name = base.ProcessName.from_path(branch)
+    if process_name is None:
+        return None
     return cls(git_gecko, git_wpt, process_name)
 
 
-def do_list(git_gecko, git_wpt, sync_type, *args, **kwargs):
+def do_list(git_gecko, git_wpt, sync_type, error=False, **kwargs):
+    # type: (Repo, Repo, Text, bool, **Any) -> None
     from . import downstream
     from . import landing
     from . import upstream
-    syncs = []
+    syncs = []  # type: List[SyncProcess]
 
     def filter_sync(sync):
-        if kwargs["error"]:
+        if error:
             return sync.error is not None and sync.status == "open"
         return True
 
@@ -265,14 +276,20 @@ def do_list(git_gecko, git_wpt, sync_type, *args, **kwargs):
 
     for sync in syncs:
         extra = []
-        if sync.sync_type == "downstream":
+        if isinstance(sync, downstream.DownstreamSync):
             try_push = sync.latest_try_push
             if try_push:
-                extra.append("https://treeherder.mozilla.org/#/jobs?repo=try&revision=%s" %
-                             sync.latest_try_push.try_rev)
+                if try_push.try_rev:
+                    extra.append("https://treeherder.mozilla.org/#/jobs?repo=try&revision=%s" %
+                                 try_push.try_rev)
                 if try_push.taskgroup_id:
                     extra.append(try_push.taskgroup_id)
-        error = sync.error
+        error_data = sync.error
+        error_msg = u""
+        if error_data is not None:
+            msg = error_data["message"]
+            if msg is not None:
+                error_msg = ("ERROR: %s" % msg.split("\n", 1)[0])
         print("%s %s %s bug:%s PR:%s %s%s" %
               ("*"if sync.error else " ",
                sync.sync_type,
@@ -280,41 +297,51 @@ def do_list(git_gecko, git_wpt, sync_type, *args, **kwargs):
                sync.bug,
                sync.pr,
                " ".join(extra),
-               "ERROR: %s" %
-               error["message"].split("\n", 1)[0] if error else ""))
+               error_msg))
 
 
-def do_detail(git_gecko, git_wpt, sync_type, obj_id, *args, **kwargs):
+def do_detail(git_gecko, git_wpt, sync_type, obj_id, **kwargs):
+    # type: (Repo, Repo, Text, int, **Any) -> None
     syncs = get_syncs(git_gecko, git_wpt, sync_type, obj_id)
     for sync in syncs:
         print(sync.output())
 
 
-def do_landing(git_gecko, git_wpt, *args, **kwargs):
+def do_landing(git_gecko,  # type: Repo
+               git_wpt,  # type: Repo
+               wpt_head=None,  # type: Optional[Text]
+               prev_wpt_head=None,  # type: Optional[Text]
+               include_incomplete=False,  # type: bool
+               accept_failures=False,  # type: bool
+               retry=False,  # type: bool
+               push=True,  # type: bool
+               **kwargs  # type: Any
+               ):
+    # type: (...) -> None
     from . import errors
     from . import landing
     from . import update
     current_landing = landing.current(git_gecko, git_wpt)
 
-    accept_failures = kwargs["accept_failures"]
-
     def update_landing():
-        landing.update_landing(git_gecko, git_wpt,
-                               kwargs["prev_wpt_head"],
-                               kwargs["wpt_head"],
-                               kwargs["include_incomplete"],
-                               retry=kwargs["retry"],
+        landing.update_landing(git_gecko,
+                               git_wpt,
+                               prev_wpt_head,
+                               wpt_head,
+                               include_incomplete,
+                               retry=retry,
                                accept_failures=accept_failures)
 
     if current_landing and current_landing.latest_try_push:
         with SyncLock("landing", None) as lock:
+            assert isinstance(lock, SyncLock)
             try_push = current_landing.latest_try_push
             logger.info("Found try push %s" % try_push.treeherder_url)
             if try_push.taskgroup_id is None:
                 update.update_taskgroup_ids(git_gecko, git_wpt, try_push)
                 assert try_push.taskgroup_id is not None
             with try_push.as_mut(lock), current_landing.as_mut(lock):
-                if kwargs["retry"]:
+                if retry:
                     update_landing()
                 elif try_push.status == "open":
                     tasks = try_push.tasks()
@@ -327,7 +354,7 @@ def do_landing(git_gecko, git_wpt, *args, **kwargs):
                                                       git_wpt,
                                                       try_push,
                                                       current_landing,
-                                                      allow_push=kwargs["push"],
+                                                      allow_push=push,
                                                       accept_failures=accept_failures,
                                                       tasks=tasks)
                         except errors.AbortError:
@@ -340,126 +367,175 @@ def do_landing(git_gecko, git_wpt, *args, **kwargs):
         update_landing()
 
 
-def do_update(git_gecko, git_wpt, *args, **kwargs):
+def do_update(git_gecko,  # type: Repo
+              git_wpt,  # type: Repo
+              sync_type=None,  # type: Optional[List[Text]]
+              status=None,  # type: Optional[List[Text]]
+              **kwargs  # type: Any
+              ):
+    # type: (...) -> None
     from . import downstream
     from . import update
     from . import upstream
-    sync_classes = []
-    if not kwargs["sync_type"]:
-        kwargs["sync_type"] = ["upstream", "downstream"]
-    for key in kwargs["sync_type"]:
-        sync_classes.append({"upstream": upstream.UpstreamSync,
-                             "downstream": downstream.DownstreamSync}[key])
-    update.update_from_github(git_gecko, git_wpt, sync_classes, kwargs["status"])
+    sync_classes = []  # type: List[type]
+    if not sync_type:
+        sync_type = [u"upstream", u"downstream"]
+    for key in sync_type:
+        sync_classes.append({u"upstream": upstream.UpstreamSync,
+                             u"downstream": downstream.DownstreamSync}[key])
+    update.update_from_github(git_gecko, git_wpt, sync_classes, status)
 
 
-def do_update_tasks(git_gecko, git_wpt, *args, **kwargs):
+def do_update_tasks(git_gecko, git_wpt, pr_id, **kwargs):
+    # type: (Repo, Repo, int, **Any) -> None
     from . import update
     update.update_taskgroup_ids(git_gecko, git_wpt)
-    update.update_tasks(git_gecko, git_wpt, kwargs["pr_id"])
+    update.update_tasks(git_gecko, git_wpt, pr_id)
 
 
-def do_pr(git_gecko, git_wpt, pr_ids, *args, **kwargs):
+def do_pr(git_gecko, git_wpt, pr_ids, rebase=False, **kwargs):
+    # type: (Repo, Repo, List[int], bool, **Any) -> None
     from . import update
     if not pr_ids:
-        pr_ids = [sync_from_path(git_gecko, git_wpt).pr]
+        sync = sync_from_path(git_gecko, git_wpt)
+        if not sync:
+            logger.error("No PR id supplied and no sync for current path")
+            return
+        if not sync.pr:
+            logger.error("No PR id supplied and no sync for current path")
+            return
+        pr_ids = [sync.pr]
     for pr_id in pr_ids:
-        pr = env.gh_wpt.get_pull(int(pr_id))
+        pr = env.gh_wpt.get_pull(pr_id)
+        if pr is None:
+            logger.error("PR %s not found" % pr_id)
+            continue
         update_repositories(git_gecko, git_wpt)
-        update.update_pr(git_gecko, git_wpt, pr, kwargs["rebase"])
+        update.update_pr(git_gecko, git_wpt, pr, rebase)
 
 
-def do_bug(git_gecko, git_wpt, bug, *args, **kwargs):
+def do_bug(git_gecko, git_wpt, bug, **kwargs):
+    # type: (Repo, Repo, int, **Any) -> None
     from . import update
     if bug is None:
-        bug = sync_from_path(git_gecko, git_wpt).bug
+        sync = sync_from_path(git_gecko, git_wpt)
+        if sync is None:
+            logger.error("No bug supplied and no sync for current path")
+            return
+        bug = sync.bug
+        if bug is None:
+            logger.error("Sync for current path has no bug")
+            return
     update.update_bug(git_gecko, git_wpt, bug)
 
 
-def do_push(git_gecko, git_wpt, *args, **kwargs):
+def do_push(git_gecko,  # type: Repo
+            git_wpt,  # type: Repo
+            rev=None,  # type: Optional[Text]
+            base_rev=None,  # type: Optional[Text]
+            processes=None,  # type: Optional[List[Text]]
+            **kwargs  # type: Any
+            ):
+    # type: (...) -> None
     from . import update
-    rev = kwargs["rev"]
-    base_rev = kwargs["base_rev"]
-    processes = kwargs["processes"]
     if rev is None:
         rev = git_gecko.commit(env.config["gecko"]["refs"]["mozilla-inbound"]).hexsha
 
     update.update_push(git_gecko, git_wpt, rev, base_rev=base_rev, processes=processes)
 
 
-def do_delete(git_gecko, git_wpt, sync_type, obj_ids, *args, **kwargs):
+def do_delete(git_gecko,  # type: Repo
+              git_wpt,  # type: Repo
+              sync_type,  # type: Text
+              obj_ids,  # type: List[int]
+              try_push=False,  # type: bool
+              delete_all=False,  # type: bool
+              seq_id=None,  # type: Optional[int]
+              **kwargs):
+    # type: (...) -> None
     from . import trypush
+    objs = []  # type: Iterable[Any]
     for obj_id in obj_ids:
         logger.info("%s %s" % (sync_type, obj_id))
-        if kwargs["try"]:
-            objs = trypush.TryPush.load_by_obj(git_gecko, sync_type, obj_id,
-                                               seq_id=kwargs["seq_id"])
+        if try_push:
+            objs = trypush.TryPush.load_by_obj(git_gecko,
+                                               sync_type,
+                                               obj_id,
+                                               seq_id=seq_id)
         else:
-            objs = get_syncs(git_gecko, git_wpt, sync_type, obj_id, seq_id=kwargs["seq_id"])
-        if not kwargs["all"] and objs:
+            objs = get_syncs(git_gecko, git_wpt, sync_type, obj_id, seq_id=seq_id)
+        if not delete_all and objs:
             objs = sorted(objs, key=lambda x: -int(x.process_name.seq_id))[:1]
         for obj in objs:
             with SyncLock.for_process(obj.process_name) as lock:
+                assert isinstance(lock, SyncLock)
                 with obj.as_mut(lock):
                     obj.delete()
 
 
-def do_worktree(git_gecko, git_wpt, sync_type, obj_id, worktree_type, *args, **kwargs):
+def do_worktree(git_gecko,  # type: Repo
+                git_wpt,  # type: Repo
+                sync_type,  # type: Text
+                obj_id,  # type: int
+                worktree_type,  # type: Text
+                **kwargs  # type: Any
+                ):
+    # type: (...) -> None
     attr_name = worktree_type + "_worktree"
     syncs = get_syncs(git_gecko, git_wpt, sync_type, obj_id)
     for sync in syncs:
         with SyncLock.for_process(sync.process_name) as lock:
+            assert isinstance(lock, SyncLock)
             with sync.as_mut(lock):
                 getattr(sync, attr_name).get()
 
 
-def do_start_listener(git_gecko, git_wpt, *args, **kwargs):
+def do_start_listener(git_gecko, git_wpt, **kwargs):
+    # type: (Repo, Repo, **Any) -> None
     listen.run_pulse_listener(env.config)
 
 
-def do_start_phab_listener(git_gecko, git_wpt, *args, **kwargs):
+def do_start_phab_listener(git_gecko, git_wpt, **kwargs):
+    # type: (Repo, Repo, **Any) -> None
     phablisten.run_phabricator_listener(env.config)
 
 
-def do_fetch(git_gecko, git_wpt, *args, **kwargs):
+def do_configure_repos(git_gecko, git_wpt, repo, config_file, **kwargs):
+    # type: (Repo, Repo, Text, Text, **Any) -> None
     from . import repos
-    c = env.config
-    name = kwargs.get("repo")
-    r = repos.wrappers[name](c)
-    logger.info("Fetching %s in %s..." % (name, r.root))
-    pyrepo = r.repo()
-    with RepoLock(pyrepo):
-        try:
-            pyrepo.git.fetch(*r.fetch_args)
-        except git.GitCommandError as e:
-            # GitPython fails when git warns about adding known host key for new IP
-            if re.search(".*Warning: Permanently added.*host key.*", e.stderr) is not None:
-                logger.debug(e.stderr)
-            else:
-                raise e
-
-
-def do_configure_repos(git_gecko, git_wpt, *args, **kwargs):
-    from . import repos
-    name = kwargs.get("repo")
-    r = repos.wrappers[name](env.config)
+    r = repos.wrappers[repo](env.config)
     with RepoLock(r.repo()):
-        r.configure(os.path.abspath(os.path.normpath(kwargs.get("config_file"))))
+        r.configure(os.path.abspath(os.path.normpath(config_file)))
 
 
-def do_status(git_gecko, git_wpt, obj_type, sync_type, obj_id, *args, **kwargs):
+def do_status(git_gecko,  # type: Repo
+              git_wpt,  # type: Repo
+              obj_type,  # type: Text
+              sync_type,  # type: Text
+              obj_id,  # type: int
+              new_status,  # type: Text
+              seq_id=None,  # type: Optional[int]
+              old_status=None,  # type: Optional[int]
+              **kwargs  # type: Any
+              ):
+    # type: (...) -> None
     from . import upstream
     from . import downstream
     from . import landing
     from . import trypush
+    objs = []  # type: Iterable[Union[TryPush, SyncProcess]]
     if obj_type == "try":
-        objs = trypush.TryPush.load_by_obj(git_gecko,
-                                           sync_type,
-                                           obj_id,
-                                           seq_id=kwargs["seq_id"])
+        try_pushes = trypush.TryPush.load_by_obj(git_gecko,
+                                                 sync_type,
+                                                 obj_id,
+                                                 seq_id=seq_id)
+        if MYPY:
+            objs = cast(Set[trypush.TryPush], try_pushes)
+        else:
+            objs = try_pushes
     else:
         if sync_type == "upstream":
-            cls = upstream.UpstreamSync
+            cls = upstream.UpstreamSync  # type: Type[SyncProcess]
         if sync_type == "downstream":
             cls = downstream.DownstreamSync
         if sync_type == "landing":
@@ -467,22 +543,24 @@ def do_status(git_gecko, git_wpt, obj_type, sync_type, obj_id, *args, **kwargs):
         objs = cls.load_by_obj(git_gecko,
                                git_wpt,
                                obj_id,
-                               seq_id=kwargs["seq_id"])
+                               seq_id=seq_id)
 
-    if kwargs["old_status"] is not None:
-        objs = {item for item in objs if item.status == kwargs["old_status"]}
+    if old_status is not None:
+        objs = {item for item in objs if item.status == old_status}
 
     if not objs:
         logger.error("No matching syncs found")
 
     for obj in objs:
-        logger.info("Setting status of %s to %s" % (obj.process_name, kwargs["new_status"]))
+        logger.info("Setting status of %s to %s" % (obj.process_name, new_status))
         with SyncLock.for_process(obj.process_name) as lock:
+            assert isinstance(lock, SyncLock)
             with obj.as_mut(lock):
-                obj.status = kwargs["new_status"]
+                obj.status = new_status  # type: ignore
 
 
-def do_test(*args, **kwargs):
+def do_test(**kwargs):
+    # type: (**Any) -> None
     if kwargs.pop("flake8", True):
         logger.info("Running flake8")
         cmd = ["flake8"]
@@ -509,46 +587,77 @@ def do_test(*args, **kwargs):
         subprocess.check_call(cmd, cwd="/app/wpt-sync/")
 
 
-def do_cleanup(git_gecko, git_wpt, *args, **kwargs):
+def do_cleanup(git_gecko, git_wpt, **kwargs):
+    # type: (Repo, Repo, **Any) -> None
     from .tasks import cleanup
     cleanup()
 
 
-def do_skip(git_gecko, git_wpt, pr_ids, *args, **kwargs):
+def do_skip(git_gecko, git_wpt, pr_ids, **kwargs):
+    # type: (Repo, Repo, List[int], **Any) -> None
     from . import downstream
     if not pr_ids:
         sync = sync_from_path(git_gecko, git_wpt)
+        if sync is None:
+            logger.error("No pr_id supplied and no sync for current path")
+            return
         syncs = {sync.pr: sync}
     else:
-        syncs = {pr_id: downstream.DownstreamSync.for_pr(git_gecko, git_wpt, pr_id)
-                 for pr_id in pr_ids}
-    for pr_id, sync in iteritems(syncs):
-        if sync is None:
-            logger.error("No active sync for PR %s" % pr_id)
-        else:
-            with SyncLock.for_process(sync.process_name) as lock:
-                with sync.as_mut(lock):
-                    sync.skip = True
+        syncs = {}
+        for pr_id in pr_ids:
+            sync = downstream.DownstreamSync.for_pr(git_gecko, git_wpt, pr_id)
+            if sync is not None:
+                assert sync.pr is not None
+                syncs[sync.pr] = sync
+    for sync_pr_id, sync in iteritems(syncs):
+        if not isinstance(sync, downstream.DownstreamSync):
+            logger.error("PR %s is for an upstream sync" % sync_pr_id)
+            continue
+        with SyncLock.for_process(sync.process_name) as lock:
+            assert isinstance(lock, SyncLock)
+            with sync.as_mut(lock):
+                sync.skip = True  # type: ignore
 
 
-def do_notify(git_gecko, git_wpt, pr_ids, *args, **kwargs):
+def do_notify(git_gecko, git_wpt, pr_ids, force=False, **kwargs):
+    # type: (Repo, Repo, List[int], bool, **Any) -> None
     from . import downstream
     if not pr_ids:
         sync = sync_from_path(git_gecko, git_wpt)
+        if sync is None:
+            logger.error("No pr_id supplied and no sync for current path")
+            return
         syncs = {sync.pr: sync}
     else:
-        syncs = {pr_id: downstream.DownstreamSync.for_pr(git_gecko, git_wpt, pr_id)
-                 for pr_id in pr_ids}
-    for pr_id, sync in iteritems(syncs):
+        syncs = {}
+        for pr_id in pr_ids:
+            sync = downstream.DownstreamSync.for_pr(git_gecko, git_wpt, pr_id)
+            if sync is not None:
+                assert sync.pr is not None
+                syncs[sync.pr] = sync
+
+    for sync_pr_id, sync in iteritems(syncs):
         if sync is None:
-            logger.error("No active sync for PR %s" % pr_id)
+            logger.error("No active sync for PR %s" % sync_pr_id)
+        elif not isinstance(sync, downstream.DownstreamSync):
+            logger.error("PR %s is for an upstream sync" % sync_pr_id)
+            continue
         else:
             with SyncLock.for_process(sync.process_name) as lock:
+                assert isinstance(lock, SyncLock)
                 with sync.as_mut(lock):
-                    sync.try_notify(force=kwargs["force"])
+                    sync.try_notify(force=force)
 
 
-def do_landable(git_gecko, git_wpt, *args, **kwargs):
+def do_landable(git_gecko,
+                git_wpt,
+                prev_wpt_head=None,  # type: Optional[Text]
+                include_incomplete=False,  # type: bool
+                include_all=False,  # type: bool
+                retrigger=False,  # type: bool
+                **kwargs  # type: Any
+                ):
+    # type: (...) -> None
     from . import update
     from .sync import LandableStatus
     from .downstream import DownstreamAction, DownstreamSync
@@ -556,9 +665,7 @@ def do_landable(git_gecko, git_wpt, *args, **kwargs):
 
     current_landing = current(git_gecko, git_wpt)
 
-    if kwargs["prev_wpt_head"] is not None:
-        prev_wpt_head = kwargs["prev_wpt_head"]
-    elif current_landing:
+    if current_landing:
         print("Current landing will update head to %s" % current_landing.wpt_commits.head.sha1)
         prev_wpt_head = current_landing.wpt_commits.head.sha1
     else:
@@ -567,7 +674,7 @@ def do_landable(git_gecko, git_wpt, *args, **kwargs):
         prev_wpt_head = sync_point["upstream"]
 
     landable = landable_commits(git_gecko, git_wpt, prev_wpt_head,
-                                include_incomplete=kwargs["include_incomplete"])
+                                include_incomplete=include_incomplete)
 
     if landable is None:
         print("Next landing will not add any new commits")
@@ -577,7 +684,7 @@ def do_landable(git_gecko, git_wpt, *args, **kwargs):
         print("Next landing will update wpt head to %s, adding %i new PRs" %
               (wpt_head, len(commits)))
 
-    if kwargs["all"] or kwargs["retrigger"]:
+    if include_all or retrigger:
         unlandable = unlanded_with_type(git_gecko, git_wpt, wpt_head, prev_wpt_head)
         count = 0
         for pr, _, status in unlandable:
@@ -585,52 +692,60 @@ def do_landable(git_gecko, git_wpt, *args, **kwargs):
             msg = status.reason_str()
             if status == LandableStatus.missing_try_results:
                 sync = DownstreamSync.for_pr(git_gecko, git_wpt, pr)
+                assert isinstance(sync, DownstreamSync)
                 next_action = sync.next_action
                 reason = next_action.reason_str()
                 if next_action == DownstreamAction.wait_try:
                     latest_try_push = sync.latest_try_push
+                    assert latest_try_push is not None
                     reason = "%s %s" % (reason,
                                         latest_try_push.treeherder_url)
                 elif next_action == DownstreamAction.manual_fix:
                     latest_try_push = sync.latest_try_push
+                    assert latest_try_push is not None
                     reason = "Manual fixup required %s" % (
                         latest_try_push.treeherder_url,)
                 msg = "%s (%s)" % (msg, reason)
             elif status == LandableStatus.error:
                 sync = DownstreamSync.for_pr(git_gecko, git_wpt, pr)
-                msg = "%s (%s)" % (msg, sync.error["message"].split("\n")[0])
+                assert sync is not None
+                if sync.error:
+                    msg = sync.error["message"] or ""
+                    msg = "%s (%s)" % (msg, msg.split("\n")[0])
             print("%s: %s" % (pr, msg))
 
         print("%i PRs are unlandable:" % count)
 
-        if kwargs["retrigger"]:
+        if retrigger:
             errors = update.retrigger(git_gecko, git_wpt, unlandable)
             if errors:
                 print("The following PRs have errors:\n%s" % "\n".join(
                     str(item) for item in errors))
 
 
-def do_retrigger(git_gecko, git_wpt, **kwargs):
+def do_retrigger(git_gecko, git_wpt, upstream=False, downstream=False, **kwargs):
+    # type: (Repo, Repo, bool, bool, **Any) -> None
     from . import errors
     from . import update
-    from . import upstream
+    from . import upstream as upstream_sync
     from .landing import current, load_sync_point, unlanded_with_type
 
     update_repositories(git_gecko, git_wpt)
 
-    if kwargs["upstream"]:
+    if upstream:
         print("Retriggering upstream syncs with errors")
-        for sync in upstream.UpstreamSync.load_by_status(git_gecko, git_wpt, "open"):
+        for sync in upstream_sync.UpstreamSync.load_by_status(git_gecko, git_wpt, "open"):
             if sync.error:
                 with SyncLock.for_process(sync.process_name) as lock:
+                    assert isinstance(lock, SyncLock)
                     with sync.as_mut(lock):
                         try:
-                            upstream.update_sync(git_gecko, git_wpt, sync, repo_update=False)
+                            upstream_sync.update_sync(git_gecko, git_wpt, sync, repo_update=False)
                         except errors.AbortError as e:
                             print("Update failed:\n%s" % e)
                             pass
 
-    if kwargs["downstream"]:
+    if downstream:
         print("Retriggering downstream syncs on master")
         current_landing = current(git_gecko, git_wpt)
         if current_landing is None:
@@ -640,12 +755,22 @@ def do_retrigger(git_gecko, git_wpt, **kwargs):
             prev_wpt_head = current_landing.wpt_commits.head.sha1
         unlandable = unlanded_with_type(git_gecko, git_wpt, None, prev_wpt_head)
 
-        errors = update.retrigger(git_gecko, git_wpt, unlandable)
-        if errors:
-            print("The following PRs have errors:\n%s" % "\n".join(errors))
+        pr_errors = update.retrigger(git_gecko, git_wpt, unlandable)
+        if pr_errors:
+            print("The following PRs have errors:\n%s" % "\n".join(six.ensure_text(str(item))
+                                                                   for item in pr_errors))
 
 
-def do_try_push_add(git_gecko, git_wpt, sync_type=None, sync_id=None, **kwargs):
+def do_try_push_add(git_gecko,  # type: Repo
+                    git_wpt,  # type: Repo
+                    try_rev,  # type: Text
+                    stability=False,  # type: bool
+                    sync_type=None,  # type: Optional[Text]
+                    sync_id=None,  # type: Optional[int]
+                    rebuild_count=None,  # type: Optional[int]
+                    **kwargs  # type: Any
+                    ):
+    # type: (...) -> None
     from . import downstream
     from . import landing
     from . import trypush
@@ -653,14 +778,28 @@ def do_try_push_add(git_gecko, git_wpt, sync_type=None, sync_id=None, **kwargs):
     sync = None
     if sync_type is None:
         sync = sync_from_path(git_gecko, git_wpt)
-    elif sync_type == "downstream":
-        sync = downstream.DownstreamSync.for_pr(git_gecko, git_wpt, sync_id)
-    elif sync_type == "landing":
-        syncs = landing.LandingSync.for_bug(git_gecko, git_wpt, sync_id, flat=True)
-        if syncs:
-            sync = syncs[0]
+        if sync is None:
+            logger.error("No sync type supplied and no sync for current path")
+            return
     else:
-        raise ValueError
+        if sync_id is None:
+            logger.error("A sync id is required when a sync type is supplied")
+            return
+        if sync_type == "downstream":
+            sync = downstream.DownstreamSync.for_pr(git_gecko,
+                                                    git_wpt,
+                                                    sync_id)
+        elif sync_type == "landing":
+            syncs = landing.LandingSync.for_bug(git_gecko,
+                                                git_wpt,
+                                                sync_id,
+                                                statuses=None,
+                                                flat=True)
+            if syncs:
+                sync = syncs[0]
+        else:
+            logger.error("Invalid sync type %s" % sync_type)
+            return
 
     if not sync:
         raise ValueError
@@ -676,21 +815,29 @@ def do_try_push_add(git_gecko, git_wpt, sync_type=None, sync_id=None, **kwargs):
             pass
 
         def push(self):
-            return kwargs["try_rev"]
+            return try_rev
 
     with SyncLock.for_process(sync.process_name) as lock:
+        assert isinstance(lock, SyncLock)
         with sync.as_mut(lock):
             trypush = trypush.TryPush.create(lock,
                                              sync,
                                              None,
-                                             stability=kwargs["stability"],
-                                             try_cls=FakeTry, rebuild_count=kwargs["rebuild_count"],
+                                             stability=stability,
+                                             try_cls=FakeTry,
+                                             rebuild_count=rebuild_count,
                                              check_open=False)
 
     print("Now run an update for the sync")
 
 
-def do_download_logs(git_gecko, git_wpt, log_path, taskgroup_id, **kwargs):
+def do_download_logs(git_gecko,  # type: Repo
+                     git_wpt,  # type: Repo
+                     log_path,  # type: Text
+                     taskgroup_id,  # type: Text
+                     **kwargs  # type: Any
+                     ):
+    # type: (...) -> None
     from . import tc
     from . import trypush
     import tempfile
@@ -709,11 +856,13 @@ def do_download_logs(git_gecko, git_wpt, log_path, taskgroup_id, **kwargs):
 
 
 def do_bugupdate(git_gecko, git_wpt, **kwargs):
+    # type: (Repo, Repo, **Any) -> None
     from . import handlers
-    handlers.BugUpdateHandler(env.config)(git_gecko, git_wpt)
+    handlers.BugUpdateHandler(env.config)(git_gecko, git_wpt, {})
 
 
 def do_build_index(git_gecko, git_wpt, index_name, **kwargs):
+    # type: (Repo, Repo, Text, **Any) -> None
     from . import index
     if not index_name:
         index_names = None
@@ -728,6 +877,7 @@ def do_build_index(git_gecko, git_wpt, index_name, **kwargs):
 
 
 def do_migrate(git_gecko, git_wpt, **kwargs):
+    assert False, "Running this is probably a bad idea"
     # Migrate refs from the refs/<type>/<subtype>/<status>/<obj_id>[/<seq_id>] format
     # to refs/<type>/<subtype>/<obj_id>/<seq_id>
     from collections import defaultdict
@@ -914,11 +1064,12 @@ def do_migrate(git_gecko, git_wpt, **kwargs):
 
 
 def set_config(opts):
+    # type: (List[Text]) -> None
     for opt in opts:
         keys, value = opt.split("=", 1)
-        keys = keys.split(".")
+        key_parts = keys.split(".")
         target = env.config
-        for key in keys[:-1]:
+        for key in key_parts[:-1]:
             target = target[key]
         logger.info("Setting config option %s from %s to %s" %
                     (".".join(keys), target[keys[-1]], value))
@@ -926,6 +1077,7 @@ def set_config(opts):
 
 
 def main():
+    # type: () -> None
     parser = get_parser()
     args = parser.parse_args()
 
@@ -934,23 +1086,27 @@ def main():
         prof = cProfile.Profile()
         prof.enable()
 
+    if args.config:
+        set_config(args.config)
+
     try:
         func_name = args.func.__name__
     except AttributeError:
         func_name = None
     if func_name == "do_test":
-        git_gecko, git_wpt = (None, None)
+        def func(**kwargs):
+            return do_test(**kwargs)
     else:
         git_gecko, git_wpt = setup()
 
-    if args.config:
-        set_config(args.config)
+        def func(**kwargs):
+            return args.func(git_gecko, git_wpt, **kwargs)
 
     try:
-        args.func(git_gecko, git_wpt, **vars(args))
-    except Exception as e:
+        func(**vars(args))
+    except Exception:
         if args.pdb:
-            traceback.print_exc(e)
+            traceback.print_exc()
             import pdb
             pdb.post_mortem()
         else:

--- a/sync/commit.py
+++ b/sync/commit.py
@@ -132,7 +132,7 @@ class Commit(object):
             raise ValueError("Unrecognised commit %r" % commit)
         if sha1 not in self.pygit2_repo:
             raise ValueError("Commit with SHA1 %s not found" % sha1)
-        self.sha1 = sha1
+        self.sha1 = sha1.encode("ascii")
         self._commit = _commit
         self._pygit2_commit = _pygit2_commit
         self._notes = None

--- a/sync/commit.py
+++ b/sync/commit.py
@@ -35,7 +35,7 @@ if MYPY:
 env = Environment()
 logger = log.get_logger(__name__)
 
-METADATA_RE = re.compile(br"\s*([^:]*): (.*)")
+METADATA_RE = re.compile(br"([^:]+): (.*)")
 
 
 def get_metadata(text):
@@ -44,7 +44,7 @@ def get_metadata(text):
     data = {}
     for line in text.splitlines():
         if line:
-            m = METADATA_RE.match(line)
+            m = METADATA_RE.match(line.strip())
             if m:
                 key, value = m.groups()
                 data[key.decode("utf8")] = value.decode("utf8")
@@ -412,7 +412,7 @@ def _apply_patch(patch,  # type: bytes
                             if line.startswith(prefix):
                                 path_parts_bytes = line[len(prefix):].split(b"/")[strip_dirs:]
                                 path_parts = [item.decode("utf8") for item in path_parts_bytes]
-                                path = "%s/%s" % (dest_prefix, "/".join(path_parts))
+                                path = os.path.join(dest_prefix, *path_parts)
                                 paths.append(path)
                         dest_repo.git.add(*paths)
                 if err_msg is not None:

--- a/sync/env.py
+++ b/sync/env.py
@@ -1,33 +1,38 @@
-_config = None
-_bz = None
-_gh_wpt = None
-
-
 MYPY = False
 if MYPY:
-    from typing import Dict, Optional, Union
-    from sync.bug import Bugzilla, MockBugzilla
-    from sync.gh import GitHub, MockGitHub
+    from typing import Dict, Optional
+    from sync.bug import Bugzilla
+    from sync.gh import GitHub
+
+_config = None  # type: Optional[Dict]
+_bz = None  # type: Optional[Bugzilla]
+_gh_wpt = None  # type: Optional[GitHub]
 
 
 class Environment(object):
     @property
     def config(self):
-        # type: () -> Optional[Dict]
+        # type: () -> Dict
+        assert _config is not None
         return _config
 
     @property
     def bz(self):
-        # type: () -> Union[Bugzilla, MockBugzilla]
+        # type: () -> Bugzilla
+        assert _bz is not None
         return _bz
 
     @property
     def gh_wpt(self):
-        # type: () -> Union[GitHub, MockGitHub]
+        # type: () -> GitHub
+        assert _gh_wpt is not None
         return _gh_wpt
 
 
-def set_env(config, bz, gh_wpt):
+def set_env(config,  # type: Dict
+            bz,  # type: Bugzilla
+            gh_wpt  # type: GitHub
+            ):
     global _config
     global _bz
     global _gh_wpt

--- a/sync/env.py
+++ b/sync/env.py
@@ -1,6 +1,6 @@
 MYPY = False
 if MYPY:
-    from typing import Dict, Optional
+    from typing import Any, Dict, Optional, Text
     from sync.bug import Bugzilla
     from sync.gh import GitHub
 
@@ -12,7 +12,7 @@ _gh_wpt = None  # type: Optional[GitHub]
 class Environment(object):
     @property
     def config(self):
-        # type: () -> Dict
+        # type: () -> Dict[Text, Any]
         assert _config is not None
         return _config
 

--- a/sync/gitutils.py
+++ b/sync/gitutils.py
@@ -35,6 +35,7 @@ def update_repositories(git_gecko, git_wpt, wait_gecko_commit=None):
     # type: (Repo, Repo, Optional[str]) -> None
     if git_gecko is not None:
         if wait_gecko_commit is not None:
+            assert wait_gecko_commit is not None  # mypy
             success = until(lambda: _update_gecko(git_gecko),
                             lambda: have_gecko_hg_commit(git_gecko, wait_gecko_commit))
             if not success:
@@ -90,10 +91,12 @@ def refs(git, prefix=None):
 
 
 def pr_for_commit(git_wpt, rev):
+    # type: (Repo, str) -> Optional[int]
     prefix = "refs/remotes/origin/pr/"
     pr_refs = refs(git_wpt, prefix)
     if rev in pr_refs:
         return int(pr_refs[rev][len(prefix):])
+    return None
 
 
 def gecko_repo(git_gecko, head):

--- a/sync/index.py
+++ b/sync/index.py
@@ -24,7 +24,7 @@ if MYPY:
     from typing import Any
     from typing import Set
     from typing import Optional
-    from _pygit2 import Blob
+    from pygit2 import Blob
     from typing import List
     from pygit2.repository import Repository
     from typing import Iterator

--- a/sync/load.py
+++ b/sync/load.py
@@ -7,11 +7,11 @@ from .env import Environment
 
 MYPY = False
 if MYPY:
+    from typing import Iterable, List, Optional, Text, Union
     from git.repo.base import Repo
+    from sync.sync import SyncProcess
     from sync.downstream import DownstreamSync
     from sync.upstream import UpstreamSync
-    from typing import Text
-    from typing import Union
 
 env = Environment()
 
@@ -20,10 +20,10 @@ logger = log.get_logger(__name__)
 
 def get_pr_sync(git_gecko,  # type: Repo
                 git_wpt,  # type: Repo
-                pr_id,  # type: Union[Text, int]
+                pr_id,  # type: Text
                 log=True,  # type: bool
                 ):
-    # type: (...) -> Union[DownstreamSync, UpstreamSync]
+    # type: (...) -> Optional[Union[DownstreamSync, UpstreamSync]]
     from . import downstream
     from . import upstream
 
@@ -38,7 +38,12 @@ def get_pr_sync(git_gecko,  # type: Repo
     return sync
 
 
-def get_bug_sync(git_gecko, git_wpt, bug_number, statuses=None):
+def get_bug_sync(git_gecko,  # type: Repo
+                 git_wpt,  # type: Repo
+                 bug_number,  # type: Text
+                 statuses=None  # type: Optional[Iterable[Text]]
+                 ):
+    # type: (...) -> List[SyncProcess]
     from . import downstream
     from . import landing
     from . import upstream
@@ -51,6 +56,8 @@ def get_bug_sync(git_gecko, git_wpt, bug_number, statuses=None):
     if not syncs:
         syncs = downstream.DownstreamSync.for_bug(git_gecko, git_wpt, bug_number,
                                                   statuses=statuses)
+
+    assert isinstance(syncs, list)
     if syncs:
         all_syncs = []
         for item in itervalues(syncs):
@@ -61,7 +68,14 @@ def get_bug_sync(git_gecko, git_wpt, bug_number, statuses=None):
     return syncs
 
 
-def get_syncs(git_gecko, git_wpt, sync_type, obj_id, status=None, seq_id=None):
+def get_syncs(git_gecko,  # type: Repo
+              git_wpt,  # type: Repo
+              sync_type,  # type: Text
+              obj_id,  # type: Text
+              status=None,  # type: Optional[Text]
+              seq_id=None  # type: Optional[Text]
+              ):
+    # type: (...) -> List[SyncProcess]
     from . import downstream
     from . import landing
     from . import upstream

--- a/sync/load.py
+++ b/sync/load.py
@@ -1,17 +1,13 @@
 from __future__ import absolute_import
 
-from six import itervalues
-
 from . import log
 from .env import Environment
 
 MYPY = False
 if MYPY:
-    from typing import Iterable, List, Optional, Text, Union
+    from typing import Dict, Iterable, Optional, Set, Text
     from git.repo.base import Repo
     from sync.sync import SyncProcess
-    from sync.downstream import DownstreamSync
-    from sync.upstream import UpstreamSync
 
 env = Environment()
 
@@ -23,7 +19,7 @@ def get_pr_sync(git_gecko,  # type: Repo
                 pr_id,  # type: Text
                 log=True,  # type: bool
                 ):
-    # type: (...) -> Optional[Union[DownstreamSync, UpstreamSync]]
+    # type: (...) -> Optional[SyncProcess]
     from . import downstream
     from . import upstream
 
@@ -43,7 +39,7 @@ def get_bug_sync(git_gecko,  # type: Repo
                  bug_number,  # type: Text
                  statuses=None  # type: Optional[Iterable[Text]]
                  ):
-    # type: (...) -> List[SyncProcess]
+    # type: (...) -> Dict[Text, Set[SyncProcess]]
     from . import downstream
     from . import landing
     from . import upstream
@@ -57,14 +53,7 @@ def get_bug_sync(git_gecko,  # type: Repo
         syncs = downstream.DownstreamSync.for_bug(git_gecko, git_wpt, bug_number,
                                                   statuses=statuses)
 
-    assert isinstance(syncs, list)
-    if syncs:
-        all_syncs = []
-        for item in itervalues(syncs):
-            all_syncs.extend(item)
-        logger.info("Got syncs %r for bug %s" % (all_syncs, bug_number))
-    else:
-        logger.info("No sync found for bug %s" % bug_number)
+    assert isinstance(syncs, dict)
     return syncs
 
 
@@ -75,15 +64,15 @@ def get_syncs(git_gecko,  # type: Repo
               status=None,  # type: Optional[Text]
               seq_id=None  # type: Optional[Text]
               ):
-    # type: (...) -> List[SyncProcess]
+    # type: (...) -> Set[SyncProcess]
     from . import downstream
     from . import landing
     from . import upstream
 
     cls_types = {
-        "downstream": downstream.DownstreamSync,
-        "landing": landing.LandingSync,
-        "upstream": upstream.UpstreamSync
+        u"downstream": downstream.DownstreamSync,
+        u"landing": landing.LandingSync,
+        u"upstream": upstream.UpstreamSync
     }
     cls = cls_types[sync_type]
     syncs = cls.load_by_obj(git_gecko, git_wpt, obj_id, seq_id=seq_id)

--- a/sync/load.py
+++ b/sync/load.py
@@ -16,7 +16,7 @@ logger = log.get_logger(__name__)
 
 def get_pr_sync(git_gecko,  # type: Repo
                 git_wpt,  # type: Repo
-                pr_id,  # type: Text
+                pr_id,  # type: int
                 log=True,  # type: bool
                 ):
     # type: (...) -> Optional[SyncProcess]
@@ -36,7 +36,7 @@ def get_pr_sync(git_gecko,  # type: Repo
 
 def get_bug_sync(git_gecko,  # type: Repo
                  git_wpt,  # type: Repo
-                 bug_number,  # type: Text
+                 bug_number,  # type: int
                  statuses=None  # type: Optional[Iterable[Text]]
                  ):
     # type: (...) -> Dict[Text, Set[SyncProcess]]
@@ -44,25 +44,33 @@ def get_bug_sync(git_gecko,  # type: Repo
     from . import landing
     from . import upstream
 
-    syncs = landing.LandingSync.for_bug(git_gecko, git_wpt, bug_number,
-                                        statuses=statuses)
+    syncs = landing.LandingSync.for_bug(git_gecko,
+                                        git_wpt,
+                                        bug_number,
+                                        statuses=statuses,
+                                        flat=False)
     if not syncs:
-        syncs = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug_number,
-                                              statuses=statuses)
+        syncs = upstream.UpstreamSync.for_bug(git_gecko,
+                                              git_wpt,
+                                              bug_number,
+                                              statuses=statuses,
+                                              flat=False)
     if not syncs:
-        syncs = downstream.DownstreamSync.for_bug(git_gecko, git_wpt, bug_number,
-                                                  statuses=statuses)
+        syncs = downstream.DownstreamSync.for_bug(git_gecko,
+                                                  git_wpt,
+                                                  bug_number,
+                                                  statuses=statuses,
+                                                  flat=False)
 
-    assert isinstance(syncs, dict)
     return syncs
 
 
 def get_syncs(git_gecko,  # type: Repo
               git_wpt,  # type: Repo
               sync_type,  # type: Text
-              obj_id,  # type: Text
+              obj_id,  # type: int
               status=None,  # type: Optional[Text]
-              seq_id=None  # type: Optional[Text]
+              seq_id=None  # type: Optional[int]
               ):
     # type: (...) -> Set[SyncProcess]
     from . import downstream

--- a/sync/lock.py
+++ b/sync/lock.py
@@ -198,7 +198,7 @@ class ProcessLock(Lock):
         return cls(sync_type, obj_id)
 
     def check(self, sync_type, obj_id):
-        # type: (Text, str) -> None
+        # type: (Text, Text) -> None
         """Check that the current lock is valid for the provided sync_type and obj_id"""
         if sync_type in self.lock_per_type:
             obj_id = None

--- a/sync/meta.py
+++ b/sync/meta.py
@@ -135,7 +135,7 @@ class Metadata(object):
 
     def exit_mut(self):
         # type: () -> None
-        ref_name = str(self.process_name)
+        ref_name = self.process_name.path()
         message = "Gecko sync update"
         retry = 0
         MAX_RETRY = 5
@@ -189,7 +189,7 @@ class Metadata(object):
         if not self.create_pr:
             return self.branch
 
-        base_ref_name = "gecko/%s" % str(self.process_name).replace("/", "-")
+        base_ref_name = "gecko/%s" % self.process_name.path().replace("/", "-")
         ref_name = base_ref_name
         prefix = "refs/remotes/origin/"
         count = 0

--- a/sync/meta.py
+++ b/sync/meta.py
@@ -130,7 +130,7 @@ class Metadata(object):
 
     @property
     def lock_key(self):
-        # type: () -> Tuple[str, str]
+        # type: () -> Tuple[Text, Text]
         return (self.process_name.subtype, self.process_name.obj_id)
 
     def exit_mut(self):

--- a/sync/meta.py
+++ b/sync/meta.py
@@ -14,7 +14,7 @@ from .lock import mut, MutGuard
 
 MYPY = False
 if MYPY:
-    from typing import Iterable, Iterator, Optional, Text, Tuple, Union
+    from typing import Iterable, Iterator, Optional, Text, Tuple
     from git.repo.base import Repo
     from sync.downstream import DownstreamSync
     from sync.base import ProcessName
@@ -184,7 +184,7 @@ class Metadata(object):
             logger.error("Updating metdata failed")
             raise
         self.pygit2_repo.references.delete(ref_name)
-        self.metadata.writer = NullWriter
+        self.metadata.writer = NullWriter()
 
     def get_remote_ref(self):
         # type: () -> Text

--- a/sync/notify/bugupdate.py
+++ b/sync/notify/bugupdate.py
@@ -10,6 +10,11 @@ from ..env import Environment
 from ..lock import mut, MutGuard, ProcLock
 from ..meta import Metadata
 
+MYPY = False
+if MYPY:
+    from typing import Text, Tuple
+
+
 env = Environment()
 
 bugzilla_url = "https://bugzilla.mozilla.org"
@@ -40,6 +45,7 @@ class TriageBugs(object):
 
     @property
     def lock_key(self):
+        # type: () -> Tuple[Text, Text]
         return (self.process_name.subtype,
                 self.process_name.obj_id)
 

--- a/sync/notify/bugupdate.py
+++ b/sync/notify/bugupdate.py
@@ -30,7 +30,7 @@ class ProcData(ProcessData):
 
 
 class TriageBugs(object):
-    process_name = ProcessName("proc", "bugzilla", 0, 0)
+    process_name = ProcessName("proc", "bugzilla", str(0), 0)
 
     def __init__(self, repo):
         self._lock = None
@@ -55,7 +55,7 @@ class TriageBugs(object):
             self._last_update = from_iso_str(self.data["last-update"])
         return self._last_update
 
-    @last_update.setter
+    @last_update.setter  # type: ignore
     @mut()
     def last_update(self, value):
         self.data["last-update"] = value.isoformat()

--- a/sync/notify/results.py
+++ b/sync/notify/results.py
@@ -486,6 +486,9 @@ def add_gecko_data(sync, results):
     assert sync._lock is not None
     with try_push.as_mut(sync._lock):
         try_tasks = complete_try_push.tasks()
+        if try_tasks is None:
+            logger.error("Trypush didn't have a taskgroup id")
+            return False
         try:
             complete_try_push.download_logs(try_tasks.wpt_tasks, first_only=True)
         except RetryableError:

--- a/sync/notify/results.py
+++ b/sync/notify/results.py
@@ -17,38 +17,49 @@ from .. import wptfyi
 
 MYPY = False
 if MYPY:
-    from typing import Union
-    from typing import Optional
-    from typing import Text
-    from typing import Any
-    from typing import List
-    from typing import Callable
-    from typing import Iterator
-    from typing import Tuple
-    from typing import Dict
-    from typing import Set
-    from mypy_extensions import NoReturn
+    from typing import (Any,
+                        Callable,
+                        Dict,
+                        Iterable,
+                        Iterator,
+                        List,
+                        Mapping,
+                        MutableMapping,
+                        Optional,
+                        Set,
+                        Text,
+                        Tuple,
+                        Union)
+    from requests import Response
+    from sync.repos import Repo
+    from sync.downstream import DownstreamSync
+    from sync.meta import MetaLink
+    from sync.tc import TaskGroupView
 
+    Logs = Mapping[Text, Mapping[Text, List[Any]]]  # Any is really "anything with a json method"
+    ResultsEntry = Tuple[Text, Optional[Text], "Result"]
+    ResultsSummary = MutableMapping[Text,
+                                    Union[int, MutableMapping[Text, MutableMapping[Text, int]]]]
 
 logger = log.get_logger(__name__)
 env = Environment()
 
-passing_statuses = frozenset(["PASS", "OK"])
-statuses = frozenset(["OK", "PASS", "CRASH", "FAIL", "TIMEOUT", "ERROR", "NOTRUN",
-                      "PRECONDITION_FAILED"])
-browsers = ["firefox", "chrome", "safari"]
+passing_statuses = frozenset([u"PASS", u"OK"])
+statuses = frozenset([u"OK", u"PASS", u"CRASH", u"FAIL", u"TIMEOUT", u"ERROR", u"NOTRUN",
+                      u"PRECONDITION_FAILED"])
+browsers = [u"firefox", u"chrome", u"safari"]
 
 
 class StatusResult(object):
     def __init__(self, base=None, head=None):
-        # type: (Optional[Any], Optional[Any]) -> None
-        self.base = None
-        self.head = None
-        self.head_expected = []
-        self.base_expected = []
+        # type: (Optional[Text], Optional[Text]) -> None
+        self.base = None  # type: Optional[Text]
+        self.head = None  # type: Optional[Text]
+        self.head_expected = []  # type: List[Text]
+        self.base_expected = []  # type: List[Text]
 
     def set(self, has_changes, status, expected):
-        # type: (bool, Text, Union[List[Text], List[str]]) -> None
+        # type: (bool, Text, List[Text]) -> None
         if has_changes:
             self.head = status
             self.head_expected = expected
@@ -85,26 +96,29 @@ class Result(object):
     def __init__(self):
         # type: () -> None
         # Mapping {browser: {platform: StatusResult}}
-        self.statuses = defaultdict(lambda: defaultdict(StatusResult))
-        self.bug_links = []
+        self.statuses = defaultdict(
+            lambda: defaultdict(
+                StatusResult))  # type: MutableMapping[Text, MutableMapping[Text, StatusResult]]
+        self.bug_links = []  # type: List[MetaLink]
 
     def iter_filter_status(self,
                            fn,  # type: Callable
                            ):
-        # type: (...) -> Iterator[Union[Iterator, Iterator[Tuple[str, str, StatusResult]]]]
+        # type: (...) -> Iterator[Tuple[Text, Text, StatusResult]]
         for browser, by_platform in iteritems(self.statuses):
             for platform, status in iteritems(by_platform):
                 if fn(browser, platform, status):
                     yield browser, platform, status
 
     def set_status(self, browser, job_name, run_has_changes, status, expected):
-        # type: (str, str, bool, Text, Union[List[Text], List[str]]) -> None
+        # type: (Text, Text, bool, Text, List[Text]) -> None
         self.statuses[browser][job_name].set(run_has_changes, status, expected)
 
     def is_consistent(self, browser, target="head"):
-        # type: (str, str) -> bool
+        # type: (Text, Text) -> bool
         assert target in ["base", "head"]
-        browser_results = self.statuses.get(browser, {})
+        browser_results = self.statuses.get(
+            browser)  # type: Optional[Mapping[Text, StatusResult]]
         if not browser_results:
             return True
         first_result = getattr(next(itervalues(browser_results)), target)
@@ -113,19 +127,19 @@ class Result(object):
                    for result in itervalues(browser_results))
 
     def is_browser_only_failure(self, target_browser="firefox"):
-        # type: (str) -> bool
-        gh_target = self.statuses[target_browser].get("GitHub")
-        gh_other = [self.statuses.get(browser, {}).get("GitHub")
+        # type: (Text) -> bool
+        gh_target = self.statuses[target_browser].get(u"GitHub")
+        gh_other = [self.statuses.get(browser, {}).get(u"GitHub")
                     for browser in browsers
                     if browser != target_browser]
-        if gh_target is None or None in gh_other:
+        if gh_target is None:
             # We don't have enough information to determine GH-only failures
             return False
 
         if gh_target.head in passing_statuses:
             return False
 
-        if any(item.head not in passing_statuses for item in gh_other):
+        if any(item is None or item.head not in passing_statuses for item in gh_other):
             return False
 
         # If it's passing on all internal platforms, assume a pref has to be
@@ -140,6 +154,7 @@ class Result(object):
         return True
 
     def is_github_only_failure(self, target_browser="firefox"):
+        # type: (Text) -> bool
         gh_status = self.statuses[target_browser].get("GitHub")
         if not gh_status:
             return False
@@ -157,41 +172,43 @@ class Result(object):
         return True
 
     def has_crash(self, target_browser="firefox"):
-        # type: (str) -> bool
+        # type: (Text) -> bool
         return any(self.iter_filter_status(
             lambda browser, _, status: (browser == target_browser and
                                         status.is_crash())))
 
     def has_new_non_passing(self, target_browser="firefox"):
-        # type: (str) -> bool
+        # type: (Text) -> bool
         return any(self.iter_filter_status(
             lambda browser, _, status: (browser == target_browser and
                                         status.is_new_non_passing())))
 
     def has_regression(self, target_browser="firefox"):
-        # type: (str) -> bool
+        # type: (Text) -> bool
         return any(self.iter_filter_status(
             lambda browser, _, status: (browser == target_browser and
                                         status.is_regression())))
 
     def has_disabled(self, target_browser="firefox"):
-        # type: (str) -> bool
+        # type: (Text) -> bool
         return any(self.iter_filter_status(
             lambda browser, _, status: (browser == target_browser and
                                         status.is_disabled())))
 
     def has_non_disabled(self, target_browser="firefox"):
+        # type: (Text) -> bool
         return any(self.iter_filter_status(
             lambda browser, platform, status: (browser == target_browser and
                                                platform != "GitHub" and
                                                not status.is_disabled())))
 
     def has_passing(self):
+        # type: () -> bool
         return any(self.iter_filter_status(
             lambda _browser, _platform, status: status.head in passing_statuses))
 
     def has_link(self, status=None):
-        # type: (Optional[str]) -> bool
+        # type: (Optional[Text]) -> bool
         if status is None:
             return len(self.bug_links) > 0
         return any(item for item in self.bug_links if item.status == status)
@@ -201,7 +218,7 @@ class TestResult(Result):
     def __init__(self):
         # type: () -> None
         # Mapping {subtestname: SubtestResult}
-        self.subtests = defaultdict(SubtestResult)
+        self.subtests = defaultdict(SubtestResult)  # type: MutableMapping[Text, "SubtestResult"]
         super(TestResult, self).__init__()
 
 
@@ -213,30 +230,30 @@ class Results(object):
     def __init__(self):
         # type: () -> None
         # Mapping of {test: TestResult}
-        self.test_results = defaultdict(TestResult)
-        self.errors = []
-        self.wpt_sha = None
-        self.treeherder_url = None
+        self.test_results = defaultdict(TestResult)  # type: MutableMapping[Text, TestResult]
+        self.errors = []  # type: List[Tuple[Text, bool]]
+        self.wpt_sha = None  # type: Optional[Text]
+        self.treeherder_url = None  # type: Optional[Text]
 
     def iter_results(self):
-        # type: () -> Iterator[Any]
+        # type: () -> Iterator[ResultsEntry]
         for test_name, result in iteritems(self.test_results):
             yield test_name, None, result
             for subtest_name, subtest_result in iteritems(result.subtests):
                 yield test_name, subtest_name, subtest_result
 
     def iter_filter(self, fn):
-        # type: (Callable) -> Iterator[Any]
+        # type: (Callable) -> Iterator[ResultsEntry]
         for test_name, subtest_name, result in self.iter_results():
             if fn(test_name, subtest_name, result):
                 yield test_name, subtest_name, result
 
     def add_jobs_from_log_files(self, logs_no_changes, logs_with_changes):
-        # type: (Dict[str, Dict], Dict[str, Dict]) -> None
+        # type: (Logs, Logs) -> None
         for (browser_logs, run_has_changes) in [(logs_with_changes, True),
                                                 (logs_no_changes, False)]:
-            for browser, job_logs in iteritems(browser_logs):
-                for job_name, job_logs in iteritems(job_logs):
+            for browser, browser_job_logs in iteritems(browser_logs):
+                for job_name, job_logs in iteritems(browser_job_logs):
                     if not run_has_changes and job_name not in self.test_results:
                         continue
 
@@ -250,9 +267,9 @@ class Results(object):
                         self.add_log(json_data, browser, job_name, run_has_changes)
 
     def add_log(self, data, browser, job_name, run_has_changes):
-        # type: (Dict[Text, Any], str, str, bool) -> None
+        # type: (Dict[Text, Any], Text, Text, bool) -> None
         for test in data["results"]:
-            use_result = run_has_changes or test["test"] in self.log_data
+            use_result = run_has_changes or test["test"] in self.test_results
             if use_result:
                 status = test["status"]
                 expected = [test.get("expected", status)] + test.get("known_intermittent", [])
@@ -271,6 +288,7 @@ class Results(object):
                      .set_status(browser, job_name, run_has_changes, status, expected))
 
     def add_metadata(self, metadata):
+        # type: (Metadata) -> None
         for test, result in iteritems(self.test_results):
             for meta_link in metadata.iterbugs(test, product="firefox"):
                 if meta_link.subtest is None:
@@ -280,13 +298,14 @@ class Results(object):
                         result.subtests[meta_link.subtest].bug_links.append(meta_link)
 
     def browsers(self):
+        # type: () -> Set[Text]
         browsers = set()
         for result in itervalues(self.test_results):
             browsers |= set(item for item in iterkeys(result.statuses))
         return browsers
 
     def job_names(self, browser):
-        # type: (str) -> Set[str]
+        # type: (Text) -> Set[Text]
         job_names = set()
         for result in itervalues(self.test_results):
             if browser in result.statuses:
@@ -295,8 +314,10 @@ class Results(object):
         return job_names
 
     def summary(self):
-        # type: () -> Dict
-        summary = defaultdict(lambda: defaultdict(lambda: defaultdict(int)))
+        # type: () -> ResultsSummary
+        summary = defaultdict(
+            lambda: defaultdict(
+                lambda: defaultdict(int)))  # type: ResultsSummary
         # Work out how many tests ran, etc.
 
         summary["parent_tests"] = 0
@@ -306,10 +327,10 @@ class Results(object):
             # type: (Union[SubtestResult, TestResult]) -> None
             for browser, browser_result in iteritems(result.statuses):
                 for job_name, job_result in iteritems(browser_result):
-                    summary[job_result.head][browser][job_name] += 1
+                    summary[job_result.head][browser][job_name] += 1  # type: ignore
 
         for test_result in itervalues(self.test_results):
-            summary["parent_tests"] += 1
+            summary["parent_tests"] += 1  # type: ignore
             summary["subtests"] = len(test_result.subtests)
             update_for_result(test_result)
             for subtest_result in itervalues(test_result.subtests):
@@ -317,34 +338,35 @@ class Results(object):
         return summary
 
     def iter_crashes(self, target_browser="firefox"):
-        # type: (str) -> Iterator
+        # type: (Text) -> Iterator[ResultsEntry]
         return self.iter_filter(lambda _test, _subtest, result:
                                 result.has_crash(target_browser))
 
     def iter_new_non_passing(self, target_browser="firefox"):
-        # type: (str) -> Iterator
+        # type: (str) -> Iterator[ResultsEntry]
         return self.iter_filter(lambda _test, _subtest, result:
                                 result.has_new_non_passing(target_browser))
 
     def iter_regressions(self, target_browser="firefox"):
-        # type: (str) -> Iterator
+        # type: (str) -> Iterator[ResultsEntry]
         return self.iter_filter(lambda _test, _subtest, result:
                                 result.has_regression(target_browser))
 
     def iter_disabled(self, target_browser="firefox"):
-        # type: (str) -> Iterator
+        # type: (str) -> Iterator[ResultsEntry]
         return self.iter_filter(lambda _test, _subtest, result:
                                 result.has_disabled(target_browser))
 
     def iter_browser_only(self, target_browser="firefox"):
-        # type: (str) -> Iterator
+        # type: (str) -> Iterator[ResultsEntry]
         def is_browser_only(_test, _subtest, result):
-            # type: (Text, Optional[Text], Union[SubtestResult, TestResult]) -> bool
+            # type: (Text, Optional[Text], Result) -> bool
             return result.is_browser_only_failure(target_browser)
         return self.iter_filter(is_browser_only)
 
 
 def get_push_changeset(commit):
+    # type: (sync_commit.GeckoCommit) -> Optional[Text]
     url = ("https://hg.mozilla.org/mozilla-central/json-pushes?changeset=%s&version=2&tipsonly=1" %
            commit.canonical_rev)
     headers = {"Accept": "application/json",
@@ -364,6 +386,7 @@ def get_push_changeset(commit):
 
 
 def get_central_tasks(git_gecko, sync):
+    # type: (Repo, DownstreamSync) -> Optional[TaskGroupView]
     merge_base_commit = sync_commit.GeckoCommit(
         git_gecko,
         git_gecko.merge_base(sync.gecko_commits.head.sha1,
@@ -374,19 +397,19 @@ def get_central_tasks(git_gecko, sync):
         git_push_sha = git_gecko.cinnabar.hg2git(hg_push_sha)
     except ValueError:
         newrelic.agent.record_exception()
-        return False
+        return None
     push_commit = sync_commit.GeckoCommit(git_gecko, git_push_sha)
     if push_commit is None:
-        return False
+        return None
 
     taskgroup_id, state, _ = tc.get_taskgroup_id("mozilla-central",
                                                  push_commit.canonical_rev)
     if taskgroup_id is None:
-        return
+        return None
 
     if state != "completed":
         logger.info("mozilla-central decision task has state %s" % state)
-        return
+        return None
 
     taskgroup_id = tc.normalize_task_id(taskgroup_id)
     tasks = tc.TaskGroup(taskgroup_id)
@@ -412,12 +435,13 @@ class LogFile(object):
         self.path = path
 
     def json(self):
-        # type: () -> NoReturn
+        # type: () -> Dict[Text, Any]
         with open(self.path) as f:
             return json.load(f)
 
 
 def get_logs(tasks, job_prefix="Gecko-"):
+    # type: (Iterable[Dict[Text, Any]], Text) -> Mapping[Text, Mapping[Text, List[LogFile]]]
     logs = defaultdict(list)
     for task in tasks:
         job_name = job_prefix + tc.parse_job_name(
@@ -433,6 +457,7 @@ def get_logs(tasks, job_prefix="Gecko-"):
 
 
 def add_gecko_data(sync, results):
+    # type: (DownstreamSync, Results) -> bool
     complete_try_push = None
 
     for try_push in sorted(sync.try_pushes(), key=lambda x: -x.process_name.seq_id):
@@ -441,7 +466,7 @@ def add_gecko_data(sync, results):
             break
 
     if not complete_try_push:
-        results.e("No complete try push available for PR %s" % sync.pr)
+        logger.info("No complete try push available for PR %s" % sync.pr)
         return False
 
     # Get the list of central tasks and download the wptreport logs
@@ -450,6 +475,8 @@ def add_gecko_data(sync, results):
         logger.info("Not all mozilla-central results available for PR %s" % sync.pr)
         return False
 
+    # TODO: this method should be @mut('sync')
+    assert sync._lock is not None
     with try_push.as_mut(sync._lock):
         try_tasks = complete_try_push.tasks()
         try:
@@ -467,12 +494,14 @@ def add_gecko_data(sync, results):
 
 
 def add_wpt_fyi_data(sync, results):
+    # type: (DownstreamSync, Results) -> bool
     head_sha1 = sync.wpt_commits.head.sha1
 
     logs = []
     for target, run_has_changes in [("base", False),
                                     ("head", True)]:
-        target_results = defaultdict(dict)
+        target_results = defaultdict(
+            dict)  # type: MutableMapping[Text, Dict[Text, List[Response]]]
         try:
             runs = wptfyi.get_runs(sha=head_sha1, labels=["pr_%s" % target])
             for run in runs:
@@ -490,6 +519,7 @@ def add_wpt_fyi_data(sync, results):
 
 
 def for_sync(sync):
+    # type: (DownstreamSync) -> Results
     results = Results()
     if not add_gecko_data(sync, results):
         results.errors.append(("Failed to get Gecko data", True))

--- a/sync/phab/listen.py
+++ b/sync/phab/listen.py
@@ -8,11 +8,6 @@ from six.moves import map
 
 from .. import log
 from ..tasks import handle
-from typing import Any
-from typing import Dict
-from typing import Text
-from typing import Tuple
-from typing import Optional
 
 
 logger = log.get_logger(__name__)
@@ -57,7 +52,6 @@ class PhabEventListener(object):
     }
 
     def __init__(self, config):
-        # type: (Dict) -> None
         self.running = True
         self.timer_in_seconds = config['phabricator']['listener']['interval']
         self.latest = None
@@ -82,7 +76,6 @@ class PhabEventListener(object):
         feed = []
 
         def chrono_key(feed_story_tuple):
-            # type: (Tuple[Text, Dict[Text, Any]]) -> int
             return int(feed_story_tuple[1]["chronologicalKey"])
 
         # keep fetching stories from Phabricator until there are no more stories to fetch
@@ -126,7 +119,6 @@ class PhabEventListener(object):
 
     @staticmethod
     def map_event_type(event_text, event):
-        # type: (Text, Dict[Text, Any]) -> Optional[str]
         # Could use compiled regex expression instead
         for event_type, mapping in PhabEventListener.event_mapping.items():
             if event_type in event_text:
@@ -140,7 +132,6 @@ class PhabEventListener(object):
 
     @staticmethod
     def map_feed_tuple(feed_tuple):
-        # type: (Tuple[Text, Dict[Text, Any]]) -> Dict[Text, Any]
         story_phid, feed_story = feed_tuple
         feed_story.update({"storyPHID": story_phid})
         return feed_story
@@ -155,10 +146,8 @@ def run_phabricator_listener(config):
 class MockPhabricator(Phabricator):
 
     def __init__(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
         self.feed = None
         pass
 
     def update_interfaces(self):
-        # type: () -> None
         pass

--- a/sync/projectutil.py
+++ b/sync/projectutil.py
@@ -17,12 +17,8 @@ import six
 
 MYPY = False
 if MYPY:
-    from typing import Any
-    from typing import Dict
-    from typing import List
-    from typing import Text
-    from typing import Optional
-    from typing import Callable
+    from typing import Any, Callable, Dict, List, Optional, Text, Tuple
+
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +61,7 @@ class Command(object):
             # type: (Any, *Text, **Any) -> Text
             return self.get(name.replace("_", "-"), *args, **kwargs)
         call.__name__ = name
-        args = (call, self)
+        args = (call, self)  # type: Tuple[Any, ...]
         if six.PY2:
             args += (self.__class__,)
         self.__dict__[name] = types.MethodType(*args)
@@ -100,13 +96,13 @@ def create_mock(name):
         _log = []
 
         def __init__(self, path):
-            # type: (Optional[str]) -> None
+            # type: (Optional[Text]) -> None
             self.name = name
             self.path = path
 
         @classmethod
         def set_data(cls, command, value):
-            # type: (str, str) -> None
+            # type: (Text, Text) -> None
             cls._data[command] = value
 
         @classmethod

--- a/sync/projectutil.py
+++ b/sync/projectutil.py
@@ -13,6 +13,7 @@ import subprocess
 import types
 
 import newrelic
+import six
 
 MYPY = False
 if MYPY:
@@ -64,7 +65,10 @@ class Command(object):
             # type: (Any, *Text, **Any) -> Text
             return self.get(name.replace("_", "-"), *args, **kwargs)
         call.__name__ = name
-        self.__dict__[name] = types.MethodType(call, self, self.__class__)
+        args = (call, self)
+        if six.PY2:
+            args += (self.__class__,)
+        self.__dict__[name] = types.MethodType(*args)
         return self.__dict__[name]
 
 

--- a/sync/repos.py
+++ b/sync/repos.py
@@ -1,20 +1,20 @@
 from __future__ import absolute_import
+import abc
 import json
 import os
 import shutil
 import git
 import pygit2
+import six
 from six import iteritems
 
 from . import log
 
 MYPY = False
 if MYPY:
-    from typing import Dict
+    from typing import Any, Dict, Text, Optional, Union
     from git.repo.base import Repo
-    from typing import Text
     from git.objects.commit import Commit
-    from typing import Union
     from pygit2.repository import Repository
 
 
@@ -25,18 +25,21 @@ wrapper_map = {}
 pygit2_map = {}
 
 
-class GitSettings(object):
-    name = None
+class GitSettings(six.with_metaclass(abc.ABCMeta, object)):
+
+    name = None  # type: Text
     cinnabar = False
 
     def __init__(self, config):
-        # type: (Dict) -> None
+        # type: (Dict[Text, Any]) -> None
         self.config = config
 
     @property
     def root(self):
-        # type: () -> str
-        return os.path.join(self.config["repo_root"], self.config["paths"]["repos"], self.name)
+        # type: () -> Text
+        return os.path.join(self.config["repo_root"],
+                            self.config["paths"]["repos"],
+                            self.name)
 
     @property
     def remotes(self):
@@ -100,8 +103,8 @@ class WptMetadata(GitSettings):
 
 
 class Cinnabar(object):
-    hg2git_cache = {}
-    git2hg_cache = {}
+    hg2git_cache = {}  # type: Dict[Text, Text]
+    git2hg_cache = {}  # type: Dict[Text, Text]
 
     def __init__(self, repo):
         self.git = repo.git
@@ -140,5 +143,5 @@ def pygit2_get(repo):
 
 
 def wrapper_get(repo):
-    # type: (Repo) -> Union[Gecko, WebPlatformTests]
+    # type: (Repo) -> Optional[GitSettings]
     return wrapper_map.get(repo)

--- a/sync/repos.py
+++ b/sync/repos.py
@@ -83,7 +83,7 @@ class Gecko(GitSettings):
         if not data_ref.is_valid():
             from . import base
             with base.CommitBuilder(repo, "Create initial sync metadata",
-                                    ref=data_ref) as commit:
+                                    ref=data_ref.path) as commit:
                 path = "_metadata"
                 data = json.dumps({"name": "wptsync"})
                 commit.add_tree({path: data})
@@ -129,9 +129,9 @@ class Cinnabar(object):
 
 
 wrappers = {
-    "gecko": Gecko,
-    "web-platform-tests": WebPlatformTests,
-    "wpt-metadata": WptMetadata,
+    u"gecko": Gecko,
+    u"web-platform-tests": WebPlatformTests,
+    u"wpt-metadata": WptMetadata,
 }
 
 

--- a/sync/settings.py
+++ b/sync/settings.py
@@ -8,7 +8,7 @@ from six.moves.configparser import RawConfigParser
 
 MYPY = False
 if MYPY:
-    from typing import Dict
+    from typing import Any, Dict, Text
 
 _config = None
 
@@ -40,6 +40,7 @@ def get_root():
 
 
 def load():
+    # type: () -> Dict[Text, Any]
     global _config
     if _config is None:
         root, _ = get_root()
@@ -57,7 +58,7 @@ def load_files(ini_sync, ini_credentials):
     root, repo_root = get_root()
 
     def nested():
-        # type: () -> Dict
+        # type: () -> Dict[Text, Any]
         return defaultdict(nested)
 
     config = nested()

--- a/sync/sync.py
+++ b/sync/sync.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import enum
 import itertools
+import sys
 import traceback
 from collections import defaultdict
 
@@ -124,7 +125,7 @@ class CommitRange(object):
 
     @property
     def lock_key(self):
-        # type: () -> Tuple[str, str]
+        # type: () -> Tuple[Text, Text]
         return (self._head_ref.name.subtype,
                 self._head_ref.name.obj_id)
 
@@ -242,7 +243,7 @@ class SyncPointName(six.with_metaclass(IdentityMap, object)):
     for an upstream sync."""
 
     def __init__(self, subtype, obj_id):
-        # type: (str, str) -> None
+        # type: (Text, Text) -> None
         self._obj_type = "sync"
         self._subtype = subtype
         self._obj_id = str(obj_id)
@@ -255,28 +256,36 @@ class SyncPointName(six.with_metaclass(IdentityMap, object)):
 
     @property
     def subtype(self):
-        # type: () -> str
+        # type: () -> Text
         return self._subtype
 
     @property
     def obj_id(self):
-        # type: () -> str
+        # type: () -> Text
         return self._obj_id
 
     @classmethod
     def _cache_key(cls, subtype, obj_id):
-        # type: (str, str) -> Tuple[str, str]
+        # type: (Text, Text) -> Tuple[Text, Text]
         return (subtype, str(obj_id))
 
     def key(self):
-        # type: () -> Tuple[str, str]
+        # type: () -> Tuple[Text, Text]
         return (self._subtype, self._obj_id)
 
     def __str__(self):
         # type: () -> str
-        return "%s/%s/%s" % (self._obj_type,
-                             self._subtype,
-                             self._obj_id)
+        data = u"%s/%s/%s" % (self._obj_type,
+                              self._subtype,
+                              self._obj_id)
+        if sys.version_info[0] == 2:
+            data = data.encode("utf8")
+        return data
+
+    def path(self):
+        return u"%s/%s/%s" % (self._obj_type,
+                              self._subtype,
+                              self._obj_id)
 
 
 class SyncData(ProcessData):
@@ -342,7 +351,7 @@ class SyncProcess(six.with_metaclass(IdentityMap, object)):
 
     @property
     def lock_key(self):
-        # type: () -> Tuple[str, str]
+        # type: () -> Tuple[Text, Text]
         return (self.process_name.subtype, self.process_name.obj_id)
 
     def __repr__(self):

--- a/sync/sync.py
+++ b/sync/sync.py
@@ -20,25 +20,16 @@ from .worktree import Worktree
 
 MYPY = False
 if MYPY:
-    from typing import Optional
-    from typing import Text
-    from typing import Tuple
-    from sync.commit import GeckoCommit
-    from sync.commit import WptCommit
-    from typing import Union
-    from typing import List
-    from typing import Set
-    from typing import Any
+    from typing import Any, Dict, Iterable, Iterator, List, Optional, Set, Text, Tuple, Union
+    from sync.commit import GeckoCommit, WptCommit
     from git.repo.base import Repo
     from sync.downstream import DownstreamSync
     from sync.upstream import UpstreamSync
     from sync.landing import LandingSync
-    from typing import Dict
     from sync.trypush import TryPush
     from sync.gh import AttrDict
     from sync.upstream import BackoutCommitFilter
     from sync.lock import SyncLock
-    from typing import Iterator
 
 env = Environment()
 
@@ -366,7 +357,7 @@ class SyncProcess(six.with_metaclass(IdentityMap, object)):
                git_wpt,  # type: Repo
                pr_id,  # type: Union[Text, int]
                ):
-        # type: (...) -> Union[None, DownstreamSync, UpstreamSync]
+        # type: (...) -> Optional[Union[DownstreamSync, UpstreamSync]]
         from . import index
         idx = index.PrIdIndex(git_gecko)
         process_name = idx.get((str(pr_id),))
@@ -377,11 +368,11 @@ class SyncProcess(six.with_metaclass(IdentityMap, object)):
     def for_bug(cls,
                 git_gecko,  # type: Repo
                 git_wpt,  # type: Repo
-                bug,  # type: str
-                statuses=None,  # type: Union[List[str], None, Set[str]]
+                bug,  # type: Text
+                statuses=None,  # type: Iterable[Text]
                 flat=False,  # type: bool
                 ):
-        # type: (...) -> Union[Dict, List[LandingSync], List[UpstreamSync]]
+        # type: (...) -> Union[Dict[Text, Set[SyncProcess]], List[SyncProcess]]
         """Get the syncs for a specific bug.
 
         :param bug: The bug number for which to find syncs.

--- a/sync/sync.py
+++ b/sync/sync.py
@@ -473,7 +473,7 @@ class SyncProcess(six.with_metaclass(IdentityMap, object)):
 
     def _output_data(self):
         rv = ["%s%s" % ("*" if self.error else " ",
-                        str(self.process_name)),
+                        self.process_name.path()),
               "gecko range: %s..%s" % (self.gecko_commits.base.sha1,
                                        self.gecko_commits.head.sha1),
               "wpt range: %s..%s" % (self.wpt_commits.base.sha1,
@@ -544,8 +544,8 @@ class SyncProcess(six.with_metaclass(IdentityMap, object)):
 
     @property
     def branch_name(self):
-        # type: () -> str
-        return str(self.process_name)
+        # type: () -> Text
+        return self.process_name.path()
 
     @property
     def status(self):

--- a/sync/tasks.py
+++ b/sync/tasks.py
@@ -117,7 +117,7 @@ def handle(self, task, body):
 def land(self, config):
     git_gecko, git_wpt = setup()
     try:
-        handlers.LandingHandler(config)(git_gecko, git_wpt)
+        handlers.LandingHandler(config)(git_gecko, git_wpt, {})
     except RetryableError as e:
         self.retry(exc=e.wrapped)
 
@@ -127,7 +127,7 @@ def land(self, config):
 @settings.configure
 def cleanup(config):
     git_gecko, git_wpt = setup()
-    handlers.CleanupHandler(config)(git_gecko, git_wpt)
+    handlers.CleanupHandler(config)(git_gecko, git_wpt, {})
 
 
 @worker.task
@@ -135,7 +135,7 @@ def cleanup(config):
 @settings.configure
 def retrigger(config):
     git_gecko, git_wpt = setup()
-    handlers.RetriggerHandler(config)(git_gecko, git_wpt)
+    handlers.RetriggerHandler(config)(git_gecko, git_wpt, {})
 
 
 @worker.task
@@ -143,4 +143,4 @@ def retrigger(config):
 @settings.configure
 def update_bugs(config):
     git_gecko, git_wpt = setup()
-    handlers.BugUpdateHandler(config)(git_gecko, git_wpt)
+    handlers.BugUpdateHandler(config)(git_gecko, git_wpt, {})

--- a/sync/tc.py
+++ b/sync/tc.py
@@ -304,7 +304,7 @@ def get_task_artifacts(destination,  # type: Text
     try:
         artifacts = fetch_json(artifacts_base_url, session=session)
     except requests.HTTPError as e:
-        logger.warning(e.message)
+        logger.warning(str(e))
     artifact_urls = ["%s/%s" % (artifacts_base_url, item["name"])
                      for item in artifacts["artifacts"]
                      if any(item["name"].endswith("/" + file_name)

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -346,7 +346,7 @@ class UpstreamSync(SyncProcess):
 
         assert self.remote_branch is not None
         assert self.remote_branch in self.git_wpt.remotes.origin.refs
-        while not env.gh_wpt.get_branch(self.remote_branch):
+        while not env.gh_wpt.has_branch(self.remote_branch):
             logger.debug("Waiting for branch")
             time.sleep(1)
 

--- a/sync/worker.py
+++ b/sync/worker.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 import celery
-from celery.beat import crontab
+from celery.schedules import crontab
 from celery.signals import after_setup_logger
 
 
@@ -15,7 +15,7 @@ beat_schedule = {
     # Try to retrigger anything we missed once a day
     'retrigger': {
         "task": "sync.tasks.retrigger",
-        "schedule": crontab(hour=8, minute=0),
+        "schedule": crontab(hour="8", minute="0"),
     },
     # Try to cleanup once an hour
     'cleanup': {
@@ -25,7 +25,7 @@ beat_schedule = {
     # Try to update metadata once a day
     'update_bugs': {
         "task": "sync.tasks.update_bugs",
-        "schedule": crontab(hour=9, minute=0),
+        "schedule": crontab(hour="9", minute="0"),
     }
 }
 

--- a/sync/worktree.py
+++ b/sync/worktree.py
@@ -15,15 +15,10 @@ from .repos import pygit2_get, wrapper_get
 
 MYPY = False
 if MYPY:
-    from typing import Tuple
     from git.repo.base import Repo
-    from _pygit2 import Worktree as PyGit2Worktree
+    from pygit2 import Worktree as PyGit2Worktree
     from pygit2.repository import Repository
-    from typing import Iterator
-    from typing import Union
-    from typing import Any
-    from typing import Optional
-
+    from typing import Any, Iterator, Optional, Text, Tuple
 
 env = Environment()
 
@@ -31,12 +26,14 @@ logger = log.get_logger(__name__)
 
 
 def cleanup(git_gecko, git_wpt):
+    # type: (Repo, Repo) -> None
     for repo in [git_gecko, git_wpt]:
         pygit2_repo = pygit2_get(repo)
         cleanup_repo(pygit2_repo, get_max_worktree_count(repo))
 
 
 def cleanup_repo(pygit2_repo, max_count=None):
+    # type: (Repository, Optional[int]) -> None
     # TODO: Always cleanup repos where the sync is finished
     prune_worktrees(pygit2_repo)
     unprunable = []
@@ -123,12 +120,13 @@ def delete_worktree(process_name, worktree):
 
 
 def worktrees(pygit2_repo):
-    # type: (Repository) -> Iterator[Union[Iterator, Iterator[PyGit2Worktree]]]
+    # type: (Repository) -> Iterator[PyGit2Worktree]
     for name in pygit2_repo.list_worktrees():
         yield pygit2_repo.lookup_worktree(name)
 
 
 def prune_worktrees(pygit2_repo):
+    # type: (Repository) -> Iterator[PyGit2Worktree]
     for worktree in worktrees(pygit2_repo):
         # For some reason libgit2 thinks worktrees are not prunable when their
         # working dir is gone

--- a/sync/worktree.py
+++ b/sync/worktree.py
@@ -178,7 +178,7 @@ class Worktree(object):
 
     @property
     def lock_key(self):
-        # type: () -> Tuple[str, str]
+        # type: () -> Tuple[Text, Text]
         return (self.process_name.subtype, self.process_name.obj_id)
 
     @mut()

--- a/sync/worktree.py
+++ b/sync/worktree.py
@@ -91,6 +91,7 @@ def cleanup_repo(pygit2_repo, max_count=None):
     prunable.sort()
     maybe_prunable.sort()
     for time, process_name, worktree in (prunable + maybe_prunable):
+        assert process_name is not None
         if time < (now - timedelta(days=2)):
             logger.info("Removing worktree without recent activity %s" % worktree.path)
             delete_worktree(process_name, worktree)
@@ -126,7 +127,7 @@ def worktrees(pygit2_repo):
 
 
 def prune_worktrees(pygit2_repo):
-    # type: (Repository) -> Iterator[PyGit2Worktree]
+    # type: (Repository) -> None
     for worktree in worktrees(pygit2_repo):
         # For some reason libgit2 thinks worktrees are not prunable when their
         # working dir is gone

--- a/sync/wptmeta/__init__.py
+++ b/sync/wptmeta/__init__.py
@@ -59,8 +59,8 @@ def parse_test(test_id):
     dir_name, test_file = id_parts.path.rsplit("/", 1)
     if dir_name[0] == "/":
         dir_name = dir_name[1:]
-    test_name = urllib.parse.urlunsplit((None, None, test_file, id_parts.query,
-                                         id_parts.fragment))  # type: ignore
+    test_name = urllib.parse.urlunsplit((None, None, test_file, id_parts.query,  # type: ignore
+                                         id_parts.fragment))
     return dir_name, test_name
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -170,7 +170,10 @@ username=test""")
             print("%s, cwd=%s" % (" ".join(cmd), self.working_tree))
             return subprocess.check_output(cmd, cwd=self.working_tree)
         call.__name__ = name
-        return types.MethodType(call, self, hg)
+        args = (call, self)
+        if six.PY2:
+            args += (hg,)
+        return types.MethodType(*args)
 
 
 @pytest.fixture(scope="function")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -314,7 +314,7 @@ def hg_commit(hg, message, bookmarks):
         bookmarks = [bookmarks]
     for bookmark in bookmarks:
         hg.bookmark(bookmark)
-    assert "+" not in hg.identify("--id")
+    assert b"+" not in hg.identify("--id")
     return rev
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -39,7 +39,7 @@ def create_file_data(file_data, repo_workdir, repo_prefix=None):
             dirname = os.path.dirname(path)
             if not os.path.exists(dirname):
                 os.makedirs(dirname)
-            with open(path, "w") as f:
+            with open(path, "wb") as f:
                 f.write(contents)
     return add_paths, del_paths
 
@@ -117,12 +117,12 @@ def env(request, mock_mach, mock_wpt):
 
 @pytest.fixture
 def initial_gecko_content():
-    return {"README": "Initial text\n"}
+    return {"README": b"Initial text\n"}
 
 
 @pytest.fixture
 def initial_wpt_content(env):
-    return {"example/test.html": """<title>Example test</title>
+    return {"example/test.html": b"""<title>Example test</title>
 <script src='/resources/testharness.js'></script>
 <script src='/resources/testharnessreport.js'></script>
 <script>
@@ -130,12 +130,12 @@ test(() => assert_true(true), "Passing test");
 test(() => assert_true(false), "Failing test");
 </script>
 """,
-            "LICENSE": "Initial license\n"}
+            "LICENSE": b"Initial license\n"}
 
 
 @pytest.fixture
 def initial_meta_content(env):
-    return {"example/META.yml": """
+    return {"example/META.yml": b"""
 links:
   - url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1234
     product: firefox
@@ -196,7 +196,7 @@ def hg_gecko_upstream(env, initial_gecko_content, initial_wpt_content, git_wpt_u
     local_rev = hg_gecko.log("-l1", "--template={node}")
     upstream_rev = git_wpt_upstream.commit("HEAD")
 
-    content = "local: %s\nupstream: %s\n" % (local_rev, upstream_rev)
+    content = b"local: %s\nupstream: %s\n" % (local_rev, upstream_rev.hexsha)
 
     wpt_paths, _ = create_file_data(initial_wpt_content, repo_dir,
                                     env.config["gecko"]["path"]["wpt"])

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -49,4 +49,5 @@ def test_processname_idx_type(git_gecko, local_gecko_commit):
     idx.insert(process_name)
 
     assert idx.get("sync", "upstream", "1234") == {process_name}
-    assert idx.get("sync", "upstream", 1234) == {process_name}
+    with pytest.raises(AssertionError):
+        assert idx.get("sync", "upstream", 1234)

--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -293,15 +293,15 @@ def test_message_filter():
     sync.configure_mock(bug=1234, pr=7)
     msg, _ = downstream.DownstreamSync.message_filter.__func__(
         sync,
-        """Upstream summary
+        b"""Upstream summary
 
 Upstream message
 
 Cq-Include-Trybots: luci.chromium.try:android_optional_gpu_tests_rel;"""
-        "luci.chromium.try:mac_optional_gpu_tests_rel;"
-        "master.tryserver.chromium.linux:linux_mojo;"
-        "master.tryserver.chromium.mac:ios-simulator-cronet;"
-        "master.tryserver.chromium.mac:ios-simulator-full-configs")
+        b"luci.chromium.try:mac_optional_gpu_tests_rel;"
+        b"master.tryserver.chromium.linux:linux_mojo;"
+        b"master.tryserver.chromium.mac:ios-simulator-cronet;"
+        b"master.tryserver.chromium.mac:ios-simulator-full-configs")
 
     assert msg == (u"""Bug 1234 [wpt PR 7] - Upstream summary, a=testonly
 
@@ -313,7 +313,7 @@ Cq-Include-Trybots: luci.chromium.try\u200B:android_optional_gpu_tests_rel;"""
                    u"luci.chromium.try\u200B:mac_optional_gpu_tests_rel;"
                    u"master.tryserver.chromium.linux:linux_mojo;"
                    u"master.tryserver.chromium.mac:ios-simulator-cronet;"
-                   u"master.tryserver.chromium.mac:ios-simulator-full-configs")
+                   u"master.tryserver.chromium.mac:ios-simulator-full-configs").encode("utf8")
 
 
 def test_github_label_on_error(env, git_gecko, git_wpt, pull_request):

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -154,7 +154,7 @@ def test_landable_skipped(env, git_gecko, git_wpt, git_wpt_upstream, pull_reques
 
     wpt_head, landable_commits = landing.landable_commits(git_gecko, git_wpt, prev_wpt_head.hexsha)
     assert len(landable_commits) == 1
-    assert landable_commits[0][0] == str(pr.number)
+    assert landable_commits[0][0] == pr.number
     assert landable_commits[0][1] == downstream_sync
 
 

--- a/test/test_notify.py
+++ b/test/test_notify.py
@@ -5,9 +5,10 @@ from sync.wptmeta import MetaLink
 def test_results_wptfyi(env, pr_19900_github):
     results_data = results.Results()
     results_data.add_jobs_from_log_files(*pr_19900_github)
-    assert results_data.summary() == {
-        "parent_tests": 1,
-        "subtests": 1,
+    summary = results_data.summary()
+    assert summary.parent_tests == 1
+    assert summary.subtests == 1
+    assert summary.job_results == {
         "OK": {"chrome": {"GitHub": 1},
                "safari": {"GitHub": 1}},
         "FAIL": {"chrome": {"GitHub": 1},
@@ -80,9 +81,10 @@ FAIL  : 1
 def test_results_gecko(env, pr_19900_gecko_ci):
     results_data = results.Results()
     results_data.add_jobs_from_log_files(*pr_19900_gecko_ci)
-    results_data.summary() == {
-        "subtests": 1,
-        "parent_tests": 1,
+    summary = results_data.summary()
+    assert summary.subtests == 1
+    assert summary.parent_tests == 1
+    assert summary.job_results == {
         "NOTRUN": {
             "firefox": {
                 "Gecko-windows10-64-qr-debug": 1,

--- a/test/test_notify_bugs.py
+++ b/test/test_notify_bugs.py
@@ -63,15 +63,15 @@ def test_msg_failure():
     results_obj = fx_only_failure()
 
     class Sync(object):
-        pr = "1234"
-        bug = "100000"
+        pr = 1234
+        bug = 100000
 
     output = bugs.bug_data_failure(Sync(),
                                    [("/test/test.html",
                                      None,
                                      results_obj.test_results["/test/test.html"])],
                                    "https://treeherder.mozilla.org/#/jobs?repo=try&revision=1234",
-                                   "12345")
+                                   12345)
     assert output == (
         'New wpt failures in /test/test.html',
         """Syncing wpt [PR 1234](https://github.com/web-platform-tests/wpt/pull/1234)\

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -21,7 +21,7 @@ def test_create_pr(env, git_gecko, git_wpt, upstream_gecko_commit):
     assert syncs.keys() == ["open"]
     assert len(syncs["open"]) == 1
     sync = syncs["open"].pop()
-    assert sync.bug == "1234"
+    assert sync.bug == 1234
     assert sync.status == "open"
     assert len(sync.gecko_commits) == 1
     assert len(sync.wpt_commits) == 1
@@ -57,7 +57,7 @@ def test_create_pr_backout(git_gecko, git_wpt, upstream_gecko_commit,
     assert syncs.keys() == ["open"]
     assert len(syncs["open"]) == 1
     sync = syncs["open"].pop()
-    assert sync.bug == "1234"
+    assert sync.bug == 1234
     assert sync.status == "open"
     assert len(sync.gecko_commits) == 1
     assert len(sync.wpt_commits) == 1
@@ -71,7 +71,7 @@ def test_create_pr_backout(git_gecko, git_wpt, upstream_gecko_commit,
     assert syncs.keys() == ["incomplete"]
     assert len(syncs["incomplete"]) == 1
     sync = syncs["incomplete"].pop()
-    assert sync.bug == "1234"
+    assert sync.bug == 1234
     assert len(sync.gecko_commits) == 0
     assert len(sync.wpt_commits) == 1
     assert len(sync.upstreamed_gecko_commits) == 1
@@ -121,7 +121,7 @@ def test_create_pr_backout_reland(git_gecko, git_wpt, upstream_gecko_commit,
     assert len(syncs["open"]) == 1
     sync = syncs["open"].pop()
     assert sync.process_name.seq_id == 0
-    assert sync.bug == "1234"
+    assert sync.bug == 1234
     assert len(sync.gecko_commits) == 1
     assert len(sync.wpt_commits) == 1
     assert len(sync.upstreamed_gecko_commits) == 1
@@ -158,7 +158,7 @@ def test_create_partial_backout_reland(git_gecko, git_wpt, upstream_gecko_commit
     assert syncs.keys() == ["open"]
     assert len(syncs["open"]) == 1
     sync = syncs["open"].pop()
-    assert sync.bug == "1234"
+    assert sync.bug == 1234
     assert len(sync.gecko_commits) == 2
     assert len(sync.wpt_commits) == 2
     assert sync.status == "open"
@@ -294,7 +294,7 @@ def test_upstream_existing(env, git_gecko, git_wpt, upstream_gecko_commit, upstr
     syncs = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
     sync = pushed.pop()
     assert syncs == {"open": {sync}}
-    assert sync.bug == "1234"
+    assert sync.bug == 1234
     assert sync.status == "open"
     assert len(sync.gecko_commits) == 2
     assert len(sync.wpt_commits) == 1


### PR DESCRIPTION
This includes all the fixes required to mypy annotate (most of) the codebase, and to pass both mypy checks and the unit tests.

Unfortunately there were ~750 initial failures and more when additional annotations were added. I don't know any way to make fixing that volume of errors in a period of weeks easy to review. So this isn't very easy. Initially I tried to do one commit per file, but that broke down at some point.

There are a few substantive changes and limitations that are worth pointing out. The biggest is that PR ids and bug numbers are now almost always passed around as numbers to match their representation in the third party APIs. However they are still strings in the ProcessName class; it might be worth changing that in a followup. 

Mypy doesn't handle decorators well in general and seems to be entirely useless for decorated properties. That makes the `@mut` pattern hard to typecheck and `@mut` property setters are all `#type: ignore` to suppress errors. I think we should do a cleanup commit to remove the pattern from the codebase in favour of explicit setters :/

In many places the typechecker requires extra hints; these are preferentially implemented with `assert isinstance()` so that we also get runtime checks, since the chance of regressions is high, particuarly where the typechecking can't trace the code flow.

This didn't move the code uniformly to unicode literals, but since we eschew the `str` type in favour of `Text` for py3 compat, it might actually be possible.