### PR TITLE
Try to create a bug for a downstream sync again on PR updates.

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -1231,19 +1231,25 @@ def update_pr(
             if sync.bug:
                 env.bz.set_status(sync.bug, "RESOLVED", "INVALID")
             sync.finish()
-        elif action == "closed":
-            # We are storing the wpt base as a reference
-            sync.data["wpt-base"] = base_sha
-            sync.next_try_push()
-        elif action == "reopened" or action == "open":
-            sync.status = "open"
-            sync.pr_status = "open"
-            sync.next_try_push()
-            assert sync.bug is not None
-            if sync.bug:
-                status = env.bz.get_status(sync.bug)
-                if status is not None and status[0] == "RESOLVED":
-                    env.bz.set_status(sync.bug, "REOPENED")
+        else:
+            # If a bug creation failed previously, try to create it again.
+            if sync.bug is None and sync.pr:
+                pr = env.gh_wpt.get_pull(sync.pr)
+                sync.create_bug(git_wpt, sync.pr, pr.title, pr.body or "")
+
+            if action == "closed":
+                # We are storing the wpt base as a reference
+                sync.data["wpt-base"] = base_sha
+                sync.next_try_push()
+            elif action == "reopened" or action == "open":
+                sync.status = "open"
+                sync.pr_status = "open"
+                sync.next_try_push()
+                assert sync.bug is not None
+                if sync.bug:
+                    status = env.bz.get_status(sync.bug)
+                    if status is not None and status[0] == "RESOLVED":
+                        env.bz.set_status(sync.bug, "REOPENED")
         sync.update_github_check()
     except Exception as e:
         sync.error = e

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -1234,9 +1234,13 @@ def update_pr(
         else:
             # If a bug creation failed previously, try to create it again.
             if sync.bug is None and sync.pr:
-                pr = env.gh_wpt.get_pull(sync.pr)
-                sync.create_bug(git_wpt, sync.pr, pr.title, pr.body or "")
-
+                try:
+                    pr = env.gh_wpt.get_pull(sync.pr)
+                    sync.create_bug(git_wpt, sync.pr, pr.title, pr.body or "")
+                except Exception:
+                    logger.error(
+                        f"The bug creation for the downstream sync with PR: {sync.pr} failed"
+                    )
             if action == "closed":
                 # We are storing the wpt base as a reference
                 sync.data["wpt-base"] = base_sha
@@ -1245,7 +1249,6 @@ def update_pr(
                 sync.status = "open"
                 sync.pr_status = "open"
                 sync.next_try_push()
-                assert sync.bug is not None
                 if sync.bug:
                     status = env.bz.get_status(sync.bug)
                     if status is not None and status[0] == "RESOLVED":

--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -669,3 +669,33 @@ def test_github_next_action_on_error(
                 sync.try_rebase()
 
     assert sync.next_action == downstream.DownstreamAction.manual_fix
+
+
+def test_update_pr_retries_bug_creation(env, git_gecko, git_wpt, pull_request):
+    pr = pull_request([(b"Test commit", {"README": b"Example change\n"})], "Test PR")
+
+    downstream.new_wpt_pr(git_gecko, git_wpt, pr)
+    sync = load.get_pr_sync(git_gecko, git_wpt, pr["number"])
+    assert sync is not None
+    assert sync.bug is not None
+
+    with SyncLock.for_process(sync.process_name) as lock:
+        # Simulate a prior bug creation failure by clearing the stored bug.
+        with sync.as_mut(lock):
+            sync.data["bug"] = None
+
+    assert sync.bug is None
+
+    # Handle the notification of the PR being merged.
+    with SyncLock.for_process(sync.process_name) as lock:
+        with sync.as_mut(lock):
+            downstream.update_pr(
+                git_gecko,
+                git_wpt,
+                sync,
+                action="closed",
+                merge_sha="b" * 25,
+                base_sha="b" * 25,
+            )
+
+    assert sync.bug is not None


### PR DESCRIPTION
We have a similar recovery mechanic on [a PR retrigger path](https://github.com/mozilla/wpt-sync/blob/master/sync/update.py#L197-L198), so it would be good to have it on the PR update path as well, since currently we sometimes have bugless downstream syncs in the landings.