### PR TITLE
Ensure has_metadata is called with bytes

### DIFF
--- a/sync/update.py
+++ b/sync/update.py
@@ -157,6 +157,7 @@ def update_pr(git_gecko, git_wpt, pr, force_rebase=False, repo_update=True):
         # If this looks like something that came from gecko, create
         # a corresponding sync
         with SyncLock("upstream", None) as lock:
+            assert isinstance(lock, SyncLock)
             upstream_sync = upstream.UpstreamSync.from_pr(lock,
                                                           git_gecko,
                                                           git_wpt,

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -119,19 +119,26 @@ class UpstreamSync(SyncProcess):
         return self
 
     @classmethod
-    def from_pr(cls, lock, git_gecko, git_wpt, pr_id, body):
+    def from_pr(cls,
+                lock,  # type: SyncLock
+                git_gecko,  # type: Repo
+                git_wpt,  # type: Repo
+                pr_id,  # type: int
+                body  # type: Text
+                ):
+        # type: (...) -> Optional[UpstreamSync]
         gecko_commits = []
         bug = None
         integration_branch = None
 
-        if not cls.has_metadata(body):
+        if not cls.has_metadata(body.encode("utf8", "replace")):
             return None
 
         commits = env.gh_wpt.get_commits(pr_id)
 
         for gh_commit in commits:
             commit = sync_commit.WptCommit(git_wpt, gh_commit.sha)
-            if cls.has_metadata(commit.message):
+            if cls.has_metadata(commit.msg):
                 gecko_commits.append(git_gecko.cinnabar.hg2git(commit.metadata["gecko-commit"]))
                 commit_bug = env.bz.id_from_url(commit.metadata["bugzilla-url"])
                 if bug is not None and commit_bug != bug:


### PR DESCRIPTION
has_metadata assumes that it's being called with a commit message that's
represented as bytes. UpstreamSync.from_pr also called it with a PR body
that's Text. Add the relevant type annotations and ensure we pass in bytes.