### PR TITLE
Update deprecated New Relic setting

### DIFF
--- a/config/newrelic.ini
+++ b/config/newrelic.ini
@@ -165,7 +165,7 @@ error_collector.enabled = true
 # To stop specific errors from reporting to the UI, set this to
 # a space separated list of the Python exception type names to
 # ignore. The exception name should be of the form 'module:class'.
-error_collector.ignore_errors =
+error_collector.ignore_classes =
 
 # Browser monitoring is the Real User Monitoring feature of the UI.
 # For those Python web frameworks that are supported, this


### PR DESCRIPTION
I've noticed the error about it in the New Relic agent log, it should correctly reapply it to the right one, but since we have this error there is no message about connection and no logs (there are logs until Sept 12), so maybe it's not correctly applied.