### PR TITLE
Add lando credentials to env variables when pushing commits.

### DIFF
--- a/config/dev/sync.ini
+++ b/config/dev/sync.ini
@@ -54,3 +54,7 @@ token = %SECRET%
 [phabricator]
 token = %SECRET%
 listener.interval = 60
+
+[lando]
+api_token="%SECRET%"
+user_email="wptsync@mozilla.com"

--- a/docker/start_wptsync.sh
+++ b/docker/start_wptsync.sh
@@ -88,10 +88,8 @@ elif [ "$1" == "--worker" ]; then
     echo "Starting celerybeat"
 
     set +x
-    export LANDO_HEADLESS_API_TOKEN=$(/app/get_ini.py /app/config/prod/credentials.ini lando api_token)
     export NEW_RELIC_LICENSE_KEY=$(/app/get_ini.py /app/config/prod/credentials.ini newrelic license_key)
     set -x
-    export LANDO_USER_EMAIL="wptsync@mozilla.com"
     export NEW_RELIC_CONFIG_FILE=/app/config/newrelic.ini
 
     # TODO: need to configure the API key correctly to record deploys

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -852,6 +852,12 @@ def push(landing: LandingSync) -> None:
 
 def push_with_lando(landing):
     logger.info("Pushing landing")
+
+    # Add lando credentials to env variables
+    env_obj = os.environ
+    env_obj["LANDO_HEADLESS_API_TOKEN"] = env.config["lando"]["api_token"]
+    env_obj["LANDO_USER_EMAIL"] = env.config["lando"]["user_email"]
+
     cmd = [
         "lando",
         "push-commits",
@@ -864,7 +870,10 @@ def push_with_lando(landing):
         "--yes"
     ]
     logger.info(" ".join(cmd))
-    return subprocess.check_output(cmd)
+    return subprocess.check_output(
+        cmd,
+        env=env_obj,
+    )
 
 
 def unlanded_with_type(git_gecko, git_wpt, wpt_head, prev_wpt_head):

--- a/sync_prod.ini
+++ b/sync_prod.ini
@@ -104,3 +104,7 @@ components = Core :: CSS Parsing and Computation; Core :: CSS Transitions and An
 
 [metadata]
 repo.url = https://github.com/web-platform-tests/wpt-metadata
+
+[lando]
+api_token="%SECRET%"
+user_email="wptsync@mozilla.com"

--- a/test/config/sync.ini
+++ b/test/config/sync.ini
@@ -60,3 +60,7 @@ token = %SECRET%
 [phabricator]
 token = %SECRET%
 listener.interval = 60
+
+[lando]
+api_token="%SECRET%"
+user_email="wptsync@mozilla.com"


### PR DESCRIPTION
Add lando credentials to env variables when pushing commits to make it also work in the attached bash.