### PR TITLE
Use canonical git revision during landing

### DIFF
--- a/sync/commit.py
+++ b/sync/commit.py
@@ -556,6 +556,25 @@ class GeckoCommit(Commit):
             return sha1
         return self.sha1
 
+    @property
+    def require_canonical_rev_git(self) -> str:
+        if self.cinnabar:
+            if "gecko-commit-git" not in self.notes:
+                canonical_rev_git = env.lando.hg2git(self.canonical_rev)
+
+                if canonical_rev_git is None:
+                    raise ValueError(
+                        f"The commit with hg hash {self.canonical_rev} is missing canonical git hash"
+                    )
+                self.notes["gecko-commit-git"] = canonical_rev_git
+            sha1 = self.notes["gecko-commit-git"]
+            if sha1 is None:
+                raise ValueError(
+                    f"The commit with hg hash {self.canonical_rev} is missing canonical git hash"
+                )
+            return sha1
+        return self.sha1
+
     def has_wpt_changes(self) -> bool:
         prefix = env.config["gecko"]["path"]["wpt"]
         return not self.is_empty(prefix)

--- a/sync/landing.py
+++ b/sync/landing.py
@@ -454,13 +454,15 @@ Automatic update from web-platform-tests\n%s
         commits = [
             item
             for item in self.unlanded_gecko_commits()
-            if item.canonical_rev not in gecko_commits_landed
+            if item.require_canonical_rev_git not in gecko_commits_landed
         ]
 
         landing_commit = self.gecko_commits[-1]
         git_work_gecko = self.gecko_worktree.get()
 
-        logger.debug("Reapplying commits: %s" % " ".join(item.canonical_rev for item in commits))
+        logger.debug(
+            "Reapplying commits: %s" % " ".join(item.require_canonical_rev_git for item in commits)
+        )
 
         if not commits:
             return
@@ -473,7 +475,7 @@ Automatic update from web-platform-tests\n%s
         already_applied_set = set(already_applied)
 
         unapplied_gecko_commits = [
-            item for item in commits if item.canonical_rev not in already_applied_set
+            item for item in commits if item.require_canonical_rev_git not in already_applied_set
         ]
 
         try:
@@ -482,7 +484,8 @@ Automatic update from web-platform-tests\n%s
                 def msg_filter(_: Any) -> tuple[bytes, dict[str, str]]:
                     msg = landing_commit.msg
                     reapplied_commits = already_applied + [
-                        commit.canonical_rev for commit in commits[: i + 1]
+                        commit.require_canonical_rev_git
+                        for commit in unapplied_gecko_commits[: i + 1]
                     ]
                     metadata = {"reapplied-commits": ", ".join(reapplied_commits)}
                     return msg, metadata
@@ -645,7 +648,7 @@ Automatic update from web-platform-tests\n%s
         ) -> None:
             if isinstance(sync, upstream.UpstreamSync):
                 for commit in commits:
-                    gecko_commit = commit.metadata.get("gecko-commit")
+                    gecko_commit = commit.metadata.get("gecko-commit-git")
                     if gecko_commit:
                         gecko_commits_landed.add(gecko_commit)
 
@@ -1060,8 +1063,10 @@ def landable_commits(
                             )
 
                 # Only check the first commit since later ones could be added in the PR
