### PR TITLE
Add "--push-to-vcs" argument when invoking "mach try"

### DIFF
--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -188,6 +188,9 @@ class TryFuzzyCommit(TryCommit):
         else:
             args.append("--no-artifact")
 
+        # --push-to-vcs is required to push directly to hgmo
+        args.append("--push-to-vcs")
+
         if self.tests_by_type is not None:
             paths = []
             all_paths = set()

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -72,7 +72,8 @@ def test_land_try(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_p
                                     "-q",
                                     "web-platform-tests mac !debug shippable",
                                     "--disable-target-task-filter",
-                                    "--artifact")
+                                    "--artifact",
+                                    "--push-to-vcs")
 
 
 def test_land_commit(env, git_gecko, git_wpt, git_wpt_upstream, pull_request, set_pr_status,


### PR DESCRIPTION
In the scope of [this bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1923647), "mach try" is going to submit changes for Lando by default soon, and we want to keep pushing directly to VCS.