### PR TITLE
Create a sync on any PR update event.

### DIFF
--- a/sync/handlers.py
+++ b/sync/handlers.py
@@ -40,14 +40,13 @@ def handle_pr(git_gecko: Repo, git_wpt: Repo, event: Dict[str, Any]) -> None:
 
     if not sync:
         # If we don't know about this sync then it's a new thing that we should
-        # set up state for
-        # TODO: maybe want to create a new sync here irrespective of the event
-        # type because we missed some events.
-        if event["action"] == "opened":
-            downstream.new_wpt_pr(
-                git_gecko, git_wpt, event["pull_request"], repo_update=repo_update
-            )
-    else:
+        # set up state for.
+        # Create a new sync here irrespective of the event type
+        # because we might have missed some events.
+        downstream.new_wpt_pr(git_gecko, git_wpt, event["pull_request"], repo_update=repo_update)
+        sync = get_pr_sync(git_gecko, git_wpt, pr_id)
+
+    if sync:
         if isinstance(sync, downstream.DownstreamSync):
             update_func = downstream.update_pr
         elif isinstance(sync, upstream.UpstreamSync):

--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -166,6 +166,42 @@ def test_wpt_pr_approved(
         assert try_push.stability
 
 
+@pytest.mark.parametrize("action,state", [("opened", "open"), ("closed", "closed")])
+def test_handle_pr_without_prior_sync(
+    env,
+    git_gecko,
+    git_wpt,
+    pull_request,
+    mock_wpt,
+    mock_mach,
+    action,
+    state,
+):
+    mock_wpt.set_data("tests-affected", "")
+
+    pr = pull_request([(b"Test commit", {"README": b"Example change\n"})], "Test PR")
+
+    assert load.get_pr_sync(git_gecko, git_wpt, pr["number"]) is None
+
+    pr["state"] = state
+    pr["base"]["sha"] = "b" * 40
+
+    with patch("sync.tree.is_open", Mock(return_value=True)), patch("sync.trypush.Mach", mock_mach):
+        handlers.handle_pr(
+            git_gecko,
+            git_wpt,
+            {
+                "action": action,
+                "number": pr["number"],
+                "pull_request": pr,
+            },
+        )
+
+    # Verify that sync was created.
+    sync = load.get_pr_sync(git_gecko, git_wpt, pr["number"])
+    assert isinstance(sync, downstream.DownstreamSync)
+
+
 def test_revert_pr(
     env,
     git_gecko,


### PR DESCRIPTION
Currently, if we missed the "opened" event for the PR, the only way to create a sync is by retriggering it. I think we could also create a sync later on.