-                sync_revs = {item.canonical_rev for item in sync.upstreamed_gecko_commits}
-                if any(commit.metadata.get("gecko-commit") in sync_revs for commit in commits):
+                sync_revs = {
+                    item.require_canonical_rev_git for item in sync.upstreamed_gecko_commits
+                }
+                if any(commit.metadata.get("gecko-commit-git") in sync_revs for commit in commits):
                     break
             else:
                 sync = None

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -339,7 +339,7 @@ def test_landing_reapply(
     rev = upstream_gecko_commit(test_changes=test_changes, bug=1111, message=b"Add change1 file")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
-    env.lando.hg_to_git[rev] = "test_revision"
+    env.lando.hg_to_git[rev] = "test_revision_1"
     pushed, _, _ = upstream.gecko_push(git_gecko, git_wpt, "autoland", rev, raise_on_error=True)
     sync_1 = pushed.pop()
 
@@ -362,7 +362,7 @@ def test_landing_reapply(
     rev = upstream_gecko_commit(test_changes=test_changes, bug=1112, message=b"Add change2 file")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
-    env.lando.hg_to_git[rev] = "test_revision"
+    env.lando.hg_to_git[rev] = "test_revision_2"
     pushed, _, _ = upstream.gecko_push(git_gecko, git_wpt, "autoland", rev, raise_on_error=True)
     sync_2 = pushed.pop()
 
@@ -397,7 +397,7 @@ def test_landing_reapply(
     rev = upstream_gecko_commit(test_changes=test_changes, bug=1113, message=b"Add change3 file")
 
     update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
-    env.lando.hg_to_git[rev] = "test_revision"
+    env.lando.hg_to_git[rev] = "test_revision_3"
     pushed, _, _ = upstream.gecko_push(git_gecko, git_wpt, "autoland", rev, raise_on_error=True)
 
     # Now start a landing
@@ -444,6 +444,93 @@ def test_landing_reapply(
     )
     sync_point = landing.load_sync_point(git_gecko, git_wpt)
     assert sync_point["upstream"] == landing_rev
+
+
+def test_reapply_local_commits_uses_canonical_git_revs(
+    env, git_gecko, git_wpt, git_wpt_upstream, local_gecko_commit
+):
+    git_wpt.remotes.origin.fetch()
+    wpt_rev = git_wpt_upstream.head.commit.hexsha
+
+    landed_commit = sync_commit.GeckoCommit(
+        git_gecko,
+        local_gecko_commit(
+            test_changes={"landed": b"LANDED\n"},
+            bug=1111,
+            message=b"Already landed",
+        ).hexsha,
+    )
+    already_reapplied_commit = sync_commit.GeckoCommit(
+        git_gecko,
+        local_gecko_commit(
+            test_changes={"already": b"ALREADY\n"},
+            bug=1112,
+            message=b"Already reapplied",
+        ).hexsha,
+    )
+    unapplied_commit = sync_commit.GeckoCommit(
+        git_gecko,
+        local_gecko_commit(
+            test_changes={"unapplied": b"UNAPPLIED\n"},
+            bug=1113,
+            message=b"Still needs reapplying",
+        ).hexsha,
+    )
+
+    landed_git_rev = "git-rev-landed"
+    already_reapplied_git_rev = "git-rev-already-reapplied"
+    unapplied_git_rev = "git-rev-unapplied"
+
+    landed_commit.notes["gecko-commit-git"] = landed_git_rev
+    already_reapplied_commit.notes["gecko-commit-git"] = already_reapplied_git_rev
+    unapplied_commit.notes["gecko-commit-git"] = unapplied_git_rev
+
+    with SyncLock("landing", None) as lock:
+        landing_sync = landing.LandingSync.new(lock, git_gecko, git_wpt, wpt_rev, wpt_rev)
+        with landing_sync.as_mut(lock):
+            git_work = landing_sync.gecko_worktree.get()
+            landing_msg = sync_commit.Commit.make_commit_msg(
+                b"Landing commit",
+                {
+                    "reapplied-commits": already_reapplied_git_rev,
+                    "wpt-head": wpt_rev,
+                    "wpt-type": "landing",
+                },
+            )
+            sync_commit.create_commit(git_work, landing_msg, allow_empty=True)
+            landing_commit = landing_sync.gecko_commits[-1]
+
+            landing_sync._unlanded_gecko_commits = [
+                landed_commit,
+                already_reapplied_commit,
+                unapplied_commit,
+            ]
+
+            captured_metadata = []
+
+            def fake_move(dest_repo, msg_filter=None, **kwargs):
+                assert msg_filter is not None
+                msg, metadata = msg_filter(None)
+                assert msg == landing_commit.msg
+                captured_metadata.append(metadata)
+                return sync_commit.GeckoCommit(git_gecko, dest_repo.head.commit.hexsha)
+
+            landed_move = Mock(side_effect=AssertionError("landed commit was reapplied"))
+            already_reapplied_move = Mock(
+                side_effect=AssertionError("already reapplied commit was reapplied")
+            )
+            unapplied_move = Mock(side_effect=fake_move)
+
+            with (
+                patch.object(landed_commit, "move", landed_move),
+                patch.object(already_reapplied_commit, "move", already_reapplied_move),
+                patch.object(unapplied_commit, "move", unapplied_move),
+            ):
+                landing_sync.reapply_local_commits({landed_git_rev})
+
+            assert captured_metadata == [
+                {"reapplied-commits": f"{already_reapplied_git_rev}, {unapplied_git_rev}"}
+            ]
 
 
 def test_landing_pr_on_central(


### PR DESCRIPTION
Since on every upstream ping we verify if all the commits contain canonical git revision I think we can assume that commits that are merged must contain the metadata with git hash. So I think we should be able to start using them during landing process.