### PR TITLE
Convert type comments to type annotations as per issue #797

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,5 +135,5 @@ sudo chown -R 10001 <path>
 
 You may not need to do this at all on mac.
 
-__Note__ that replacing the default entrypoint means that you're nolonger running the `start_wptsync.sh` script at container start-up and therefore some
+__Note__ that replacing the default entry point means that you're no longer running the `start_wptsync.sh` script at container start-up and therefore some
 configuration may be missing or incomplete. For example, the Dockerfile (build-time) doesn't set up any credentials; instead, credentials are only set up in the container at run-time with the above-mentioned script.

--- a/sync/base.py
+++ b/sync/base.py
@@ -75,7 +75,7 @@ class IdentityMap(type):
     determined based on data that forms part of the instance key rather
     than passed in explicitly."""
 
-    _cache = weakref.WeakValueDictionary()  # type: weakref.WeakValueDictionary
+    _cache: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
 
     def __init__(cls, name, bases, cls_dict):
         if not hasattr(cls, "_cache_key"):
@@ -97,11 +97,10 @@ class IdentityMap(type):
         return value
 
 
-def iter_tree(pygit2_repo,  # type: Repository
-              root_path="",  # type: Text
-              rev=None,  # type: Optional[PyGit2Commit]
-              ):
-    # type: (...) -> Iterator[Tuple[Tuple[Text, ...], TreeEntry]]
+def iter_tree(pygit2_repo: Repository,
+              root_path: Text = "",
+              rev: Optional[PyGit2Commit] = None,
+              ) -> Iterator[Tuple[Tuple[Text, ...], TreeEntry]]:
     """Iterator over all paths ins a tree"""
     if rev is None:
         ref_name = env.config["sync"]["ref"]
@@ -134,10 +133,9 @@ def iter_tree(pygit2_repo,  # type: Repository
                 yield name, item
 
 
-def iter_process_names(pygit2_repo,  # type: Repository
-                       kind=["sync", "try"],  # type: List[str]
-                       ):
-    # type: (...) -> Iterator[ProcessName]
+def iter_process_names(pygit2_repo: Repository,
+                       kind: List[str] = ["sync", "try"],
+                       ) -> Iterator[ProcessName]:
     """Iterator over all ProcessName objects"""
     ref = pygit2_repo.references[env.config["sync"]["ref"]]
     root = ref.peel().tree
@@ -163,33 +161,28 @@ def iter_process_names(pygit2_repo,  # type: Repository
 
 
 class ProcessNameIndex(six.with_metaclass(IdentityMap, object)):
-    def __init__(self, repo):
-        # type: (Repo) -> None
+    def __init__(self, repo: Repo) -> None:
         self.repo = repo
         self.pygit2_repo = pygit2_get(repo)
         self.reset()
 
     @classmethod
-    def _cache_key(cls, repo):
-        # type: (Repo) -> Tuple[Repo]
+    def _cache_key(cls, repo: Repo) -> Tuple[Repo]:
         return (repo,)
 
-    def reset(self):
-        # type: () -> None
-        self._all = set()  # type: Set[ProcessName]
-        self._data = defaultdict(
+    def reset(self) -> None:
+        self._all: Set[ProcessName] = set()
+        self._data: ProcessNameIndexData = defaultdict(
             lambda: defaultdict(
-                lambda: defaultdict(set)))  # type: ProcessNameIndexData
+                lambda: defaultdict(set)))
         self._built = False
 
-    def build(self):
-        # type: () -> None
+    def build(self) -> None:
         for process_name in iter_process_names(self.pygit2_repo):
             self.insert(process_name)
         self._built = True
 
-    def insert(self, process_name):
-        # type: (ProcessName) -> None
+    def insert(self, process_name: ProcessName) -> None:
         self._all.add(process_name)
 
         self._data[
@@ -197,14 +190,12 @@ class ProcessNameIndex(six.with_metaclass(IdentityMap, object)):
                 process_name.subtype][
                     process_name.obj_id].add(process_name)
 
-    def has(self, process_name):
-        # type: (ProcessName) -> bool
+    def has(self, process_name: ProcessName) -> bool:
         if not self._built:
             self.build()
         return process_name in self._all
 
-    def get(self, obj_type, subtype=None, obj_id=None):
-        # type: (Text, Optional[Text], Optional[Text]) -> Set[ProcessName]
+    def get(self, obj_type: Text, subtype: Optional[Text] = None, obj_id: Optional[Text] = None) -> Set[ProcessName]:
         if not self._built:
             self.build()
 
@@ -213,9 +204,9 @@ class ProcessNameIndex(six.with_metaclass(IdentityMap, object)):
             assert isinstance(key, six.string_types)
             if key is None:
                 break
-            target = target[key]  # type: ignore
+            target: ignore = target[key]
 
-        rv = set()  # type: Set[ProcessName]
+        rv: Set[ProcessName] = set()
         stack = [target]
 
         while stack:
@@ -239,8 +230,7 @@ class ProcessName(six.with_metaclass(IdentityMap, object)):
 
     """
 
