### PR TITLE
Fix needinfo user settings in prod and test configs.

### DIFF
--- a/sync_prod.ini
+++ b/sync_prod.ini
@@ -72,7 +72,8 @@ refs.autoland = autoland/branches/default/tip
 path.wpt = testing/web-platform/tests
 path.meta = testing/web-platform/meta
 try.max-tests = 500
-upstream.needinfo-users = wptsync@mozilla.bugs
+needinfo.upstream = aborovova@mozilla.com, james@hoppipolla.co.uk
+needinfo.landing = aborovova@mozilla.com, james@hoppipolla.co.uk
 worktree.max-count = 20
 
 [web-platform-tests]

--- a/test/config/sync.ini
+++ b/test/config/sync.ini
@@ -29,7 +29,7 @@ refs.autoland = mozilla/bookmarks/mozilla/autoland
 path.wpt = testing/web-platform/tests
 path.meta = testing/web-platform/meta
 try.stability_count = 5
-oneedinfo.upstream=example@example.org,
+needinfo.upstream=example@example.org,
 needinfo.landing=example@example.org,
 
 [web-platform-tests]


### PR DESCRIPTION
The format of needinfo user settings was changed in the scope of [this PR](https://github.com/mozilla/wpt-sync/pull/573).
And then in [this PR](https://github.com/mozilla/wpt-sync/pull/709) it was reverted for production.

We will try first with non-wpt sync email addresses to see if fixing configs will make it work.