### PR TITLE
Reapply gecko commits if "gecko-commit-git" is missing.

### DIFF
--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -267,24 +267,42 @@ class UpstreamSync(SyncProcess):
         if len(self.gecko_commits) == 0:
             return False
 
-        # Find the commits that were already upstreamed. Some gecko commits may not
-        # result in an upstream commit, if the patch has no effect. But if we find
-        # the last commit that was previously upstreamed then all earlier ones must
-        # also match.
-        upstreamed_commits = {item.sha1 for item in self.upstreamed_gecko_commits}
-        matching_commits = list(self.gecko_commits[:])
-        for gecko_commit in reversed(list(self.gecko_commits)):
-            if gecko_commit.sha1 in upstreamed_commits:
+        matching_commits: List[Commit] = list()
+
+        # Verify that all commits contain "gecko-commit-git" in the metadata.
+        has_canonical_git_hash = True
+        for wpt_commit in self.wpt_commits:
+            if not wpt_commit.metadata.get("gecko-commit-git"):
+                has_canonical_git_hash = False
                 break
-            matching_commits.pop()
 
-        if len(matching_commits) == len(self.gecko_commits) == len(self.upstreamed_gecko_commits):
-            return False
+        if has_canonical_git_hash:
+            # Find the commits that were already upstreamed. Some gecko commits may not
+            # result in an upstream commit, if the patch has no effect. But if we find
+            # the last commit that was previously upstreamed then all earlier ones must
+            # also match.
+            upstreamed_commits = {item.sha1 for item in self.upstreamed_gecko_commits}
+            matching_commits = list(self.gecko_commits[:])
 
-        if len(matching_commits) == 0:
+            for gecko_commit in reversed(list(self.gecko_commits)):
+                if gecko_commit.sha1 in upstreamed_commits:
+                    break
+                matching_commits.pop()
+
+            if (
+                len(matching_commits)
+                == len(self.gecko_commits)
+                == len(self.upstreamed_gecko_commits)
+            ):
+                return False
+
+            if len(matching_commits) == 0:
+                self.wpt_commits.head = self.wpt_commits.base
+            elif len(matching_commits) < len(self.upstreamed_gecko_commits):
+                self.wpt_commits.head = self.wpt_commits[len(matching_commits) - 1]
+        else:
+            # Reset wpt commits to reapply all gecko commits with updated metadata.
             self.wpt_commits.head = self.wpt_commits.base
-        elif len(matching_commits) < len(self.upstreamed_gecko_commits):
-            self.wpt_commits.head = self.wpt_commits[len(matching_commits) - 1]
 
         # Ensure the worktree is clean
         wpt_work = self.wpt_worktree.get()
@@ -325,11 +343,10 @@ class UpstreamSync(SyncProcess):
     @mut()
     def add_commit(self, gecko_commit: GeckoCommit) -> tuple[Commit | None, bool]:
         git_work = self.wpt_worktree.get()
+        metadata = {"gecko-commit": gecko_commit.canonical_rev}
 
-        metadata = {
-            "gecko-commit": gecko_commit.canonical_rev,
-            "gecko-commit-git": gecko_commit.canonical_rev_git,
-        }
+        if gecko_commit.canonical_rev_git:
+            metadata["gecko-commit-git"] = gecko_commit.canonical_rev_git
 
         if os.path.exists(os.path.join(git_work.working_dir, gecko_commit.canonical_rev + ".diff")):
             # If there's already a patch file here then don't try to create a new one

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -270,10 +270,7 @@ class UpstreamSync(SyncProcess):
         matching_commits: List[Commit] = list()
 
         # Verify that all commits contain "gecko-commit-git" in the metadata.
-        has_canonical_git_hash = True
-        for wpt_commit in self.wpt_commits:
-            if not wpt_commit.metadata.get("gecko-commit-git"):
-                has_canonical_git_hash = False
+        has_canonical_git_hash = all(wpt_commit.metadata.get("gecko-commit-git") for wpt_commit in self.wpt_commits)
                 break
 
         if has_canonical_git_hash:
@@ -282,7 +279,7 @@ class UpstreamSync(SyncProcess):
             # the last commit that was previously upstreamed then all earlier ones must
             # also match.
             upstreamed_commits = {item.sha1 for item in self.upstreamed_gecko_commits}
-            matching_commits = list(self.gecko_commits[:])
+            matching_commits = list(self.gecko_commits)
 
             for gecko_commit in reversed(list(self.gecko_commits)):
                 if gecko_commit.sha1 in upstreamed_commits:

--- a/sync/upstream.py
+++ b/sync/upstream.py
@@ -270,8 +270,9 @@ class UpstreamSync(SyncProcess):
         matching_commits: List[Commit] = list()
 
         # Verify that all commits contain "gecko-commit-git" in the metadata.
-        has_canonical_git_hash = all(wpt_commit.metadata.get("gecko-commit-git") for wpt_commit in self.wpt_commits)
-                break
+        has_canonical_git_hash = all(
+            wpt_commit.metadata.get("gecko-commit-git") for wpt_commit in self.wpt_commits
+        )
 
         if has_canonical_git_hash:
             # Find the commits that were already upstreamed. Some gecko commits may not

--- a/test/test_upstream.py
+++ b/test/test_upstream.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 
 from sync import commit as sync_commit, upstream
 from sync.gitutils import update_repositories
@@ -675,3 +675,38 @@ def test_pr_commits_fast_forward(
 
     for wpt_commit, pr_commit in zip(sync.wpt_commits._commits, pr_commits):
         assert wpt_commit.commit == pr_commit.commit
+
+
+def test_backfill_git_hashes(env, git_gecko, git_wpt, upstream_gecko_commit):
+    bug = 1234
+    test_changes = {"README": b"Change README\n"}
+    rev = upstream_gecko_commit(test_changes=test_changes, bug=bug, message=b"Change README")
+
+    update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
+
+    with patch(
+        "sync.upstream.GeckoCommit.canonical_rev_git",
+        new_callable=PropertyMock,
+        return_value=None,
+    ):
+        upstream.gecko_push(git_gecko, git_wpt, "autoland", rev, raise_on_error=True)
+
+    syncs = upstream.UpstreamSync.for_bug(git_gecko, git_wpt, bug)
+    sync = syncs["open"].pop()
+
+    wpt_commit = sync.wpt_commits[0]
+
+    # Verify that "gecko-commit-git" is not set in metadata
+    assert wpt_commit.metadata.get("gecko-commit-git") is None
+
+    backfill_git_rev = "git_revision"
+    for commit in sync.gecko_commits:
+        commit.notes["gecko-commit-git"] = backfill_git_rev
+
+    # Run the update to backfill
+    with SyncLock.for_process(sync.process_name) as upstream_sync_lock:
+        with sync.as_mut(upstream_sync_lock):
+            upstream.update_sync(git_gecko, git_wpt, sync, repo_update=False)
+
+    # Verify that "gecko-commit-git" is now in metadata
+    assert sync.wpt_commits[0].metadata.get("gecko-commit-git") == backfill_git_rev


### PR DESCRIPTION
I think if we only need to add git hashes to open upstream syncs, we could just run update on them and reapply the gecko commits which should then contain the git hashes as well.