-    def __init__(self, obj_type, subtype, obj_id, seq_id):
-        # type: (Text, Text, Text, Union[Text, int]) -> None
+    def __init__(self, obj_type: Text, subtype: Text, obj_id: Text, seq_id: Union[Text, int]) -> None:
         assert obj_type is not None
         assert subtype is not None
         assert obj_id is not None
@@ -253,73 +243,60 @@ class ProcessName(six.with_metaclass(IdentityMap, object)):
 
     @classmethod
     def _cache_key(cls,
-                   obj_type,  # type: Text
-                   subtype,  # type: Text
-                   obj_id,  # type: Text
-                   seq_id,  # type: Union[Text, int]
-                   ):
-        # type: (...) -> Tuple[Text, Text, Text, Text]
+                   obj_type: Text,
+                   subtype: Text,
+                   obj_id: Text,
+                   seq_id: Union[Text, int],
+                   ) -> Tuple[Text, Text, Text, Text]:
         return (obj_type, subtype, six.ensure_text(str(obj_id)), six.ensure_text(str(seq_id)))
 
-    def __str__(self):
-        # type: () -> str
+    def __str__(self) -> str:
         data = u"%s/%s/%s/%s" % self.as_tuple()
         if sys.version_info[0] == 2:
             data = data.encode("utf8")
         return data
 
-    def key(self):
-        # type: () -> Tuple[Text, Text, Text, Text]
+    def key(self) -> Tuple[Text, Text, Text, Text]:
         return self._cache_key(self._obj_type, self._subtype, self._obj_id, self._seq_id)
 
-    def path(self):
-        # type: () -> Text
+    def path(self) -> Text:
         return u"%s/%s/%s/%s" % self.as_tuple()
 
-    def __eq__(self, other):
-        # type: (Any) -> bool
+    def __eq__(self, other: Any) -> bool:
         if self is other:
             return True
         if self.__class__ != other.__class__:
             return False
         return self.as_tuple() == other.as_tuple()
 
-    def __hash__(self):
-        # type: () -> int
+    def __hash__(self) -> int:
         return hash(self.key())
 
     @property
-    def obj_type(self):
-        # type: () -> Text
+    def obj_type(self) -> Text:
         return self._obj_type
 
     @property
-    def subtype(self):
-        # type: () -> Text
+    def subtype(self) -> Text:
         return self._subtype
 
     @property
-    def obj_id(self):
-        # type: () -> Text
+    def obj_id(self) -> Text:
         return self._obj_id
 
     @property
-    def seq_id(self):
-        # type: () -> int
+    def seq_id(self) -> int:
         return int(self._seq_id)
 
-    def as_tuple(self):
-        # type: () -> Tuple[Text, Text, Text, int]
+    def as_tuple(self) -> Tuple[Text, Text, Text, int]:
         return (self.obj_type, self.subtype, self.obj_id, self.seq_id)
 
     @classmethod
-    def from_path(cls, path):
-        # type: (Text) -> Optional[ProcessName]
+    def from_path(cls, path: Text) -> Optional[ProcessName]:
         return cls.from_tuple(path.split("/"))
 
     @classmethod
-    def from_tuple(cls, parts):
-        # type: (List[Text]) -> Optional[ProcessName]
+    def from_tuple(cls, parts: List[Text]) -> Optional[ProcessName]:
         if parts[0] not in [u"sync", u"try"]:
             return None
         if len(parts) != 4:
