### PR TITLE
Ensure mercurial is installed under python2

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -34,9 +34,9 @@ RUN set -eux; \
         # Required by cinnabar, mach, wpt, even for Py3
         python2.7 \
         python3 \
-        python3-distutils; \
-        apt-get install -y \
-           python3-pip; \
+        python3-distutils \
+        python-pip \
+        python3-pip; \
         pip3 install --upgrade pip; \
         pip3 install --user requests;
 
@@ -139,7 +139,8 @@ RUN set -eux; \
     # Install the wptsync app in development
     pip3 install -r /app/wpt-sync/requirements/prod.txt --no-deps --require-hashes \
     && pip3 install -r /app/wpt-sync/requirements/dev.txt --no-deps \
-    && pip3 install -r /app/wpt-sync/requirements/mozautomation.txt --no-deps
+    && pip3 install -r /app/wpt-sync/requirements/mozautomation.txt --no-deps \
+    && pip2 install -r /app/wpt-sync/requirements/py2.txt
 
 # /app/wpt-sync: bind mount to src dir (only on dev) or dir with wheels?
 # /app/workspace: bind mount to [empty] dir where service will write working data, logs

--- a/requirements/py2.txt
+++ b/requirements/py2.txt
@@ -1,0 +1,2 @@
+mercurial==5.4.2 \
+    --hash=sha256:5c8b93da701ee39e312da9e35a7f3163e17ed173a4707857bc467c3b3ab74853


### PR DESCRIPTION
That's required for git cinnabar. We pin the version to 5.4.x because
release cinnabar doesn't yet support 5.5.x