### PR TITLE
Remove empty pathes from changed files

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -521,7 +521,8 @@ class DownstreamSync(SyncProcess):
 
     def files_changed(self) -> set[str]:
         # TODO: Would be nice to do this from mach with a gecko worktree
-        return set(self.wpt.files_changed().decode("utf8", "replace").split("\n"))
+        paths = self.wpt.files_changed().decode("utf8", "replace").split("\n")
+        return set(path for path in paths if path.strip())
 
     @property
     def metadata_commit(self) -> GeckoCommit | None:


### PR DESCRIPTION
At the moment, we run `mach file-info` with `testing/web-platform/tests <actual files which changed>`. Which worked fine [until recently when `file-info` command was fixed to work with files inside the directory (if it's specified)](https://bugzilla.mozilla.org/show_bug.cgi?id=1963319), since then it started to return all the bug components inside `testing/web-platform/tests` and the bot started picking a wrong component. To identify the right component, we don't really need to specify `testing/web-platform/tests` folder. This PR tries fixing this behavior.

From what I could track, it starts happening when parsing a string received from `wpt files-changed` we get an extra empty string and later down the chain we add `testing/web-platform/tests` prefix.

It's already tested and fixed on production.