@@ -327,8 +304,7 @@ class ProcessName(six.with_metaclass(IdentityMap, object)):
         return cls(*parts)
 
     @classmethod
-    def with_seq_id(cls, repo, obj_type, subtype, obj_id):
-        # type: (Repo, Text, Text, Text) -> ProcessName
+    def with_seq_id(cls, repo: Repo, obj_type: Text, subtype: Text, obj_id: Text) -> ProcessName:
         existing = ProcessNameIndex(repo).get(obj_type, subtype, obj_id)
         last_id = -1
         for process_name in existing:
@@ -346,10 +322,9 @@ class VcsRefObject(six.with_metaclass(IdentityMap, object)):
     This is typically either a tag or a head (i.e. branch), but can be any
     git object."""
 
-    ref_prefix = None  # type: Text
+    ref_prefix: Text = None
 
-    def __init__(self, repo, name, commit_cls=sync_commit.Commit):
-        # type: (Repo, Union[ProcessName, SyncPointName], type) -> None
+    def __init__(self, repo: Repo, name: Union[ProcessName, SyncPointName], commit_cls: type = sync_commit.Commit) -> None:
         self.repo = repo
         self.pygit2_repo = pygit2_get(repo)
 
@@ -360,33 +335,28 @@ class VcsRefObject(six.with_metaclass(IdentityMap, object)):
         self.commit_cls = commit_cls
         self._lock = None
 
-    def as_mut(self, lock):
-        # type: (SyncLock) -> MutGuard
+    def as_mut(self, lock: SyncLock) -> MutGuard:
         return MutGuard(lock, self)
 
     @property
-    def lock_key(self):
-        # type: () -> Tuple[Text, Text]
+    def lock_key(self) -> Tuple[Text, Text]:
         return (self.name.subtype, self.name.obj_id)
 
     @classmethod
     def _cache_key(cls,
-                   repo,  # type: Repo
-                   process_name,  # type: Union[ProcessName, SyncPointName]
-                   commit_cls=sync_commit.Commit,  # type: type
-                   ):
-        # type: (...) -> Tuple[Repo, Union[ProcessNameKey, Tuple[Text, Text]]]
+                   repo: Repo,
+                   process_name: Union[ProcessName, SyncPointName],
+                   commit_cls: type = sync_commit.Commit,
+                   ) -> Tuple[Repo, Union[ProcessNameKey, Tuple[Text, Text]]]:
         return (repo, process_name.key())
 
-    def _cache_verify(self, repo, process_name, commit_cls=sync_commit.Commit):
-        # type: (Repo, Union[ProcessName, SyncPointName], type) -> bool
+    def _cache_verify(self, repo: Repo, process_name: Union[ProcessName, SyncPointName], commit_cls: type = sync_commit.Commit) -> bool:
         return commit_cls == self.commit_cls
 
     @classmethod
     @constructor(lambda args: (args["name"].subtype,
                                args["name"].obj_id))
-    def create(cls, lock, repo, name, obj, commit_cls=sync_commit.Commit):
-        # type: (SyncLock, Repo, ProcessName, Text, type) -> VcsRefObject
+    def create(cls, lock: SyncLock, repo: Repo, name: ProcessName, obj: Text, commit_cls: type = sync_commit.Commit) -> VcsRefObject:
         path = cls.get_path(name)
         logger.debug("Creating ref %s" % path)
         pygit2_repo = pygit2_get(repo)
@@ -395,34 +365,28 @@ class VcsRefObject(six.with_metaclass(IdentityMap, object)):
         pygit2_repo.references.create(path, pygit2_repo.revparse_single(obj).id)
         return cls(repo, name, commit_cls)
 
-    def __str__(self):
-        # type: () -> str
+    def __str__(self) -> str:
         return six.ensure_str(self.path)
 
-    def delete(self):
-        # type: () -> None
+    def delete(self) -> None:
         self.pygit2_repo.references[self.path].delete()
 
     @classmethod
-    def get_path(cls, name):
-        # type: (Union[ProcessName, SyncPointName]) -> Text
+    def get_path(cls, name: Union[ProcessName, SyncPointName]) -> Text:
         return u"refs/%s/%s" % (cls.ref_prefix, name.path())
 
     @property
-    def path(self):
-        # type: () -> Text
+    def path(self) -> Text:
         return self.get_path(self.name)
 
     @property
-    def ref(self):
-        # type: () -> Reference
+    def ref(self) -> Reference:
         if self.path in self.pygit2_repo.references:
             return git.Reference(self.repo, self.path)
         return None
 
     @property
-    def commit(self):
-        # type: () -> Optional[Commit]
+    def commit(self) -> Optional[Commit]:
         ref = self.ref
         if ref is not None:
             commit = self.commit_cls(self.repo, ref.commit)
@@ -431,8 +395,7 @@ class VcsRefObject(six.with_metaclass(IdentityMap, object)):
 
     @commit.setter  # type: ignore
     @mut()
-    def commit(self, commit):
-        # type: (Union[Commit, Text]) -> None
+    def commit(self, commit: Union[Commit, Text]) -> None:
         if isinstance(commit, sync_commit.Commit):
             sha1 = commit.sha1
         else:
@@ -447,13 +410,12 @@ class BranchRefObject(VcsRefObject):
 
 class CommitBuilder(object):
     def __init__(self,
-                 repo,  # type: Repo
-                 message,  # type: Text
-                 ref=None,  # type: Optional[Text]
-                 commit_cls=sync_commit.Commit,  # type: type
-                 initial_empty=False  # type: bool
-                 ):
-        # type: (...) -> None
+                 repo: Repo,
+                 message: Text,
+                 ref: Optional[Text] = None,
+                 commit_cls: type = sync_commit.Commit,
+                 initial_empty: bool = False
+                 ) -> None:
         """Object to be used as a context manager for commiting changes to the repo.
 
         This class provides low-level access to the git repository in order to
