### PR TITLE
Update python to version 3.8 in CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.12
       - name: Run
         run:  pip install bandit && bandit -r sync -ll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Run
         run:  pip install bandit && bandit -r sync -ll


### PR DESCRIPTION
There is no available build of python 3.7 for the latest Ubuntu version in the Github actions.

See https://github.com/mozilla/wpt-sync/actions/runs/13328758853/job/37227831844?pr=2451.