### PR TITLE
Do not invalidate the try push when there are no gecko_commits in the downstream sync

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -299,7 +299,8 @@ class DownstreamSync(SyncProcess):
             return None
 
         if len(self.gecko_commits) == 0:
-            return None
+            # Something most likely is not correct, but we can't fix it here.
+            return latest_try_push
         if self.metadata_commit is not None:
             if len(self.gecko_commits) == 1:
                 # Apparently we only have a metadata commit and the actual change got rebased away


### PR DESCRIPTION
I couldn't really reproduce it with tests, but it seems like the most logical place where it could loop in [this](https://bugzilla.mozilla.org/show_bug.cgi?id=1849778) and [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1848752).