### PR TITLE
Downgrade billiard to 3.6.4.0

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -5,9 +5,8 @@ backcall==0.2.0 \
     --hash=sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255
 backports.shutil-get-terminal-size==1.0.0 \
     --hash=sha256:0975ba55054c15e346944b38956a4c9cbee9009391e41b86c68990effb8c1f64
-billiard==4.0.0 \
-    --hash=sha256:344d9a1d7d3addf171eb2c596c9e98d1eff81b0e03f1f9398939a3518ca263a9 \
-    --hash=sha256:5d48c4168456d906c0057f2facc1f6316daa26d611b4b37766d5112057efa22d
+billiard==3.6.4.0 \
+    --hash=sha256:87103ea78fa6ab4d5c751c4909bcff74617d985de7fa8b672cf8618afd5a875b
 bugsy==0.12.0 \
     --hash=sha256:b5df82ff0e708cca73a517bfa80494a43b1b97267d5778a5cba62f7a9d04e9da \
     --hash=sha256:2d49af1cb4a2841e3d677ac535b054c51f457a5d124ad106c43a8fc3847fb26e


### PR DESCRIPTION
4.0.0 breaks Celery; the fix will be in the next Celery release