@@ -495,13 +457,12 @@ class CommitBuilder(object):
 
         # State set for the life of the context manager
         self.lock = RepoLock(repo)
-        self.parents = None  # type: Optional[List[Text]]
+        self.parents: Optional[List[Text]] = None
         self.commit = None
-        self.index = None  # type: pygit2.Index
+        self.index: pygit2.Index = None
         self.has_changes = False
 
-    def __enter__(self):
-        # type: () -> CommitBuilder
+    def __enter__(self) -> CommitBuilder:
         self._count += 1
         if self._count != 1:
             return self
@@ -524,8 +485,7 @@ class CommitBuilder(object):
             self.parents = []
         return self
 
-    def __exit__(self, *args, **kwargs):
-        # type: (*Any, **Any) -> None
+    def __exit__(self, *args: *Any, **kwargs: **Any) -> None:
         self._count -= 1
         if self._count != 0:
             return
@@ -547,31 +507,27 @@ class CommitBuilder(object):
         self.lock.__exit__(*args, **kwargs)
         self.commit = self.commit_cls(self.repo, sha1)
 
-    def add_tree(self, tree):
-        # type: (Dict[Text, bytes]) -> None
+    def add_tree(self, tree: Dict[Text, bytes]) -> None:
         self.has_changes = True
         for path, data in iteritems(tree):
             blob = self.pygit2_repo.create_blob(data)
             index_entry = pygit2.IndexEntry(path, blob, pygit2.GIT_FILEMODE_BLOB)
             self.index.add(index_entry)
 
-    def delete(self, delete):
-        # type: (List[Text]) -> None
+    def delete(self, delete: List[Text]) -> None:
         self.has_changes = True
         if delete:
             for path in delete:
                 self.index.remove(path)
 
-    def get(self):
-        # type: () -> Optional[Any]
+    def get(self) -> Optional[Any]:
         return self.commit
 
 
 class ProcessData(six.with_metaclass(IdentityMap, object)):
-    obj_type = None  # type: Text
+    obj_type: Text = None
 
-    def __init__(self, repo, process_name):
-        # type: (Repo, ProcessName) -> None
+    def __init__(self, repo: Repo, process_name: ProcessName) -> None:
         assert process_name.obj_type == self.obj_type
         self.repo = repo
         self.pygit2_repo = pygit2_get(repo)
