### PR TITLE
Handle labels in META.yml files

### DIFF
--- a/sync/meta.py
+++ b/sync/meta.py
@@ -210,13 +210,12 @@ class Metadata:
                                   subtest=subtest,
                                   status=status)
 
-    def iterbugs(self,
-                 test_id: str,
-                 product: str = "firefox",
-                 prefixes: Iterable[str] | None = None,
-                 subtest: str | None = None,
-                 status: str | None = None,
-                 ) -> Iterator[MetaLink]:
+    def iter_bug_links(self,
+                       test_id: str,
+                       product: str = "firefox",
+                       prefixes: Iterable[str] | None = None,
+                       subtest: str | None = None,
+                       status: str | None = None) -> Iterator[MetaLink]:
         if prefixes is None:
             prefixes = (env.bz.bz_url,
                         "https://github.com/wpt/web-platform-tests")

--- a/sync/notify/bugupdate.py
+++ b/sync/notify/bugupdate.py
@@ -58,9 +58,9 @@ class TriageBugs:
 
     def meta_links(self):
         rv = defaultdict(list)
-        for link in self.wpt_metadata.iterbugs(test_id=None,
-                                               product="firefox",
-                                               prefixes=(bugzilla_url,)):
+        for link in self.wpt_metadata.iter_bug_links(test_id=None,
+                                                     product="firefox",
+                                                     prefixes=(bugzilla_url,)):
             bug = int(env.bz.id_from_url(link.url, bugzilla_url))
             rv[bug].append(link)
         return rv

--- a/sync/notify/results.py
+++ b/sync/notify/results.py
@@ -270,7 +270,7 @@ class Results:
 
     def add_metadata(self, metadata: Metadata) -> None:
         for test, result in self.test_results.items():
-            for meta_link in metadata.iterbugs(test, product="firefox"):
+            for meta_link in metadata.iter_bug_links(test, product="firefox"):
                 if meta_link.subtest is None:
                     result.bug_links.append(meta_link)
                 else:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -151,7 +151,11 @@ links:
   - url: https://bugzilla-dev.allizom.org/show_bug.cgi?id=1234
     product: firefox
     results:
-      - test: test.html"""}
+      - test: test.html
+  - label: test-data
+    results:
+      - test: test.html
+"""}
 
 
 @pytest.fixture

--- a/test/test_metadata.py
+++ b/test/test_metadata.py
@@ -23,6 +23,9 @@ def test_add(env, git_wpt_metadata):
     process_name = ProcessName("sync", "downstream", "1234", 0)
     meta = Metadata(process_name)
     assert len(list(meta.metadata.iterlinks("/example/test.html"))) == 1
+    labels = list(meta.metadata.iterlabels("/example/test.html"))
+    assert len(labels) == 1
+    assert labels[0].label == "test-data"
 
     with SyncLock.for_process(process_name) as lock:
         with meta.as_mut(lock):
@@ -33,19 +36,22 @@ def test_add(env, git_wpt_metadata):
                           "%s/show_bug.cgi?id=3456" % env.bz.bz_url,
                           product="firefox")
 
-    assert len(list(meta.iterbugs("/example/test.html"))) == 2
-    assert len(list(meta.iterbugs("/example-1/test.html"))) == 1
+    assert len(list(meta.iter_bug_links("/example/test.html"))) == 2
+    assert len(list(meta.iter_bug_links("/example-1/test.html"))) == 1
+    labels = list(meta.metadata.iterlabels("/example/test.html"))
+    assert len(labels) == 1
+    assert labels[0].label == "test-data"
 
     # Arrange to reread the metadata from origin/master
     meta = Metadata(process_name)
-    links = list(meta.iterbugs("/example/test.html"))
+    links = list(meta.iter_bug_links("/example/test.html"))
     assert len(links) == 2
     assert links[0].test_id == "/example/test.html"
     assert links[0].url == "%s/show_bug.cgi?id=1234" % env.bz.bz_url
     assert links[1].test_id == "/example/test.html"
     assert links[1].url == "%s/show_bug.cgi?id=2345" % env.bz.bz_url
 
-    links_1 = list(meta.iterbugs("/example-1/test.html"))
+    links_1 = list(meta.iter_bug_links("/example-1/test.html"))
     assert len(links_1) == 1
     assert links_1[0].test_id == "/example-1/test.html"
     assert links_1[0].url == "%s/show_bug.cgi?id=3456" % env.bz.bz_url
