### PR TITLE
Handle _lock on Mock objects

### DIFF
--- a/test/test_notify_bugs.py
+++ b/test/test_notify_bugs.py
@@ -207,7 +207,6 @@ def test_already_linked(env):
                  None,
                  None))
     sync = Mock()
-    sync = Mock()
     # The Mock class defines a _lock property which interferes with our one;
     # since we don't run tests multithreaded just overwrite it with another Mock
     sync._lock = Mock()

--- a/test/test_notify_bugs.py
+++ b/test/test_notify_bugs.py
@@ -111,6 +111,9 @@ be cause the bot to automatically update or remove the annotation.
 def test_fx_only(env):
     results_obj = fx_only_failure()
     sync = Mock()
+    # The Mock class defines a _lock property which interferes with our one;
+    # since we don't run tests multithreaded just overwrite it with another Mock
+    sync._lock = Mock()
     sync.lock_key = ("downstream", None)
     sync.notify_bugs = FrozenDict()
     env.config["notify"]["components"] = "Foo :: Bar; Testing :: web-platform-tests"
@@ -134,6 +137,9 @@ def test_fx_only(env):
 def test_crash(env):
     results_obj = fx_crash()
     sync = Mock()
+    # The Mock class defines a _lock property which interferes with our one;
+    # since we don't run tests multithreaded just overwrite it with another Mock
+    sync._lock = Mock()
     sync.lock_key = ("downstream", None)
     sync.notify_bugs = FrozenDict()
     env.config["notify"]["components"] = "Foo :: Bar; Testing :: web-platform-tests"
@@ -201,6 +207,10 @@ def test_already_linked(env):
                  None,
                  None))
     sync = Mock()
+    sync = Mock()
+    # The Mock class defines a _lock property which interferes with our one;
+    # since we don't run tests multithreaded just overwrite it with another Mock
+    sync._lock = Mock()
     sync.lock_key = ("downstream", None)
     sync.notify_bugs = FrozenDict()
     env.config["notify"]["components"] = "Foo :: Bar; Testing :: web-platform-tests"
@@ -262,6 +272,9 @@ def test_split_id():
 def test_already_filed(env):
     results_obj = fx_only_failure()
     sync = Mock()
+    # The Mock class defines a _lock property which interferes with our one;
+    # since we don't run tests multithreaded just overwrite it with another Mock
+    sync._lock = Mock()
     sync.lock_key = ("downstream", None)
     sync.notify_bugs = FrozenDict(**{"failure :: Testing :: web-platform-tests": 1234})
 


### PR DESCRIPTION
unittest.Mock got an _lock attribute to synchronise access to the Mock in multithreaded cases. Unfortunately this clashes with our use of _lock on syncs to ensure we don't allow more than one process to mutate a sync at once.

For the cases where we're mocking whole Sync objects in tests, just overwrite the _lock class attribute with another mock; this seems to be enough for the tests to pass again.