@@ -580,30 +536,25 @@ class ProcessData(six.with_metaclass(IdentityMap, object)):
         self.path = self.get_path(process_name)
         self._data = self._load()
         self._lock = None
-        self._updated = set()  # type: Set[Text]
-        self._deleted = set()  # type: Set[Text]
+        self._updated: Set[Text] = set()
+        self._deleted: Set[Text] = set()
         self._delete = False
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         return six.ensure_str("<%s %s>" % (self.__class__.__name__, self.process_name))
 
-    def __hash__(self):
-        # type: () -> int
+    def __hash__(self) -> int:
         return hash(self.process_name)
 
-    def __eq__(self, other):
-        # type: (Any) -> bool
+    def __eq__(self, other: Any) -> bool:
         if type(self) != type(other):
             return False
         return self.repo == other.repo and self.process_name == other.process_name
 
-    def as_mut(self, lock):
-        # type: (SyncLock) -> MutGuard
+    def as_mut(self, lock: SyncLock) -> MutGuard:
         return MutGuard(lock, self)
 
-    def exit_mut(self):
-        # type: () -> None
+    def exit_mut(self) -> None:
         message = u"Update %s\n\n" % self.path
         with CommitBuilder(self.repo, message=message, ref=self.ref.path) as commit:
             from . import index
@@ -630,13 +581,12 @@ class ProcessData(six.with_metaclass(IdentityMap, object)):
     @constructor(lambda args: (args["process_name"].subtype,
                                args["process_name"].obj_id))
     def create(cls,
-               lock,  # type: SyncLock
-               repo,  # type: Repo
-               process_name,  # type: ProcessName
-               data,  # type: Dict[Text, Any]
-               message=u"Sync data",  # type: Text
-               ):
-        # type: (...) -> ProcessData
+               lock: SyncLock,
+               repo: Repo,
+               process_name: ProcessName,
+               data: Dict[Text, Any],
+               message: Text = u"Sync data",
+               ) -> ProcessData:
         assert process_name.obj_type == cls.obj_type
         path = cls.get_path(process_name)
         ref = git.Reference(repo, env.config["sync"]["ref"])
@@ -652,23 +602,20 @@ class ProcessData(six.with_metaclass(IdentityMap, object)):
         return cls(repo, process_name)
 
     @classmethod
-    def _cache_key(cls, repo, process_name):
-        # type: (Repo, ProcessName) -> Tuple[Repo, ProcessNameKey]
+    def _cache_key(cls, repo: Repo, process_name: ProcessName) -> Tuple[Repo, ProcessNameKey]:
         return (repo, process_name.key())
 
     @classmethod
-    def get_path(self, process_name):
-        # type: (ProcessName) -> Text
+    def get_path(self, process_name: ProcessName) -> Text:
         return process_name.path()
 
     @classmethod
     def load_by_obj(cls,
-                    repo,  # type: Repo
-                    subtype,  # type: Text
-                    obj_id,  # type: int
-                    seq_id=None  # Type: Optional[int]
-                    ):
-        # type: (...) -> Set[ProcessData]
+                    repo: Repo,
+                    subtype: Text,
+                    obj_id: int,
+                    seq_idOptional[int] = None
+                    ) -> Set[ProcessData]:
         process_names = ProcessNameIndex(repo).get(cls.obj_type,
                                                    subtype,
                                                    str(obj_id))
@@ -688,8 +635,7 @@ class ProcessData(six.with_metaclass(IdentityMap, object)):
             rv.add(cls(repo, process_name))
         return rv
 
-    def _save(self, data, message, commit_builder=None):
-        # type: (Dict[Text, Any], Text, CommitBuilder) -> Optional[Any]
+    def _save(self, data: Dict[Text, Any], message: Text, commit_builder: CommitBuilder = None) -> Optional[Any]:
         if commit_builder is None:
             commit_builder = CommitBuilder(self.repo, message=message, ref=self.ref.path)
         else:
@@ -699,15 +645,13 @@ class ProcessData(six.with_metaclass(IdentityMap, object)):
             commit.add_tree(tree)
         return commit.get()
 
