### PR TITLE
Specify the node name to the celery worker

### DIFF
--- a/docker/start_wptsync.sh
+++ b/docker/start_wptsync.sh
@@ -116,7 +116,8 @@ elif [ "$1" == "--worker" ]; then
                        --pidfile=${CELERY_PID_FILE} \
                        --logfile=${CELERY_LOG_FILE} \
                        --loglevel=DEBUG \
-                       -P prefork
+                       -P prefork \
+                       -n ${CELERY_WORKER}
 
     # ./bin/run_docker_dev.sh run --worker --phab
     if [ "$2" == "--phab" ]; then


### PR DESCRIPTION
We already have [a logic to clean up a stale pid file](https://github.com/mozilla/wpt-sync/blob/master/docker/start_wptsync.sh#L83) when starting a container, but the pid file for a worker has a wrong name now because we don't provide a node name anymore, which is used in the name of the pid file.

Closes #2109.