### PR TITLE
Don't add /app/wpt-sync as a volume in Dockerfile

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -130,11 +130,10 @@ RUN set -eux; \
     git config --global user.name moz-wptsync-bot; \
     git config --global user.email wptsync@mozilla.com;
 
-# /app/wpt-sync: bind mount to src dir (only on dev) or dir with wheels?
 # /app/workspace: bind mount to [empty] dir where service will write working data, logs
-# config files, credentials, ssh config
 # /app/repos: bind mount to ebs volume for gecko and wpt repos (or local dev repos)
-VOLUME ["/app/wpt-sync", "/app/workspace", "/app/repos", "/app/config"]
+# /app/config config files, credentials, ssh config, all stored on the host
+VOLUME ["/app/workspace", "/app/repos", "/app/config"]
 
 RUN cd /app/wpt-sync && ls && uv sync --locked
 


### PR DESCRIPTION
We generally want to use this directory from the container rather than mounting the whole thing.