-    def _delete_data(self, message, commit_builder=None):
-        # type: (Text, Optional[CommitBuilder]) -> None
+    def _delete_data(self, message: Text, commit_builder: Optional[CommitBuilder] = None) -> None:
         if commit_builder is None:
             commit_builder = CommitBuilder(self.repo, message=message, ref=self.ref.path)
         with commit_builder as commit:
             commit.delete([self.path])
 
-    def _load(self):
-        # type: () -> Dict[Text, Any]
+    def _load(self) -> Dict[Text, Any]:
         ref = self.pygit2_repo.references[self.ref.path]
         repo = self.pygit2_repo
         try:
@@ -717,80 +661,65 @@ class ProcessData(six.with_metaclass(IdentityMap, object)):
         return json.loads(data)
 
     @property
-    def lock_key(self):
-        # type: () -> Tuple[Text, Text]
+    def lock_key(self) -> Tuple[Text, Text]:
         return (self.process_name.subtype, self.process_name.obj_id)
 
-    def __getitem__(self, key):
-        # type: (Text) -> Any
+    def __getitem__(self, key: Text) -> Any:
         return self._data[key]
 
-    def __contains__(self, key):
-        # type: (Text) -> bool
+    def __contains__(self, key: Text) -> bool:
         return key in self._data
 
-    def get(self, key, default=None):
-        # type: (Text, Any) -> Any
+    def get(self, key: Text, default: Any = None) -> Any:
         return self._data.get(key, default)
 
-    def items(self):
-        # type: () -> Iterator[Tuple[Text, Any]]
+    def items(self) -> Iterator[Tuple[Text, Any]]:
         for key, value in iteritems(self._data):
             yield key, value
 
     @mut()
-    def __setitem__(self, key, value):
-        # type: (Text, Any) -> None
+    def __setitem__(self, key: Text, value: Any) -> None:
         if key not in self._data or self._data[key] != value:
             self._data[key] = value
             self._updated.add(key)
 
     @mut()
-    def __delitem__(self, key):
-        # type: (Text) -> None
+    def __delitem__(self, key: Text) -> None:
         if key in self._data:
             del self._data[key]
             self._deleted.add(key)
 
     @mut()
-    def delete(self):
-        # type: () -> None
+    def delete(self) -> None:
         self._delete = True
 
 
 class FrozenDict(Mapping):
-    def __init__(self, **kwargs):
-        # type: (**Any) -> None
+    def __init__(self, **kwargs: **Any) -> None:
         self._data = {}
         for key, value in iteritems(kwargs):
             self._data[six.ensure_text(key)] = value
 
-    def __getitem__(self, key):
-        # type: (Text) -> Any
+    def __getitem__(self, key: Text) -> Any:
         return self._data[key]
 
-    def __contains__(self, key):
-        # type: (Any) -> bool
+    def __contains__(self, key: Any) -> bool:
         return key in self._data
 
-    def copy(self, **kwargs):
-        # type: (**Any) -> FrozenDict
+    def copy(self, **kwargs: **Any) -> FrozenDict:
         new_data = self._data.copy()
         for key, value in iteritems(kwargs):
             new_data[six.ensure_text(key)] = value
         return self.__class__(**new_data)
 
-    def __iter__(self):
-        #  type: () -> Iterator[Text]
+    def __iter__(self) -> Iterator[Text]:
         for item in self._data:
             yield item
 
-    def __len__(self):
-        #  type: () -> int
+    def __len__(self) -> int:
         return len(self._data)
 
-    def as_dict(self):
-        # type: () -> Dict[Text, Any]
+    def as_dict(self) -> Dict[Text, Any]:
         return self._data.copy()
 
 
@@ -799,8 +728,7 @@ class entry_point(object):
         self.task = task
 
     def __call__(self, f):
-        def inner(*args, **kwargs):
-            # type: (*Any, **Any) -> Optional[LandingSync]
+        def inner(*args: *Any, **kwargs: **Any) -> Optional[LandingSync]:
             logger.info("Called entry point %s.%s" % (f.__module__, f.__name__))
             logger.debug("Called args %r kwargs %r" % (args, kwargs))
 


### PR DESCRIPTION
Type comments are changed to type annotations on 'base.py' file under 'sync' folder since with Python3 we have now the opportunity to use type annotations. I will be waiting for feedback before continuing to update other files as well.