@@ -57,15 +63,21 @@ def test_update(env, git_wpt_metadata):
     links = list(meta.metadata.iterlinks("/example/test.html"))
     assert len(links) == 1
     assert links[0].url == "%s/show_bug.cgi?id=1234" % env.bz.bz_url
+    labels = list(meta.metadata.iterlabels("/example/test.html"))
+    assert len(labels) == 1
+    assert labels[0].label == "test-data"
 
     with SyncLock.for_process(process_name) as lock:
         with meta.as_mut(lock):
             links[0].url = "%s/show_bug.cgi?id=2345" % env.bz.bz_url
 
     meta = Metadata(process_name)
-    links = list(meta.iterbugs("/example/test.html"))
+    links = list(meta.iter_bug_links("/example/test.html"))
     assert links[0].test_id == "/example/test.html"
     assert links[0].url == "%s/show_bug.cgi?id=2345" % env.bz.bz_url
+    labels = list(meta.metadata.iterlabels("/example/test.html"))
+    assert len(labels) == 1
+    assert labels[0].label == "test-data"
 
 
 def test_delete(env, git_wpt_metadata):
@@ -74,11 +86,17 @@ def test_delete(env, git_wpt_metadata):
     links = list(meta.metadata.iterlinks("/example/test.html"))
     assert len(links) == 1
     assert links[0].url == "%s/show_bug.cgi?id=1234" % env.bz.bz_url
+    labels = list(meta.metadata.iterlabels("/example/test.html"))
+    assert len(labels) == 1
+    assert labels[0].label == "test-data"
 
     with SyncLock.for_process(process_name) as lock:
         with meta.as_mut(lock):
             links[0].delete()
 
     meta = Metadata(process_name)
-    links = list(meta.iterbugs("/example/test.html"))
+    links = list(meta.iter_bug_links("/example/test.html"))
     len(links) == 0
+    labels = list(meta.metadata.iterlabels("/example/test.html"))
+    assert len(labels) == 1
+    assert labels[0].label == "test-data"

--- a/test/test_notify.py
+++ b/test/test_notify.py
@@ -256,16 +256,16 @@ def test_link(env):
     result0.set_status("firefox", "GitHub", False, "PASS", ["PASS"])
     result0.set_status("firefox", "GitHub", True, "FAIL", ["PASS"])
     result0.bug_links.append(MetaLink(None,
+                                      "/test/test0.html",
                                       "%s/show_bug.cgi?id=1234" % env.bz.bz_url,
-                                      "firefox",
-                                      "/test/test0.html"))
+                                      "firefox"))
     result1 = results.Result()
     result1.set_status("firefox", "GitHub", False, "PASS", ["PASS"])
     result1.set_status("firefox", "GitHub", True, "FAIL", ["PASS"])
     result1.bug_links.append(MetaLink(None,
+                                      "/test/test1.html",
                                       "https://github.com/web-platform-tests/wpt/issues/123",
-                                      "firefox",
-                                      "/test/test1.html"))
+                                      "firefox"))
 
     results_iter = [("/test/test0.html", None, result0),
                     ("/test/test1.html", None, result1)]

--- a/test/test_notify_bugs.py
+++ b/test/test_notify_bugs.py
@@ -187,7 +187,7 @@ def test_update_metadata(env, git_gecko, git_wpt, pull_request, git_wpt_metadata
     bug = bugs_filed[0]
 
     metadata = meta.Metadata(sync.process_name, branch=head)
-    links = list(metadata.iterbugs("/test/test.html"))
+    links = list(metadata.iter_bug_links("/test/test.html"))
     assert len(links) == 1
     link = links[0]
     assert link.url == f"{env.bz.bz_url}/show_bug.cgi?id={bug}"
@@ -201,9 +201,9 @@ def test_already_linked(env):
     results_obj = fx_only_failure()
     results_obj.test_results["/test/test.html"].bug_links.append(
         MetaLink(None,
+                 "/test/test.html",
                  f"{env.bz.bz_url}/show_bug.cgi?id=10000",
                  "firefox",
-                 "/test/test.html",
                  None,
                  None))
     sync = Mock()


### PR DESCRIPTION
Previously we only correctly handled metadata entries which had a "url" key, which generally speaking labels do not. In practice that meant we failed to notify for test changes in directories with labels.

This change adds a specific type to represent labels and ensure that they're correctly roundtripped through the update process.

This matches the data representation used in other tooling, but we will still need to update the code if a new kind of metadata is added.