### PR TITLE
Fix formatting of lando credentials in the production config.

### DIFF
--- a/sync_prod.ini
+++ b/sync_prod.ini
@@ -106,5 +106,5 @@ components = Core :: CSS Parsing and Computation; Core :: CSS Transitions and An
 repo.url = https://github.com/web-platform-tests/wpt-metadata
 
 [lando]
-api_token="%SECRET%"
-user_email="wptsync@mozilla.com"
+api_token=%SECRET%
+user_email=wptsync@mozilla.com


### PR DESCRIPTION
Fixing it now in the right config file 