### PR TITLE
Remove try logs after 3 days without activity instead of 5

### DIFF
--- a/sync/tc.py
+++ b/sync/tc.py
@@ -518,8 +518,8 @@ def cleanup():
             if not os.path.isdir(rev_path):
                 continue
             now = datetime.now()
-            # Data hasn't been touched in five days
+            # Data hasn't been touched in three days
             if (datetime.fromtimestamp(os.stat(rev_path).st_mtime) <
-                now - timedelta(days=5)):
+                now - timedelta(days=3)):
                 logger.info("Removing downloaded logs without recent activity %s" % rev_path)
                 shutil.rmtree(rev_path)


### PR DESCRIPTION
Since the try logs require about 8Gb of disk space to reduce the chance of running out of space, we should clean up logs earlier.