### PR TITLE
Don't encode attachment we send to bugzilla

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -983,7 +983,7 @@ class DownstreamSync(SyncProcess):
 
         with env.bz.bug_ctx(self.bug) as bug:
             if truncated:
-                bug.add_attachment(data=message.encode("utf8"),
+                bug.add_attachment(data=message,
                                    file_name="wpt-results.md",
                                    summary="Notable wpt changes",
                                    is_markdown=True,


### PR DESCRIPTION
AFAICT from bugsy this is wrong, even though you might think an attachment
is arbitary bytes. Hard to write a meaningful test for this, but if it
works we should stop seeing some errors in new relic