### PR TITLE
Quick fix for try_rebase failure

### DIFF
--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -286,7 +286,8 @@ def test_next_try_push_infra_fail_try_rebase(env, git_gecko, git_wpt, pull_reque
                     try_push.infra_fail = True
                     try_push["stability"] = False
 
-                assert sync.next_action == downstream.DownstreamAction.try_push_stability
+                assert sync.next_action == downstream.DownstreamAction.try_rebase
+                sync.next_try_push(try_cls=MockTryCls)
 
                 # Check that rebase has happened
                 commit_hash_after_rebase = sync.gecko_commits.base.sha1


### PR DESCRIPTION
We can't call try_rebase in a non-@mut context because it mutates the PR. In particular this means we can't call it from next_action(), which is intended to be an idempotent method that describes the next action required for a sync, but doesn't actually carry it out. In practice this causes a runtime error when we attempt to update the sync state to indicate the problem.

This is a quick fix to unblock the sync, that is intended to be replaced with a better fix. Here we hardcode the logic that if the rebase succeeds, we need to do a stability try push. That relies on the assumption that for downstream syncs the only kind of try push is a stability one, which isn't true in the code (but is in practice). Ideally after the rebase calling `next_action` again would return the right result (either a try push being required if the rebase changed the branch head, or a manual update being required if the rebase failed).

Also we should write a test for the specific case that failed.