### PR TITLE
Do not install dependencies when starting the container.

### DIFF
--- a/docker/start_wptsync.sh
+++ b/docker/start_wptsync.sh
@@ -61,10 +61,6 @@ clean_pid() {
 }
 
 if [ "$1" != "--test" ] && [ "$1" != "--shell" ]; then
-    # This should be unnecessary because the dependencies are in the container. But this
-    # allows things to work if we override the /app/wpt-sync directory with a mount.
-    uv sync
-
     eval "$(ssh-agent -s)"
     # Install ssh keys
     cp -v ${WPTSYNC_GH_SSH_KEY:-/app/config/dev/ssh/id_github} /app/.ssh/id_github


### PR DESCRIPTION
Now dependecies will be picked from the container.