### PR TITLE
Fix confusion between different exception queues

### DIFF
--- a/sync_prod.ini
+++ b/sync_prod.ini
@@ -39,10 +39,6 @@ taskcluster-try-exception.queue = wpt-sync-prod/taskcluster-try-exception
 taskcluster-try-exception.exchange = exchange/taskcluster-queue/v1/task-exception
 taskcluster-try-exception.routing_key = route.index.gecko.v2.try.latest.taskgraph.decision
 
-taskcluster-try-exception.queue = wpt-sync-prod/taskcluster-try-failed
-taskcluster-try-exception.exchange = exchange/taskcluster-queue/v1/task-exception
-taskcluster-try-exception.routing_key = route.notify.pulse.wptsync.\#
-
 taskcluster-wptsync-completed.queue = wpt-sync-prod/taskcluster-try-completed
 taskcluster-wptsync-completed.exchange = exchange/taskcluster-queue/v1/task-completed
 taskcluster-wptsync-completed.routing_key = route.notify.pulse.wptsync.#
@@ -50,6 +46,10 @@ taskcluster-wptsync-completed.routing_key = route.notify.pulse.wptsync.#
 taskcluster-wptsync-failed.queue = wpt-sync-prod/taskcluster-try-failed
 taskcluster-wptsync-failed.exchange = exchange/taskcluster-queue/v1/task-failed
 taskcluster-wptsync-failed.routing_key = route.notify.pulse.wptsync.#
+
+taskcluster-wptsync-exception.queue = wpt-sync-prod/taskcluster-try-exception
+taskcluster-wptsync-exception.exchange = exchange/taskcluster-queue/v1/task-exception
+taskcluster-wptsync-exception.routing_key = route.notify.pulse.wptsync.#
 
 [sync]
 ref = refs/syncs/data


### PR DESCRIPTION
We were defining taskcluster-try-exception.* twice, which prevents the sync starting. We should define one queue for execeptions reported to the decision task and one -wptsync queue for exceptions reported for the overall try taskgroup.