### PR TITLE
Escape angle brackets in PR titles and text when creating a downstream bug.

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -40,6 +40,18 @@ logger = log.get_logger(__name__)
 env = Environment()
 
 
+def _escape_pr_text(text: str) -> str:
+    # Escape HTML-tag-like substrings in PR text so the request body
+    # doesn't contain tokens that Bugzilla API rejects with HTTP 406. Bare
+    # angle brackets used for comparisons or arrows (e.g. `x < 5`, `->`) are
+    # left untouched.
+    _html_tag_re = re.compile(r"</?[a-zA-Z][^>]*>")
+    return _html_tag_re.sub(
+        lambda m: m.group(0).replace("<", "&lt; ").replace(">", "&gt;"),
+        text,
+    )
+
+
 @enum.unique
 class DownstreamAction(enum.Enum):
     ready = 0
@@ -114,11 +126,11 @@ class DownstreamSync(SyncProcess):
             "Details from upstream follow.",
             "",
             "%s wrote:" % author.decode("utf8", "ignore"),
-            ">  %s" % pr_title,
+            ">  %s" % _escape_pr_text(pr_title),
         ]
         if pr_msg:
             msg.append(">  ")
-            msg.extend(">  %s" % line for line in pr_msg.split("\n"))
+            msg.extend(">  %s" % _escape_pr_text(line) for line in pr_msg.split("\n"))
         return "\n".join(msg)
 
     @classmethod
@@ -419,7 +431,7 @@ class DownstreamSync(SyncProcess):
         if self.bug is not None:
             return
         comment = self.make_bug_comment(git_wpt, pr_id, pr_title, pr_body)
-        summary = f"[wpt-sync] Sync PR {pr_id} - {pr_title}"
+        summary = f"[wpt-sync] Sync PR {pr_id} - {_escape_pr_text(pr_title)}"
         if len(summary) > 255:
             summary = summary[:254] + "\u2026"
         bug = env.bz.new(

--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -11,6 +11,7 @@ import subprocess
 import traceback
 from collections import defaultdict
 from datetime import datetime
+import html
 
 
 import enum
@@ -47,7 +48,7 @@ def _escape_pr_text(text: str) -> str:
     # left untouched.
     _html_tag_re = re.compile(r"</?[a-zA-Z][^>]*>")
     return _html_tag_re.sub(
-        lambda m: m.group(0).replace("<", "&lt; ").replace(">", "&gt;"),
+        lambda m: html.escape(m.group(0)),
         text,
     )
 

--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -53,6 +53,41 @@ def test_new_wpt_pr(env, git_gecko, git_wpt, pull_request, mock_mach, mock_wpt):
     assert "Creating a bug in component Testing :: web-platform" in env.bz.output.getvalue()
 
 
+def test_new_wpt_pr_escapes_angle_brackets(
+    env, git_gecko, git_wpt, pull_request, mock_mach, mock_wpt
+):
+    # Angle brackets in PR-sourced text must be escaped before being sent to
+    # Bugzilla — the request with HTTP 406 as a suspected tag-injection payload.
+    mock_mach.set_data(
+        "file-info",
+        b"""Testing :: web-platform-tests
+  testing/web-platform/tests/README
+""",
+    )
+    mock_wpt.set_data("files-changed", b"README\n")
+
+    title = "Add <html> tag when x < 5"
+    body = "Equivalent to `<head/>` and a < b."
+
+    pr = pull_request([(b"Test commit", {"README": b"Example change\n"})], title, body)
+
+    downstream.new_wpt_pr(git_gecko, git_wpt, pr)
+
+    output = env.bz.output.getvalue()
+
+    # Tag-like substrings from the PR must not appear raw in the bug request.
+    assert "<html>" not in output
+    assert "<head/>" not in output
+
+    # Their escaped versions must be present instead.
+    assert "&lt; html&gt;" in output
+    assert "&lt; head/&gt;" in output
+
+    # Bare angle brackets used as comparisons must be left untouched.
+    assert "x < 5" in output
+    assert "a < b" in output
+
+
 def test_new_pr_existing_branch(env, git_gecko, git_wpt, pull_request, mock_mach, mock_wpt):
     pr = pull_request([(b"Test commit", {"README": b"Example change\n"})], "Test PR")
 

--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -80,8 +80,8 @@ def test_new_wpt_pr_escapes_angle_brackets(
     assert "<head/>" not in output
 
     # Their escaped versions must be present instead.
-    assert "&lt; html&gt;" in output
-    assert "&lt; head/&gt;" in output
+    assert "&lt;html&gt;" in output
+    assert "&lt;head/&gt;" in output
 
     # Bare angle brackets used as comparisons must be left untouched.
     assert "x < 5" in output

--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -638,7 +638,7 @@ def test_metadata_update(env, git_gecko, git_wpt, pull_request, pull_request_com
 
 
 def test_gecko_rebase(env, git_gecko, git_wpt, pull_request):
-    pr = pull_request([(b"Test commit", {"README": b"Example change\n"})], b"Test PR")
+    pr = pull_request([(b"Test commit", {"README": b"Example change\n"})], "Test PR")
 
     downstream.new_wpt_pr(git_gecko, git_wpt, pr)
     sync = load.get_pr_sync(git_gecko, git_wpt, pr["number"])


### PR DESCRIPTION
Bugzilla API rejects requests to create a bug with a title or a comment containing the html tags.

We have an issue with creating bugs for PRs like:
https://github.com/web-platform-tests/wpt/pull/60110
https://github.com/web-platform-tests/wpt/pull/60046