### PR TITLE
Don't convert pr name to string for comparison

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -848,7 +848,7 @@ class DownstreamSync(SyncProcess):
             # merged and if so what the merge commit was, although in that
             # case we would still not know the commit prior to merge, which
             # is what we need
-            if commit.pr() == str(self.pr):
+            if commit.pr() == self.pr:
                 break
             commits.append(commit)
         return commits


### PR DESCRIPTION
That means the comparison will always fail since both sides are now integers