### PR TITLE
Add the link to google doc with documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Synchronize changes between gecko and web-platform-tests
 
 ## Additional documentation
 
-See `./docs`
+See `./docs`.
+More up-to-date information can be found [in this document](https://docs.google.com/document/d/1T-GKq50R4SQcSWJjwKVmLid_NnMZzB1PgAqEnvelLK8/)
+(only accessible to Mozilla employees).
 
 ## Development environment
 


### PR DESCRIPTION
As discussed, this PR adds the link to the document in google doc to README.