### PR TITLE
Revert "Temporary exclude accessibility tests in downstream syncs."

### DIFF
--- a/sync/downstream.py
+++ b/sync/downstream.py
@@ -939,11 +939,6 @@ class DownstreamSync(SyncProcess):
                     item = item_bytes.decode("utf8", "replace")
                     path, test_type = item.strip().split("\t")
                     tests_by_type[test_type].append(path)
-
-            # TODO: Temporary exclude accessibility tests until we fixed the mozharness.
-            if "aamtest" in tests_by_type:
-                del tests_by_type["aamtest"]
-
             self.data["affected-tests"] = tests_by_type
         return self.data["affected-tests"]
 


### PR DESCRIPTION
Reverts mozilla/wpt-sync#2754

Looks like we have [the job for accessibility tests](https://treeherder.mozilla.org/jobs?repo=try&revision=86d6b54de982ef52d1e2851150f3bf20ebb23ff9&selectedTaskRun=P5DEz0e0RsO9qCj4dxb7wQ.0), so I guess we could revert it.