### PR TITLE
Don't try to get the branch protection endpoint

### DIFF
--- a/sync/gh.py
+++ b/sync/gh.py
@@ -218,7 +218,10 @@ class GitHub(object):
         if branch is None:
             # TODO: Maybe raise an exception here
             return []
-        return branch.get_required_status_checks().contexts
+        return (branch.raw_data
+                .get("protection", {})
+                .get("required_status_checks", {})
+                .get("contexts", []))
 
     def get_check_runs(self, pr_id):
         # type: (int) -> Dict[Text, Dict[Text, Any]]


### PR DESCRIPTION
This returns a 404 for reasons I don't understand (maybe
permissions). But the data we need is returned in the branch response,
it's just that pygithub doens't expose it. So use the raw_data to get
at it.