### PR TITLE
Enable ordering of ProcessName class

### DIFF
--- a/sync/base.py
+++ b/sync/base.py
@@ -266,6 +266,11 @@ class ProcessName(metaclass=IdentityMap):
             return False
         return self.as_tuple() == other.as_tuple()
 
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, self.__class__):
+            raise ValueError(f"Cannot compare {self.__class__} and {other.__class__}")
+        return self.as_tuple() < other.as_tuple()
+
     def __hash__(self) -> int:
         return hash(self.key())
 


### PR DESCRIPTION
In worktree.py we have a list of tuples of the form (mtime, ProcessName, path) which we try to sort. Usually this works fine, but in the case where two worktrees have the exact same mtime it breaks because ProcessName isn't sortable. To solve this, make the ProcessName class implement __lt__.