### PR TITLE
Only handle decision tasks with the decision task handler

### DIFF
--- a/sync/listen.py
+++ b/sync/listen.py
@@ -244,13 +244,17 @@ class DecisionTaskFilter(Filter):
     name = "decision-task"
 
     def accept(self, body):
-        tags = body.get("task", {}).get("tags", {})
-        return (tags.get("kind") == "decision-task" and
-                tags.get("createdForUser") == "wptsync@mozilla.com")
+        return is_decision_task(body)
 
 
 class TryTaskFilter(Filter):
     name = "try-task"
 
     def accept(self, body):
-        return True
+        return not is_decision_task(body)
+
+
+def is_decision_task(body):
+    tags = body.get("task", {}).get("tags", {})
+    return (tags.get("kind") == "decision-task" and
+            tags.get("createdForUser") == "wptsync@mozilla.com")

--- a/test/sample-data/taskcluster/decision-task-success-pulse.json
+++ b/test/sample-data/taskcluster/decision-task-success-pulse.json
@@ -1,0 +1,37 @@
+{
+  "status": {
+    "workerType": "decision",
+    "taskGroupId": "DwAqOASuSxiNP1ChX8iwkw",
+    "runs": [
+      {
+        "scheduled": "2020-03-09T13:34:02.348Z",
+        "reasonCreated": "scheduled",
+        "taken\nUntil": "2020-03-09T13:54:16.522Z",
+        "started": "2020-03-09T13:34:16.540Z",
+        "workerId": "i-0fe01fd37331ac5bf",
+        "reasonResolved": "completed",
+        "workerGroup": "aws",
+        "state": "completed",
+        "runId": 0,
+        "resolved": "\n2020-03-09T13:36:18.355Z"
+      }
+    ],
+    "expires": "2020-04-06T13:34:01.774Z",
+    "retriesLeft": 5,
+    "state": "completed",
+    "schedulerId": "gecko-level-1",
+    "deadline": "2020-03-10T13:34:01.774Z",
+    "taskId": "DwAqOASuSxiNP1ChX8i\nwkw",
+    "provisionerId": "gecko-1"
+  },
+  "task": {
+    "tags": {
+      "createdForUser": "wptsync@mozilla.com",
+      "kind": "decision-task"
+    }
+  },
+  "workerId": "i-0fe01fd37331ac5bf",
+  "workerGroup": "aws",
+  "version": 1,
+  "runId": 0
+}

--- a/test/sample-data/taskcluster/test-task-success-pulse.json
+++ b/test/sample-data/taskcluster/test-task-success-pulse.json
@@ -1,0 +1,41 @@
+{
+  "status": {
+    "taskId": "CtDM1BbHRoup0547JB-Lxw",
+    "provisionerId": "gecko-t",
+    "workerType": "t-linux-xlarge-source",
+    "schedulerId": "gecko-level-1",
+    "taskGroupId": "XVU\nSwAt0Tha5apuF29H9ZQ",
+    "deadline": "2020-09-24T21:41:19.383Z",
+    "expires": "2020-10-21T21:41:19.383Z",
+    "retriesLeft": 5,
+    "state": "completed",
+    "runs": [
+      {
+        "runId": 0,
+        "state": "completed",
+        "reasonCreated": "schedul\ned",
+        "reasonResolved": "completed",
+        "workerGroup": "us-west-1",
+        "workerId": "i-03511e7cb6d7e6112",
+        "takenUntil": "2020-09-23T22:01:39.040Z",
+        "scheduled": "2020-09-23T21:41:38.984Z",
+        "started": "2020-09-23T21:41\n:39.045Z",
+        "resolved": "2020-09-23T21:42:47.262Z"
+      }
+    ]
+  },
+  "runId": 0,
+  "task": {
+    "tags": {
+      "os": "linux",
+      "kind": "source-test",
+      "label": "source-test-mozlint-file-whitespace",
+      "retrigger": "true",
+      "createdForUser": "wptsync@mozilla.com",
+      "worker-implementation": "docker-worker"
+    }
+  },
+  "workerGroup": "us-west-1",
+  "workerId": "i-03511e7cb6d7e6112",
+  "version": 1
+}

--- a/test/test_listen.py
+++ b/test/test_listen.py
@@ -1,0 +1,24 @@
+import json
+from sync import listen
+
+
+def test_try_task_filter(env, tc_response):
+    filter_ = listen.TryTaskFilter(env.config, listen.logger)
+    with tc_response("decision-task-success-pulse.json") as f:
+        data = json.load(f)
+        assert filter_.accept(data) is False
+
+    with tc_response("test-task-success-pulse.json") as f:
+        data = json.load(f)
+        assert filter_.accept(data) is True
+
+
+def test_decision_task_filter(env, tc_response):
+    filter_ = listen.DecisionTaskFilter(env.config, listen.logger)
+    with tc_response("decision-task-success-pulse.json") as f:
+        data = json.load(f)
+        assert filter_.accept(data) is True
+
+    with tc_response("test-task-success-pulse.json") as f:
+        data = json.load(f)
+        assert filter_.accept(data) is False


### PR DESCRIPTION
We only want to set the taskgroup id from successful decision tasks.
Handling these in both the try-task handler and the decsion-task
handler means we end up setting the taskgroup id even when the
decision task failed, which then means we have the wrong
taskgroup id and can't download the test results