### PR TITLE
Handle case where landing is interrupted

### DIFF
--- a/sync/landing.py
+++ b/sync/landing.py
@@ -870,7 +870,7 @@ MANUAL PUSH: wpt sync bot
 
 
 def push(landing: LandingSync) -> None:
-    """Push from git_work_gecko to inbound."""
+    """Push from git_work_gecko to autoland."""
     success = False
 
     old_head = None
@@ -1197,19 +1197,20 @@ def update_landing(
                     "Existing landing head commit %s doesn't match"
                     "supplied wpt head %s" % (landing.wpt_commits.head.sha1, new_wpt_head)
                 )
-            head = landing.gecko_commits.head
-            if git_gecko.is_ancestor(
-                head.commit, git_gecko.rev_parse(env.config["gecko"]["refs"]["central"])
-            ):
-                logger.info("Landing reached central")
-                with landing.as_mut(lock):
-                    landing.finish()
-                return None
-            elif git_gecko.is_ancestor(
-                head.commit, git_gecko.rev_parse(landing.gecko_integration_branch())
-            ):
-                logger.info("Landing is on inbound but not yet on central")
-                return None
+            if len(landing.gecko_commits) > 0 and landing.landing_commit is not None:
+                head = landing.gecko_commits.head
+                if git_gecko.is_ancestor(
+                    head.commit, git_gecko.rev_parse(env.config["gecko"]["refs"]["central"])
+                ):
+                    logger.info("Landing reached central")
+                    with landing.as_mut(lock):
+                        landing.finish()
+                    return None
+                elif git_gecko.is_ancestor(
+                    head.commit, git_gecko.rev_parse(landing.gecko_integration_branch())
+                ):
+                    logger.info("Landing is on autoland but not yet on main")
+                    return None
 
             landable = landable_commits(
                 git_gecko,

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -275,6 +275,7 @@ def test_download_logs_after_retriggers_complete(
             with (
                 patch.object(tc.TaskGroup, "tasks", property(tasks)),
                 patch("sync.landing.push_to_gecko"),
+                patch("sync.landing.update_landing"),
             ):
                 try_push.download_logs = Mock(return_value=[])
                 try_push["stability"] = True
@@ -294,6 +295,7 @@ def test_no_download_logs_after_all_try_tasks_success(
             with (
                 patch.object(tc.TaskGroup, "tasks", property(tasks)),
                 patch("sync.landing.push_to_gecko"),
+                patch("sync.landing.update_landing"),
             ):
                 try_push.download_logs = Mock(return_value=[])
                 landing.try_push_complete(git_gecko, git_wpt, try_push, sync)
@@ -919,3 +921,48 @@ def test_upstream_commit_missing_pr_number_with_has_no_pr(
 
     # Make sure that landing was created this time.
     assert landing_sync is not None
+
+
+def test_update_landing_interrupted_before_patches(
+    env,
+    git_gecko,
+    git_wpt,
+    git_wpt_upstream,
+    pull_request,
+    set_pr_status,
+    hg_gecko_try,
+    mock_mach,
+):
+    pr = pull_request([(b"Test commit", {"README": b"example_change"})])
+    head_rev = pr._commits[0]["sha"]
+
+    trypush.Mach = mock_mach
+    downstream.new_wpt_pr(git_gecko, git_wpt, pr)
+    downstream_sync = set_pr_status(pr.number, "success")
+
+    git_wpt_upstream.head.commit = head_rev
+    git_wpt.remotes.origin.fetch()
+    landing.wpt_push(git_gecko, git_wpt, [head_rev], create_missing=False)
+
+    with SyncLock.for_process(downstream_sync.process_name) as downstream_lock:
+        with downstream_sync.as_mut(downstream_lock):
+            downstream_sync.data["force-metadata-ready"] = True
+
+    # Create a LandingSync without applying patches.
+    sync_point = landing.load_sync_point(git_gecko, git_wpt)
+    prev_wpt_head = sync_point["upstream"]
+
+    with SyncLock("landing", None) as lock:
+        landing_sync = landing.LandingSync.new(lock, git_gecko, git_wpt, prev_wpt_head, head_rev)
+
+    assert list(landing_sync.gecko_commits) == []
+    assert landing_sync.landing_commit is None
+
+    # Invoke update_landing and confirm that the patches are applied
+    with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+        mock_read.return_value = "0000000000000000"
+        result = landing.update_landing(git_gecko, git_wpt, new_wpt_head=head_rev)
+
+    # The landing should have progressed (patches applied), not returned None.
+    assert result is not None
+    assert list(result.gecko_commits) != []


### PR DESCRIPTION
Previously if the landing was interrupted before applying any commits, the head gecko commit would point at the base commit and the update_landing code would conclude that the landing was complete, since all commits were on the integration branch.

Add a check that we actually have patches and the final metadata update commit.