### PR TITLE
Ensure mach commands use correct, independent state

### DIFF
--- a/config/dev/sync.ini
+++ b/config/dev/sync.ini
@@ -3,6 +3,7 @@ repos = .
 worktrees = work
 logs = logs
 locks = locks
+state = state
 # testing only
 remotes = remotes
 try_logs = try_logs

--- a/sync/worktree.py
+++ b/sync/worktree.py
@@ -220,12 +220,16 @@ class Worktree(object):
                                                          os.path.abspath(self.path),
                                                          self.pygit2_repo.lookup_reference(
                                                              "refs/heads/%s" % self.process_name))
+                wrapper = wrapper_get(self.repo)
+                assert wrapper is not None
+                wrapper.after_worktree_create(self.path)
             else:
                 worktree = self.pygit2_repo.lookup_worktree(self.worktree_name)
 
             assert os.path.exists(self.path)
             assert worktree.path == self.path
             self._worktree = git.Repo(self.path)
+
         # TODO: In general the worktree should be on the right branch, but it would
         # be good to check. In the specific case of landing, we move the wpt worktree
         # around various commits, so it isn't necessarily on the correct branch
@@ -249,3 +253,6 @@ class Worktree(object):
                 return
         assert worktree.path == self.path
         delete_worktree(self.process_name, worktree)
+        wrapper = wrapper_get(self.repo)
+        assert wrapper is not None
+        wrapper.after_worktree_delete(self.path)

--- a/sync_prod.ini
+++ b/sync_prod.ini
@@ -6,6 +6,7 @@ worktrees = work
 logs = logs
 try_logs = data
 locks = locks
+state = state
 
 [pulse]
 username = %SECRET%

--- a/test/config/sync.ini
+++ b/test/config/sync.ini
@@ -3,6 +3,7 @@ repos = repos
 worktrees = work
 logs = logs
 locks = locks
+state = state
 # testing only
 remotes = remotes
 try_logs = try_logs

--- a/test/test_worktree.py
+++ b/test/test_worktree.py
@@ -1,0 +1,23 @@
+import os
+
+from sync import base, repos, worktree
+from sync.lock import SyncLock
+
+
+def test_create_delete(env, git_gecko, hg_gecko_upstream):
+    git_gecko.remotes.mozilla.fetch()
+    process_name = base.ProcessName("sync", "downstream", "1", "0")
+    wt = worktree.Worktree(git_gecko, process_name)
+    with SyncLock.for_process(process_name) as lock:
+        base.BranchRefObject.create(lock, git_gecko, process_name, "FETCH_HEAD")
+        with wt.as_mut(lock):
+            wt.get()
+
+            assert os.path.exists(wt.path)
+            # This is a gecko repo so it ought to have created a state directory
+            state_path = repos.Gecko.get_state_path(env.config, wt.path)
+            assert os.path.exists(state_path)
+
+            wt.delete()
+            assert not os.path.exists(wt.path)
+            assert not os.path.exists(state_path)


### PR DESCRIPTION
Running `mach` now requires first running `mach
create-mach-environment`, which creates a virtualenv. We need to do
that for each worktree and we don't want to share state between
worktrees, since recreating the mach environment while a command is
running may cause problems. So instead we add lifecycle events to
worktree creation and deletion, and use those events to first create a
state directory specific to the worktree and then later delete it. To
ensure the correct state directory is used we also need to set the
MOZBUILD_STATE_PATH environment variable each time we invoke mach.