### PR TITLE
Unset "UV_REQUIRE_HASHES" for mach commands

### DIFF
--- a/sync/projectutil.py
+++ b/sync/projectutil.py
@@ -75,6 +75,8 @@ class Mach(Command):
         else:
             cmd_env = os.environ.copy()
         cmd_env["MOZBUILD_STATE_PATH"] = state_path
+        if "UV_REQUIRE_HASHES" in cmd_env:
+            del cmd_env["UV_REQUIRE_HASHES"]
         opts["env"] = cmd_env
         return super().get(*subcommand, **opts)
 


### PR DESCRIPTION
The requirements in mach package don't contain hashes, so we have to unset the requirements for them.