### PR TITLE
Handle the possibility of a missing reflog

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -287,8 +287,13 @@ Automatic update from web-platform-tests\n%s
             else:
                 # Check if we rebased locally without pushing the rebase;
                 # this is a thing we used to do to check the PR would merge
-                ref_log = sync.git_wpt.references[sync.branch_name].log()
-                commit_is_local = any(entry.newhexsha == pr_head for entry in ref_log)
+                try:
+                    ref_log = sync.git_wpt.references[sync.branch_name].log()
+                except Exception:
+                    # If we can't read the reflog just skip this
+                    pass
+                else:
+                    commit_is_local = any(entry.newhexsha == pr_head for entry in ref_log)
             if commit_is_local:
                 logger.info("Upstream sync doesn't introduce any gecko changes")
                 return None


### PR DESCRIPTION
When landing PRs that came from mozilla-central we check if the are upstream commits are identical to the ones we already pushed, because we know there's no point in re-applying those.

One of the codepaths uses the reflog to check if the upstream commits are the same as any previous head of the PR branch. But it's not guaranteed that a reflog exists for a branch. In particular for very old branches it may have been gc'd. gitpython doesn't handle that situation very well, and raises an exception which suggests a bug.

We can handle that exception and just fallback to the code which assumes that the commits may have changed (even though this is likely to generate a merge conflict that has to be handled manually).