### PR TITLE
Skip "bandit" "request_without_timeout" issues

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,2 @@
 [bandit]
-skips: B101,B404,B603
+skips: B101,B404,B603,B113

--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,0 @@
-[bandit]
-skips: B101,B404,B603,B113

--- a/sync/.bandit
+++ b/sync/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+skips: B101,B404,B603,B113


### PR DESCRIPTION
[The New version of bandit ](https://github.com/PyCQA/bandit/releases/tag/1.7.5) introduces [a new check for requests missing timeouts ](https://github.com/PyCQA/bandit/pull/743). 
For now, I've just skipped this, but happy also add the actual timeouts.

Also moved the `bandit` settings file to the source folder. According to [this issue](https://github.com/PyCQA/bandit/issues/698#issuecomment-811720709), this is the way to make it actually apply.