### PR TITLE
Fix the asserts when checking we have all commits in a landing

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -142,7 +142,8 @@ test(() => assert_true(true), "Passing test");
 test(() => assert_true(false), "Failing test");
 </script>
 """,
-            "LICENSE": b"Initial license\n"}
+            "LICENSE": b"Initial license\n",
+            "resources/testdriver_vendor.js": b"Initial testdriver_vendor\n"}
 
 
 @pytest.fixture


### PR DESCRIPTION
The previous patch failed to consider two cases:

 * Upstream syncs which typically (but not always) don't result in a
   patch to gecko.

 * Downstream syncs for changes that were also applied
   to gecko (this happens sometimes when people don't want to wait for
   the sync)

This fixes the two cases as follows:

 * For upstream syncs it counts the number of such syncs and adds that
   number to the relevent assert.

 * For downstream syncs it ensures that there's always a commit even
   if it's empty. This commit will be removed later when we rebase
   onto autoland.