### PR TITLE
Run commands from the /app/wpt-sync directory

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -6,6 +6,7 @@ ENV PATH=/app/third_party/git-cinnabar:/app/third_party/fzf/bin:/app/.local/bin:
     SHELL=/bin/bash \
     WPTSYNC_ROOT=/app/workspace \
     WPTSYNC_REPO_ROOT=/app/repos/ \
+    WPTSYNC_APP_ROOT=/app/wpt-sync/ \
     DEBIAN_FRONTEND=noninteractive \
     UV_REQUIRE_HASHES=1 \
     UV_LINK_MODE=copy \

--- a/docker/start_wptsync.sh
+++ b/docker/start_wptsync.sh
@@ -16,6 +16,8 @@ CELERY_PID_FILE=${WPTSYNC_ROOT}/%n.pid
 CELERY_LOG_FILE=${WPTSYNC_ROOT}/logs/%n%I.log
 CELERYBEAT_PID_FILE=${WPTSYNC_ROOT}/celerybeat.pid
 
+cd "$WPTSYNC_APP_ROOT"
+
 cleanup() {
     echo "Stopping celery..."
     uv run celery multi stopwait ${CELERY_WORKER} \
@@ -138,7 +140,6 @@ elif [ "$1" == "--worker" ]; then
 
 elif [ "$1" == "--test" ]; then
     shift 1;
-    cd /app/wpt-sync
     uv sync
     uv run --extra=test wptsync test "$@"
 else


### PR DESCRIPTION
It's somewhat unclear why setting UV_PROJECT doesn't help here, but in testing it seemed to be ignored (whereas passing in --project worked).