### PR TITLE
Enable running fission on try

### DIFF
--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -144,7 +144,7 @@ class TryFuzzyCommit(TryCommit):
         super(TryFuzzyCommit, self).__init__(git_gecko, worktree, tests_by_type, rebuild,
                                              hacks=hacks, **kwargs)
         self.queries = self.extra_args.get("queries",
-                                           [u"web-platform-tests !macosx !shippable !asan !fis"])
+                                           [u"web-platform-tests !macosx !shippable !asan"])
         if isinstance(self.queries, six.string_types):
             self.queries = [self.queries]
         self.full = self.extra_args.get("full", False)

--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -70,16 +70,18 @@ def test_wpt_pr_approved(env, git_gecko, git_wpt, pull_request, set_pr_status,
         assert sync.latest_try_push is None
 
         # If we 'merge' the PR, then we will see a stability try push
-        handlers.handle_pr(git_gecko, git_wpt,
-                           {"action": "closed",
-                            "number": pr.number,
-                            "pull_request": {
+        with patch.object(trypush.TryCommit, 'read_treeherder', autospec=True) as mock_read:
+            mock_read.return_value = "0000000000000000"
+            handlers.handle_pr(git_gecko, git_wpt,
+                               {"action": "closed",
                                 "number": pr.number,
-                                "merge_commit_sha": "a" * 25,
-                                "base": {"sha": "b" * 25},
-                                "merged": True,
-                                "state": "closed",
-                                "merged_by": {"login": "test_user"}}})
+                                "pull_request": {
+                                    "number": pr.number,
+                                    "merge_commit_sha": "a" * 25,
+                                    "base": {"sha": "b" * 25},
+                                    "merged": True,
+                                    "state": "closed",
+                                    "merged_by": {"login": "test_user"}}})
         try_push = sync.latest_try_push
         assert try_push.stability
 


### PR DESCRIPTION
Before we were still running the fission disabled configuration. Now that those have `nofis` in the job name, we were failing to run any try builds at all.