### PR TITLE
Push to try via Lando

### DIFF
--- a/sync/command.py
+++ b/sync/command.py
@@ -931,8 +931,9 @@ def do_try_push_add(
         def __exit__(self, *args: Any) -> None:
             pass
 
-        def push(self) -> str:
-            return try_rev
+        def push(self) -> tuple[int | None, str]:
+            # There's no Lando job for a try push added manually
+            return None, try_rev
 
     with SyncLock.for_process(sync.process_name) as lock:
         assert isinstance(lock, SyncLock)

--- a/sync/handlers.py
+++ b/sync/handlers.py
@@ -204,6 +204,8 @@ class DecisionTaskHandler(Handler):
                     return
 
         try_push = trypush.TryPush.for_commit(git_gecko, sha1)
+        if try_push is None:
+            try_push = trypush.TryPush.for_task(git_gecko, task)
         if not try_push:
             logger.debug(f"No try push for SHA1 {sha1} taskId {task_id}")
             # This could be a race condition if the decision task completes before this
@@ -213,6 +215,8 @@ class DecisionTaskHandler(Handler):
         with SyncLock.for_process(try_push.process_name) as lock:
             assert isinstance(lock, SyncLock)
             with try_push.as_mut(lock):
+                if try_push.try_rev is None:
+                    try_push.try_rev = sha1
                 # If we retrigger, we create a new taskgroup, with id equal to the new task_id.
                 # But the retriggered decision task itself is still in the original taskgroup
                 if state == "completed":

--- a/sync/lando.py
+++ b/sync/lando.py
@@ -99,6 +99,8 @@ class MockLando(Lando):
         self.hg_to_git: dict[str, Optional[str]] = {}
         self.git_to_hg: dict[str, Optional[str]] = {}
         self.try_pushes: list[Mapping[str, Any]] = []
+        self.job_status: dict[int, str] = {}
+        self.default_job_status = "LANDED"
 
     def try_push(
         self,
@@ -119,10 +121,11 @@ class MockLando(Lando):
     def landing_job(self, job_id: int) -> Mapping[str, Any]:
         if not 0 < job_id <= len(self.try_pushes):
             raise ValueError(f"Lando has no job with id {job_id}")
+        status = self.job_status.get(job_id, self.default_job_status)
         return {
             "id": job_id,
-            "status": "LANDED",
-            "commit_id": "%040x" % job_id,
+            "status": status,
+            "commit_id": "%040x" % job_id if status == "LANDED" else None,
             "error": "",
             "url": urljoin(self.base_url, f"/landings/{job_id}"),
         }

--- a/sync/lando.py
+++ b/sync/lando.py
@@ -11,6 +11,7 @@ git2hg_cache: dict[str, str] = {}
 class Lando:
     def __init__(self, config: Mapping[str, Any]):
         self.base_url = config["lando"]["url"]
+        self.api_try_token = config["lando"]["try_api_token"]
 
     def get(self, path: str) -> Optional[Mapping[str, Any]]:
         exc = None
@@ -33,6 +34,45 @@ class Lando:
             return data
         assert exc is not None
         raise exc
+
+    def try_push(
+        self,
+        patches: list[str],
+        base_commit: str,
+        base_commit_vcs: str = "hg",
+        patch_format: str = "git-format-patch",
+        repo_name: str = "try",
+    ) -> int:
+        body = {
+            "base_commit": base_commit,
+            "base_commit_vcs": base_commit_vcs,
+            "patch_format": patch_format,
+            "patches": patches,
+            "repo_name": repo_name,
+        }
+        headers = {
+            "Authorization": f"Bearer {self.api_try_token}",
+            "Content-Type": "application/json",
+        }
+        responce = requests.post(
+            urljoin(self.base_url, "/api/try/patches"), headers=headers, json=body
+        )
+        try:
+            data = responce.json()
+        except ValueError:
+            data = None
+        if data is None or not isinstance(data.get("id"), int):
+            raise ValueError(f"Lando response missing id property: {data}")
+
+        return data["id"]
+
+    def landing_job(self, job_id: int) -> Mapping[str, Any]:
+        """Get the current state of a Lando landing job"""
+        data = self.get(f"/landing_jobs/{job_id}")
+        if data is None:
+            raise ValueError(f"Lando has no job with id {job_id}")
+
+        return data
 
     def hg2git(self, hg_hash: str) -> Optional[str]:
         data = self.get(f"/api/hg2git/firefox/{hg_hash}")
@@ -61,6 +101,37 @@ class MockLando(Lando):
         super().__init__(config)
         self.hg_to_git: dict[str, Optional[str]] = {}
         self.git_to_hg: dict[str, Optional[str]] = {}
+        self.try_pushes: list[Mapping[str, Any]] = []
+
+    def try_push(
+        self,
+        patches: list[str],
+        base_commit: str,
+        base_commit_vcs: str = "hg",
+        patch_format: str = "git-format-patch",
+        repo_name: str = "try",
+    ) -> int:
+        self.try_pushes.append(
+            {
+                "base_commit": base_commit,
+                "base_commit_vcs": base_commit_vcs,
+                "patch_format": patch_format,
+                "patches": patches,
+                "repo_name": repo_name,
+            }
+        )
+        return len(self.try_pushes)
+
+    def landing_job(self, job_id: int) -> Mapping[str, Any]:
+        if not 0 < job_id <= len(self.try_pushes):
+            raise ValueError(f"Lando has no job with id {job_id}")
+        return {
+            "id": job_id,
+            "status": "LANDED",
+            "commit_id": "%040x" % job_id,
+            "error": "",
+            "url": urljoin(self.base_url, f"/landings/{job_id}"),
+        }
 
     def hg2git(self, hg_hash: str) -> Optional[str]:
         return self.hg_to_git.get(hg_hash)

--- a/sync/lando.py
+++ b/sync/lando.py
@@ -13,10 +13,19 @@ class Lando:
         self.base_url = config["lando"]["url"]
         self.api_try_token = config["lando"]["try_api_token"]
 
-    def get(self, path: str) -> Optional[Mapping[str, Any]]:
+    def request(
+        self,
+        method: str,
+        path: str,
+        retry_count: int = 1,
+        headers: Optional[Mapping[str, str]] = None,
+        body: Optional[Mapping[str, Any]] = None,
+    ) -> Optional[Mapping[str, Any]]:
         exc = None
-        for _retry_count in range(5):
-            resp = requests.get(urljoin(self.base_url, path))
+        for _retry_count in range(retry_count):
+            resp = requests.request(
+                method, urljoin(self.base_url, path), headers=headers, json=body
+            )
             if resp.status_code == 404:
                 return None
             try:
@@ -39,28 +48,16 @@ class Lando:
         self,
         patches: list[str],
         base_commit: str,
-        base_commit_vcs: str = "hg",
-        patch_format: str = "git-format-patch",
-        repo_name: str = "try",
     ) -> int:
         body = {
             "base_commit": base_commit,
-            "base_commit_vcs": base_commit_vcs,
-            "patch_format": patch_format,
+            "base_commit_vcs": "hg",
+            "patch_format": "git-format-patch",
             "patches": patches,
-            "repo_name": repo_name,
+            "repo_name": "try",
         }
-        headers = {
-            "Authorization": f"Bearer {self.api_try_token}",
-            "Content-Type": "application/json",
-        }
-        responce = requests.post(
-            urljoin(self.base_url, "/api/try/patches"), headers=headers, json=body
-        )
-        try:
-            data = responce.json()
-        except ValueError:
-            data = None
+        headers = {"Authorization": f"Bearer {self.api_try_token}"}
+        data = self.request("POST", "/api/try/patches", headers=headers, body=body)
         if data is None or not isinstance(data.get("id"), int):
             raise ValueError(f"Lando response missing id property: {data}")
 
@@ -68,14 +65,14 @@ class Lando:
 
     def landing_job(self, job_id: int) -> Mapping[str, Any]:
         """Get the current state of a Lando landing job"""
-        data = self.get(f"/landing_jobs/{job_id}")
+        data = self.request("GET", f"/landing_jobs/{job_id}", retry_count=5)
         if data is None:
             raise ValueError(f"Lando has no job with id {job_id}")
 
         return data
 
     def hg2git(self, hg_hash: str) -> Optional[str]:
-        data = self.get(f"/api/hg2git/firefox/{hg_hash}")
+        data = self.request("GET", f"/api/hg2git/firefox/{hg_hash}", retry_count=5)
         if data is None:
             return None
         if not isinstance(data.get("git_hash"), str):
@@ -85,7 +82,7 @@ class Lando:
 
     def git2hg(self, git_hash: str) -> Optional[str]:
         if git_hash not in git2hg_cache:
-            data = self.get(f"/api/git2hg/firefox/{git_hash}")
+            data = self.request("GET", f"/api/git2hg/firefox/{git_hash}", retry_count=5)
             if data is None:
                 return None
             if not isinstance(data.get("hg_hash"), str):
@@ -107,17 +104,14 @@ class MockLando(Lando):
         self,
         patches: list[str],
         base_commit: str,
-        base_commit_vcs: str = "hg",
-        patch_format: str = "git-format-patch",
-        repo_name: str = "try",
     ) -> int:
         self.try_pushes.append(
             {
                 "base_commit": base_commit,
-                "base_commit_vcs": base_commit_vcs,
-                "patch_format": patch_format,
+                "base_commit_vcs": "hg",
+                "patch_format": "git-format-patch",
                 "patches": patches,
-                "repo_name": repo_name,
+                "repo_name": "try",
             }
         )
         return len(self.try_pushes)

--- a/sync/projectutil.py
+++ b/sync/projectutil.py
@@ -84,7 +84,7 @@ class WPT(Command):
 
 def create_mock(name: str) -> type[Command]:
     class MockCommand(Command):
-        _data: dict[str, bytes] = {}
+        _data: dict[str, bytes | Callable[..., bytes]] = {}
         _log: list[dict[str, Any]] = []
 
         def __init__(self, path: str) -> None:
@@ -92,7 +92,7 @@ def create_mock(name: str) -> type[Command]:
             self.path = path
 
         @classmethod
-        def set_data(cls, command: str, value: bytes) -> None:
+        def set_data(cls, command: str, value: bytes | Callable[..., bytes]) -> None:
             cls._data[command] = value
 
         @classmethod
@@ -100,9 +100,8 @@ def create_mock(name: str) -> type[Command]:
             return cls._log
 
         def get(self, *args: str, **kwargs: Any) -> bytes:
-            data = self._data.get(args[0], b"")
-            if callable(data):
-                data = data(*args[1:], **kwargs)
+            value = self._data.get(args[0], b"")
+            data = value(self, *args[1:], **kwargs) if callable(value) else value
 
             self._log.append(
                 {"command": self.name, "cwd": self.path, "args": args, "kwargs": kwargs, "rv": data}

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
+import base64
+import json
 import os
 import re
 import shutil
 import subprocess
+import time
 import traceback
 from collections import defaultdict
 
@@ -37,7 +40,13 @@ logger = log.get_logger(__name__)
 env = Environment()
 
 auth_tc = tc.TaskclusterClient()
-rev_re = re.compile("revision=(?P<rev>[0-9a-f]{40})")
+try_output_re = re.compile(
+    r"^Commit message:\n(?P<message>.*?)\n^Calculated try_task_config\.json:\n",
+    re.MULTILINE | re.DOTALL,
+)
+try_task_config_path = "try_task_config.json"
+lando_poll_interval = 10
+lando_poll_timeout = 30 * 60
 
 
 class TryCommit:
@@ -48,6 +57,7 @@ class TryCommit:
         tests_by_type: Mapping[str, list[str]] | None,
         rebuild: int,
         hacks: bool = True,
+        base: str | None = None,
         **kwargs: Any,
     ) -> None:
         self.git_gecko = git_gecko
@@ -55,6 +65,7 @@ class TryCommit:
         self.tests_by_type = tests_by_type
         self.rebuild = rebuild
         self.hacks = hacks
+        self.base = base
         self.try_rev = None
         self.extra_args = kwargs
         self.reset: str | None = None
@@ -96,34 +107,39 @@ class TryCommit:
                 self.worktree.index.add([tc_config])
 
     def push(self) -> str:
-        status, output = self._push()
-        return self.read_treeherder(status, output)
+        job_id = self._push()
+        return self.read_try_rev(job_id)
 
-    def _push(self) -> tuple[int, str]:
+    def _push(self) -> int:
         raise NotImplementedError
 
-    def read_treeherder(self, status: int, output: str) -> str:
-        msg = f"Failed to push to try:\n{output}"
-        try_rev: str | None = None
-        if status != 0:
-            logger.error(msg)
-            raise RetryableError(AbortError(msg))
-        rev_match = rev_re.search(output)
-        if not rev_match:
-            logger.warning(f"No revision found in string:\n\n{output}\n")
-            # Assume that the revision is HEAD
-            # This happens in tests and isn't a problem, but would be in real code,
-            # so that's not ideal
-            try:
-                try_rev = cinnabar(self.git_gecko).git2hg(self.worktree.head.commit.hexsha)
-            except ValueError:
-                pass
-        else:
-            try_rev = rev_match.group("rev")
-        if try_rev is None:
-            logger.error(msg)
-            raise AbortError(msg)
-        return try_rev
+    def read_try_rev(self, job_id: int) -> str:
+        """Wait for Lando to apply the patches we pushed and return the revision
+        it created on try"""
+        deadline = time.monotonic() + lando_poll_timeout
+        while True:
+            job = env.lando.landing_job(job_id)
+            status = job.get("status")
+            if status == "LANDED":
+                try_rev = job.get("commit_id")
+                if not isinstance(try_rev, str):
+                    msg = f"Lando job {job_id} landed without a revision:\n{job}"
+                    logger.error(msg)
+                    raise AbortError(msg)
+                return try_rev
+            if status in ("FAILED", "CANCELLED"):
+                msg = f"Lando job {job_id} for the try push is {status}:\n{job.get('error')}"
+                logger.error(msg)
+                raise AbortError(msg)
+            if time.monotonic() > deadline:
+                msg = (
+                    f"Timed out waiting for Lando job {job_id} to land the try push; "
+                    f"last status was {status}. See {job.get('url')}"
+                )
+                logger.error(msg)
+                raise AbortError(msg)
+            logger.info(f"Waiting for Lando job {job_id} to land the try push, status {status}")
+            time.sleep(lando_poll_interval)
 
 
 class TryFuzzyCommit(TryCommit):
@@ -134,9 +150,12 @@ class TryFuzzyCommit(TryCommit):
         tests_by_type: Mapping[str, list[str]] | None,
         rebuild: int,
         hacks: bool = True,
+        base: str | None = None,
         **kwargs: Any,
     ) -> None:
-        super().__init__(git_gecko, worktree, tests_by_type, rebuild, hacks=hacks, **kwargs)
+        super().__init__(
+            git_gecko, worktree, tests_by_type, rebuild, hacks=hacks, base=base, **kwargs
+        )
         self.queries = self.extra_args.get(
             "queries", ["web-platform-tests !macosx !shippable !asan !tsan"]
         )
@@ -147,14 +166,24 @@ class TryFuzzyCommit(TryCommit):
         self.artifact = self.extra_args.get("artifact", True)
 
     def create(self) -> None:
+        self.reset = self.worktree.head.commit.hexsha
         if self.hacks:
-            self.reset = self.worktree.head.commit.hexsha
             self.apply_hacks()
             # TODO add something useful to the commit message here since that will
             # appear in email &c.
             self.worktree.index.commit(message="Apply task hacks before running try")
 
-    def _push(self) -> tuple[int, str]:
+    def _push(self) -> int:
+        status, output = self.run_mach_try()
+        if status != 0:
+            msg = f"Failed to run mach try:\n{output}"
+            logger.error(msg)
+            raise RetryableError(AbortError(msg))
+        message, try_task_config = self.read_try_task_config(output)
+        self.create_try_commit(message, try_task_config)
+        return self.push_to_lando()
+
+    def run_mach_try(self) -> tuple[int, str]:
         self.worktree.git.reset("--hard")
 
         working_dir = self.worktree.working_dir
@@ -172,7 +201,8 @@ class TryFuzzyCommit(TryCommit):
         query_args = []
         for query in self.queries:
             query_args.extend(["-q", query])
-        logger.info("Pushing to try with fuzzy query: %s" % " ".join(query_args))
+
+        logger.info("Creating try commit with fuzzy query: %s" % " ".join(query_args))
 
         can_push_routes = b"--route " in mach.try_("fuzzy", "--help")
 
@@ -191,8 +221,9 @@ class TryFuzzyCommit(TryCommit):
         else:
             args.append("--no-artifact")
 
-        # --push-to-vcs is required to push directly to hgmo
-        args.append("--push-to-vcs")
+        # --no-push means mach only computes the try_task_config.json and the commit
+        # message; making the commit and pushing it to try is handled here instead
+        args.append("--no-push")
 
         if self.tests_by_type is not None:
             paths = []
@@ -212,7 +243,78 @@ class TryFuzzyCommit(TryCommit):
             output = mach.try_(*args, stderr=subprocess.STDOUT)
             return 0, output.decode("utf8", "replace")
         except subprocess.CalledProcessError as e:
-            return e.returncode, e.output
+            return e.returncode, e.output.decode("utf8", "replace")
+
+    def read_try_task_config(self, output: str) -> tuple[str, str]:
+        """Read the commit message and the try_task_config.json content from the
+        output of `mach try fuzzy --no-push`
+
+        :return: Tuple of (commit message, try_task_config.json content)
+        """
+        match = try_output_re.search(output)
+        if match is None:
+            msg = f"Failed to read the try commit message from mach output:\n{output}"
+            logger.error(msg)
+            raise AbortError(msg)
+        try:
+            # The config is the first JSON object after the header line, but it's
+            # followed by other output, so just decode as much as parses
+            try_task_config, _ = json.JSONDecoder().raw_decode(output[match.end() :])
+        except ValueError:
+            msg = f"Failed to read try_task_config.json from mach output:\n{output}"
+            logger.error(msg)
+            raise AbortError(msg)
+
+        content = (
+            json.dumps(try_task_config, indent=4, separators=(",", ": "), sort_keys=True) + "\n"
+        )
+        return match.group("message"), content
+
+    def create_try_commit(self, message: str, try_task_config: str) -> None:
+        working_dir = self.worktree.working_dir
+        assert working_dir is not None
+
+        with open(os.path.join(working_dir, try_task_config_path), "w") as f:
+            f.write(try_task_config)
+        self.worktree.index.add([try_task_config_path])
+        self.worktree.index.commit(message=message)
+        logger.info(
+            "Created try commit %s with message:\n%s" % (self.worktree.head.commit.hexsha, message)
+        )
+
+    def push_to_lando(self) -> int:
+        if self.base is None:
+            raise AbortError("Can't push to try without a base commit")
+
+        try:
+            base_commit = cinnabar(self.git_gecko).git2hg(self.base)
+        except ValueError as e:
+            msg = f"Failed to get the hg revision of the base commit {self.base}:\n{e}"
+            logger.error(msg)
+            raise AbortError(msg)
+        patches = [
+            base64.b64encode(patch).decode("ascii") for patch in self.commit_patches(self.base)
+        ]
+        logger.info("Pushing %d commits to try on top of %s" % (len(patches), base_commit))
+        try:
+            job_id = env.lando.try_push(patches, base_commit)
+        except Exception as e:
+            msg = f"Failed to push to try:\n{e}"
+            logger.error(msg)
+            raise RetryableError(AbortError(msg))
+        logger.info("Pushed to try as Lando job %s" % job_id)
+        return job_id
+
+    def commit_patches(self, base: str) -> list[bytes]:
+        revs = self.worktree.git.rev_list("--reverse", f"{base}..HEAD").splitlines()
+        if not revs:
+            raise AbortError(f"No commits to push to try between {base} and the try commit")
+        return [
+            self.worktree.git.format_patch(
+                rev, "-1", "--always", "--stdout", "--no-base", stdout_as_string=False
+            )
+            for rev in revs
+        ]
 
 
 class TryPush(base.ProcessData):
@@ -262,7 +364,13 @@ class TryPush(base.ProcessData):
                 logger.error("Could not find config for Stability rebuild count, using default 5")
                 rebuild_count = 5
         with try_cls(
-            sync.git_gecko, git_work, affected_tests, rebuild_count, hacks=hacks, **kwargs
+            sync.git_gecko,
+            git_work,
+            affected_tests,
+            rebuild_count,
+            hacks=hacks,
+            base=sync.gecko_commits.base.sha1,
+            **kwargs,
         ) as c:
             try_rev = c.push()
 

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import base64
-import json
 import os
 import re
 import shutil
@@ -40,10 +39,6 @@ logger = log.get_logger(__name__)
 env = Environment()
 
 auth_tc = tc.TaskclusterClient()
-try_output_re = re.compile(
-    r"^Commit message:\n(?P<message>.*?)\n^Calculated try_task_config\.json:\n",
-    re.MULTILINE | re.DOTALL,
-)
 
 
 def try_rev_from_job(job_id: int, job: Mapping[str, Any]) -> str | None:
@@ -196,16 +191,38 @@ class TryFuzzyCommit(TryCommit):
             self.worktree.index.commit(message="Apply task hacks before running try")
 
     def _push(self) -> int:
-        status, output = self.run_mach_try()
+        paths = self.test_paths()
+        status, output = self.run_mach_try(paths)
         if status != 0:
             msg = f"Failed to run mach try:\n{output}"
             logger.error(msg)
             raise RetryableError(AbortError(msg))
-        message, try_task_config = self.read_try_task_config(output)
-        self.create_try_commit(message, try_task_config)
+        self.create_try_commit(self.commit_message(paths))
         return self.push_to_lando()
 
-    def run_mach_try(self) -> tuple[int, str]:
+    def test_paths(self) -> list[str]:
+        """Paths of the affected tests to pass to mach try, capped at the
+        configured maximum number of tests."""
+        if self.tests_by_type is None:
+            return []
+
+        working_dir = self.worktree.working_dir
+        assert working_dir is not None
+
+        paths = []
+        all_paths = set()
+        for values in self.tests_by_type.values():
+            for item in values:
+                if item not in all_paths and os.path.exists(os.path.join(working_dir, item)):
+                    paths.append(item)
+                all_paths.add(item)
+        max_tests = env.config["gecko"]["try"].get("max-tests")
+        if max_tests and len(paths) > max_tests:
+            logger.warning("Capping number of affected tests at %d" % max_tests)
+            paths = paths[:max_tests]
+        return paths
+
+    def run_mach_try(self, paths: list[str]) -> tuple[int, str]:
         self.worktree.git.reset("--hard")
 
         working_dir = self.worktree.working_dir
@@ -243,23 +260,12 @@ class TryFuzzyCommit(TryCommit):
         else:
             args.append("--no-artifact")
 
-        # --no-push means mach only computes the try_task_config.json and the commit
-        # message; making the commit and pushing it to try is handled here instead
-        args.append("--no-push")
+        # --write-task-config means mach only writes try_task_config.json to the root
+        # of the worktree; making the commit and pushing it to try is handled here
+        # instead
+        args.append("--write-task-config")
 
-        if self.tests_by_type is not None:
-            paths = []
-            all_paths = set()
-            for values in self.tests_by_type.values():
-                for item in values:
-                    if item not in all_paths and os.path.exists(os.path.join(working_dir, item)):
-                        paths.append(item)
-                    all_paths.add(item)
-            max_tests = env.config["gecko"]["try"].get("max-tests")
-            if max_tests and len(paths) > max_tests:
-                logger.warning("Capping number of affected tests at %d" % max_tests)
-                paths = paths[:max_tests]
-            args.extend(paths)
+        args.extend(paths)
 
         try:
             output = mach.try_(*args, stderr=subprocess.STDOUT)
@@ -267,43 +273,32 @@ class TryFuzzyCommit(TryCommit):
         except subprocess.CalledProcessError as e:
             return e.returncode, e.output.decode("utf8", "replace")
 
-    def read_try_task_config(self, output: str) -> tuple[str, str]:
-        """Read the commit message and the try_task_config.json content from the
-        output of `mach try fuzzy --no-push`
-
-        :return: Tuple of (commit message, try_task_config.json content)
-        """
-        match = try_output_re.search(output)
-        if match is None:
-            msg = f"Failed to read the try commit message from mach output:\n{output}"
-            logger.error(msg)
-            raise AbortError(msg)
-        try:
-            # The config is the first JSON object after the header line, but it's
-            # followed by other output, so just decode as much as parses
-            try_task_config, _ = json.JSONDecoder().raw_decode(output[match.end() :])
-        except ValueError:
-            msg = f"Failed to read try_task_config.json from mach output:\n{output}"
-            logger.error(msg)
-            raise AbortError(msg)
-
-        content = (
-            json.dumps(try_task_config, indent=4, separators=(",", ": "), sort_keys=True) + "\n"
-        )
-        return match.group("message"), content
-
-    def create_try_commit(self, message: str, try_task_config: str) -> None:
-        working_dir = self.worktree.working_dir
-        assert working_dir is not None
+    def commit_message(self, paths: list[str]) -> str:
+        """Message for the try commit, in the same format as the one `mach try fuzzy`
+        generates when it makes the commit itself."""
+        args = [f"query={query}" for query in self.queries]
+        if paths:
+            args.append("paths={}".format(":".join(paths)))
+        message = "Fuzzy {}".format("&".join(args))
 
         if self.token is not None:
             # This is the last commit in the push, so its message is the one that's
             # passed to the decision task.
             message = f"{message}\n\n{f'wptsync-try-push: {self.token}'}"
 
+        return message
+
+    def create_try_commit(self, message: str) -> None:
+        working_dir = self.worktree.working_dir
+        assert working_dir is not None
+
         try_task_config_path = "try_task_config.json"
-        with open(os.path.join(working_dir, try_task_config_path), "w") as f:
-            f.write(try_task_config)
+
+        if not os.path.exists(os.path.join(working_dir, try_task_config_path)):
+            msg = f"mach try didn't write {try_task_config_path}"
+            logger.error(msg)
+            raise AbortError(msg)
+
         self.worktree.index.add([try_task_config_path])
         self.worktree.index.commit(message=message)
         logger.info(

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import base64
 import os
-import re
 import shutil
 import subprocess
 import time
@@ -253,6 +252,8 @@ class TryFuzzyCommit(TryCommit):
             args.append("--full")
         if self.disable_target_task_filter:
             args.append("--disable-target-task-filter")
+        if self.token is not None:
+            args.extend(["--env", f"WPTSYNC_TRY_PUSH_TOKEN={self.token}"])
         if can_push_routes:
             args.append("--route=notify.pulse.wptsync.try-task.on-any")
         if self.artifact:
@@ -279,14 +280,7 @@ class TryFuzzyCommit(TryCommit):
         args = [f"query={query}" for query in self.queries]
         if paths:
             args.append("paths={}".format(":".join(paths)))
-        message = "Fuzzy {}".format("&".join(args))
-
-        if self.token is not None:
-            # This is the last commit in the push, so its message is the one that's
-            # passed to the decision task.
-            message = f"{message}\n\n{f'wptsync-try-push: {self.token}'}"
-
-        return message
+        return "Fuzzy {}".format("&".join(args))
 
     def create_try_commit(self, message: str) -> None:
         working_dir = self.worktree.working_dir
@@ -462,23 +456,9 @@ class TryPush(base.ProcessData):
 
     @classmethod
     def for_task(cls, git_gecko: Repo, task: Mapping[str, Any]) -> Optional[Self]:
-        """Get the try push that a task belongs to, using the token we add to the try
-        commit message, which is what the decision task is passed.
-
-        :param task: Task definition, as returned by the Taskcluster queue
-        """
-        commit_msg = task.get("payload", {}).get("env", {}).get("GECKO_COMMIT_MSG")
-        if commit_msg is None:
+        token = task.get("payload", {}).get("env", {}).get("WPTSYNC_TRY_PUSH_TOKEN")
+        if not isinstance(token, str):
             return None
-
-        match = re.compile(
-            r"^%s: (?P<token>\S+)$" % re.escape("wptsync-try-push"), re.MULTILINE
-        ).search(commit_msg)
-
-        if match is None:
-            return None
-        else:
-            token = match.group("token")
 
         parts = token.split("/")
         if len(parts) != 3:
@@ -497,7 +477,7 @@ class TryPush(base.ProcessData):
 
     @property
     def token(self) -> str | None:
-        """Token identifying this try push in its commit message on try"""
+        """ID identifying this try push in Taskcluster task environments."""
         return self.get("try-token")
 
     @property

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import time
 import traceback
+import uuid
 from collections import defaultdict
 
 import taskcluster
@@ -20,7 +21,7 @@ from .env import Environment
 from .errors import AbortError, RetryableError
 from .index import TaskGroupIndex, TryCommitIndex
 from .load import get_syncs
-from .lock import constructor, mut
+from .lock import SyncLock, constructor, mut
 from .projectutil import Mach
 from .repos import cinnabar
 from .sync import SyncProcess
@@ -32,7 +33,6 @@ from git.repo.base import Repo
 if TYPE_CHECKING:
     from sync.downstream import DownstreamSync
     from sync.landing import LandingSync
-    from sync.lock import SyncLock
     from sync.tc import TaskGroup
 
 
@@ -44,8 +44,22 @@ try_output_re = re.compile(
     r"^Commit message:\n(?P<message>.*?)\n^Calculated try_task_config\.json:\n",
     re.MULTILINE | re.DOTALL,
 )
-lando_poll_interval = 10
-lando_poll_timeout = 30 * 60
+
+
+def try_rev_from_job(job_id: int, job: Mapping[str, Any]) -> str | None:
+    status = job.get("status")
+    if status == "LANDED":
+        try_rev = job.get("commit_id")
+        if not isinstance(try_rev, str):
+            msg = f"Lando job {job_id} landed without a revision:\n{job}"
+            logger.error(msg)
+            raise AbortError(msg)
+        return try_rev
+    if status in ("FAILED", "CANCELLED"):
+        msg = f"Lando job {job_id} for the try push is {status}:\n{job.get('error')}"
+        logger.error(msg)
+        raise AbortError(msg)
+    return None
 
 
 class TryCommit:
@@ -57,6 +71,7 @@ class TryCommit:
         rebuild: int,
         hacks: bool = True,
         base: str | None = None,
+        token: str | None = None,
         **kwargs: Any,
     ) -> None:
         self.git_gecko = git_gecko
@@ -65,6 +80,7 @@ class TryCommit:
         self.rebuild = rebuild
         self.hacks = hacks
         self.base = base
+        self.token = token
         self.try_rev = None
         self.extra_args = kwargs
         self.reset: str | None = None
@@ -105,40 +121,39 @@ class TryCommit:
 
                 self.worktree.index.add([tc_config])
 
-    def push(self) -> str:
+    def push(self) -> tuple[int, str | None]:
+        """Push to try.
+
+        :return: Tuple of (Lando job id, revision on try). The revision is None if
+                 Lando hasn't landed the commits yet.
+        """
         job_id = self._push()
-        return self.read_try_rev(job_id)
+        return job_id, self.read_try_rev(job_id)
 
     def _push(self) -> int:
         raise NotImplementedError
 
-    def read_try_rev(self, job_id: int) -> str:
+    def read_try_rev(self, job_id: int) -> str | None:
         """Wait for Lando to apply the patches we pushed and return the revision
-        it created on try"""
-        deadline = time.monotonic() + lando_poll_timeout
+        it created on try.
+
+        :return: The revision on try, or None if the job hasn't landed yet
+        """
+        deadline = time.monotonic() + 60
         while True:
             job = env.lando.landing_job(job_id)
-            status = job.get("status")
-            if status == "LANDED":
-                try_rev = job.get("commit_id")
-                if not isinstance(try_rev, str):
-                    msg = f"Lando job {job_id} landed without a revision:\n{job}"
-                    logger.error(msg)
-                    raise AbortError(msg)
+            try_rev = try_rev_from_job(job_id, job)
+            if try_rev is not None:
                 return try_rev
-            if status in ("FAILED", "CANCELLED"):
-                msg = f"Lando job {job_id} for the try push is {status}:\n{job.get('error')}"
-                logger.error(msg)
-                raise AbortError(msg)
+            status = job.get("status")
             if time.monotonic() > deadline:
-                msg = (
-                    f"Timed out waiting for Lando job {job_id} to land the try push; "
-                    f"last status was {status}. See {job.get('url')}"
+                logger.info(
+                    f"Lando job {job_id} hasn't landed the try push yet; last status was "
+                    f"{status}. Waiting for the decision task instead. See {job.get('url')}"
                 )
-                logger.error(msg)
-                raise AbortError(msg)
+                return None
             logger.info(f"Waiting for Lando job {job_id} to land the try push, status {status}")
-            time.sleep(lando_poll_interval)
+            time.sleep(10)
 
 
 class TryFuzzyCommit(TryCommit):
@@ -150,10 +165,18 @@ class TryFuzzyCommit(TryCommit):
         rebuild: int,
         hacks: bool = True,
         base: str | None = None,
+        token: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(
-            git_gecko, worktree, tests_by_type, rebuild, hacks=hacks, base=base, **kwargs
+            git_gecko,
+            worktree,
+            tests_by_type,
+            rebuild,
+            hacks=hacks,
+            base=base,
+            token=token,
+            **kwargs,
         )
         self.queries = self.extra_args.get(
             "queries", ["web-platform-tests !macosx !shippable !asan !tsan"]
@@ -273,6 +296,11 @@ class TryFuzzyCommit(TryCommit):
         working_dir = self.worktree.working_dir
         assert working_dir is not None
 
+        if self.token is not None:
+            # This is the last commit in the push, so its message is the one that's
+            # passed to the decision task.
+            message = f"{message}\n\n{f'wptsync-try-push: {self.token}'}"
+
         try_task_config_path = "try_task_config.json"
         with open(os.path.join(working_dir, try_task_config_path), "w") as f:
             f.write(try_task_config)
@@ -358,6 +386,9 @@ class TryPush(base.ProcessData):
 
         git_work = sync.gecko_worktree.get()
 
+        sync_id = str(getattr(sync, sync.obj_id))
+        token = f"{sync.sync_type}/{sync_id}/{uuid.uuid4()}"
+
         if rebuild_count is None:
             rebuild_count = 0 if not stability else env.config["gecko"]["try"]["stability_count"]
             if not isinstance(rebuild_count, int):
@@ -370,12 +401,15 @@ class TryPush(base.ProcessData):
             rebuild_count,
             hacks=hacks,
             base=sync.gecko_commits.base.sha1,
+            token=token,
             **kwargs,
         ) as c:
-            try_rev = c.push()
+            job_id, try_rev = c.push()
 
         data = {
             "try-rev": try_rev,
+            "try-token": token,
+            "lando-job-id": job_id,
             "stability": stability,
             "gecko-head": sync.gecko_commits.head.sha1,
             "wpt-head": sync.wpt_commits.head.sha1,
@@ -386,16 +420,24 @@ class TryPush(base.ProcessData):
             sync.git_gecko, cls.obj_type, sync.sync_type, str(getattr(sync, sync.obj_id))
         )
         rv = super().create(lock, sync.git_gecko, process_name, data)
-        try_idx.insert(try_idx.make_key(try_rev), process_name)
+        if try_rev is not None:
+            try_idx.insert(try_idx.make_key(try_rev), process_name)
 
         with rv.as_mut(lock):
             rv.created = taskcluster.fromNowJSON("0 days")
 
         if sync.bug is not None:
-            env.bz.comment(
-                sync.bug,
-                "Pushed to try%s %s" % (" (stability)" if stability else "", rv.treeherder_url),
-            )
+            if try_rev is not None:
+                env.bz.comment(
+                    sync.bug,
+                    f"Pushed to try{' (stability)' if stability else ''} {rv.treeherder_url}",
+                )
+            else:
+                env.bz.comment(
+                    sync.bug,
+                    f"Pushed to try{' (stability)' if stability else ''} "
+                    + f"https://treeherder.mozilla.org/jobs?repo=try&landoInstance=lando-prod-2025&landoCommitID={job_id}",
+                )
 
         return rv
 
@@ -423,6 +465,46 @@ class TryPush(base.ProcessData):
             return cls(git_gecko, process_name)
         return None
 
+    @classmethod
+    def for_task(cls, git_gecko: Repo, task: Mapping[str, Any]) -> Optional[Self]:
+        """Get the try push that a task belongs to, using the token we add to the try
+        commit message, which is what the decision task is passed.
+
+        :param task: Task definition, as returned by the Taskcluster queue
+        """
+        commit_msg = task.get("payload", {}).get("env", {}).get("GECKO_COMMIT_MSG")
+        if commit_msg is None:
+            return None
+
+        match = re.compile(
+            r"^%s: (?P<token>\S+)$" % re.escape("wptsync-try-push"), re.MULTILINE
+        ).search(commit_msg)
+
+        if match is None:
+            return None
+        else:
+            token = match.group("token")
+
+        parts = token.split("/")
+        if len(parts) != 3:
+            logger.warning(f"Unexpected try push token {token}")
+            return None
+        subtype, obj_id, _ = parts
+        # The token contains the sync, so only its try pushes can match
+        process_names = base.ProcessNameIndex(git_gecko).get(cls.obj_type, subtype, obj_id)
+        for process_name in process_names:
+            try_push = cls(git_gecko, process_name)
+            if try_push.token == token:
+                logger.info(f"Found try push {process_name!r} for token {token}")
+                return try_push
+        logger.info(f"No try push for token {token}")
+        return None
+
+    @property
+    def token(self) -> str | None:
+        """Token identifying this try push in its commit message on try"""
+        return self.get("try-token")
+
     @property
     def treeherder_url(self) -> str:
         return "https://treeherder.mozilla.org/#/jobs?repo=try&revision=%s" % self.try_rev
@@ -446,9 +528,55 @@ class TryPush(base.ProcessData):
         idx = TryCommitIndex(self.repo)
         if self.try_rev is not None:
             idx.delete(idx.make_key(self.try_rev), self.process_name)
-        self._data["try-rev"] = value
-        assert self.try_rev is not None
-        idx.insert(idx.make_key(self.try_rev), self.process_name)
+        self["try-rev"] = value
+        idx.insert(idx.make_key(value), self.process_name)
+
+    def poll_try_rev(self) -> str | None:
+        """Ask Lando once for the revision it created on try, if we don't have it yet.
+
+        :return: The revision on try, or None if it's still unknown
+        """
+        if self.try_rev is not None or self.status != "open":
+            return self.try_rev
+        job_id = self.get("lando-job-id")
+        if job_id is None:
+            logger.warning(
+                "Try push %s has no revision and no Lando job to get it from" % self.process_name
+            )
+            return None
+
+        try:
+            try_rev = try_rev_from_job(job_id, env.lando.landing_job(job_id))
+        except AbortError as e:
+            with SyncLock.for_process(self.process_name) as lock:
+                assert isinstance(lock, SyncLock)
+                with self.as_mut(lock):
+                    self.status = "complete"
+                    self.infra_fail = True
+                    bug = self.get("bug")
+                    if bug is not None:
+                        env.bz.comment(bug, "Try push failed to land: %s" % e.message)
+            return None
+        except Exception:
+            # Don't allow a problem with one try push to stop us handling the others
+            logger.error(
+                "Failed to get Lando job %s for try push %s:\n%s"
+                % (job_id, self.process_name, traceback.format_exc())
+            )
+            return None
+
+        if try_rev is None:
+            logger.info(
+                "Lando job %s for try push %s hasn't landed yet" % (job_id, self.process_name)
+            )
+            return None
+
+        with SyncLock.for_process(self.process_name) as lock:
+            assert isinstance(lock, SyncLock)
+            with self.as_mut(lock):
+                logger.info("Try push %s landed on try as %s" % (self.process_name, try_rev))
+                self.try_rev = try_rev
+        return try_rev
 
     @property
     def taskgroup_id(self) -> str | None:

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -44,7 +44,6 @@ try_output_re = re.compile(
     r"^Commit message:\n(?P<message>.*?)\n^Calculated try_task_config\.json:\n",
     re.MULTILINE | re.DOTALL,
 )
-try_task_config_path = "try_task_config.json"
 lando_poll_interval = 10
 lando_poll_timeout = 30 * 60
 
@@ -274,6 +273,7 @@ class TryFuzzyCommit(TryCommit):
         working_dir = self.worktree.working_dir
         assert working_dir is not None
 
+        try_task_config_path = "try_task_config.json"
         with open(os.path.join(working_dir, try_task_config_path), "w") as f:
             f.write(try_task_config)
         self.worktree.index.add([try_task_config_path])
@@ -306,14 +306,14 @@ class TryFuzzyCommit(TryCommit):
         return job_id
 
     def commit_patches(self, base: str) -> list[bytes]:
-        revs = self.worktree.git.rev_list("--reverse", f"{base}..HEAD").splitlines()
-        if not revs:
+        commits = list(self.worktree.iter_commits(f"{base}..HEAD", reverse=True))
+        if not commits:
             raise AbortError(f"No commits to push to try between {base} and the try commit")
         return [
             self.worktree.git.format_patch(
-                rev, "-1", "--always", "--stdout", "--no-base", stdout_as_string=False
+                commit.hexsha, "-1", "--always", "--stdout", "--no-base", stdout_as_string=False
             )
-            for rev in revs
+            for commit in commits
         ]
 
 

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -122,18 +122,18 @@ class TryCommit:
                  Lando hasn't landed the commits yet.
         """
         job_id = self._push()
-        return job_id, self.read_try_rev(job_id)
+        return job_id, self.read_try_rev(job_id, 60)
 
     def _push(self) -> int:
         raise NotImplementedError
 
-    def read_try_rev(self, job_id: int) -> str | None:
+    def read_try_rev(self, job_id: int, timeout: int) -> str | None:
         """Wait for Lando to apply the patches we pushed and return the revision
         it created on try.
 
         :return: The revision on try, or None if the job hasn't landed yet
         """
-        deadline = time.monotonic() + 60
+        deadline = time.monotonic() + timeout
         while True:
             job = env.lando.landing_job(job_id)
             try_rev = try_rev_from_job(job_id, job)

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -40,6 +40,12 @@ env = Environment()
 auth_tc = tc.TaskclusterClient()
 
 
+class MachTooOldError(Exception):
+    """The mach in the worktree doesn't support the arguments we need to push to try.
+
+    Rebasing the sync onto a more recent gecko revision is expected to fix this."""
+
+
 def try_rev_from_job(job_id: int, job: Mapping[str, Any]) -> str | None:
     status = job.get("status")
     if status == "LANDED":
@@ -242,7 +248,15 @@ class TryFuzzyCommit(TryCommit):
 
         logger.info("Creating try commit with fuzzy query: %s" % " ".join(query_args))
 
-        can_push_routes = b"--route " in mach.try_("fuzzy", "--help")
+        try_help = mach.try_("fuzzy", "--help")
+
+        if b"--write-task-config" not in try_help:
+            raise MachTooOldError("mach try fuzzy doesn't support --write-task-config")
+
+        if b"--env" not in try_help:
+            raise MachTooOldError("mach try fuzzy doesn't support --env")
+
+        can_push_routes = b"--route " in try_help
 
         args = ["fuzzy"] + query_args
         if self.rebuild:
@@ -373,8 +387,6 @@ class TryPush(base.ProcessData):
         TaskGroupIndex.get_or_create(sync.git_gecko)
         try_idx = TryCommitIndex.get_or_create(sync.git_gecko)
 
-        git_work = sync.gecko_worktree.get()
-
         sync_id = str(getattr(sync, sync.obj_id))
         token = f"{sync.sync_type}/{sync_id}/{uuid.uuid4()}"
 
@@ -383,17 +395,36 @@ class TryPush(base.ProcessData):
             if not isinstance(rebuild_count, int):
                 logger.error("Could not find config for Stability rebuild count, using default 5")
                 rebuild_count = 5
-        with try_cls(
-            sync.git_gecko,
-            git_work,
-            affected_tests,
-            rebuild_count,
-            hacks=hacks,
-            base=sync.gecko_commits.base.sha1,
-            token=token,
-            **kwargs,
-        ) as c:
-            job_id, try_rev = c.push()
+
+        def push() -> tuple[int, str | None]:
+            with try_cls(
+                sync.git_gecko,
+                sync.gecko_worktree.get(),
+                affected_tests,
+                rebuild_count,
+                hacks=hacks,
+                base=sync.gecko_commits.base.sha1,
+                token=token,
+                **kwargs,
+            ) as c:
+                return c.push()
+
+        try:
+            job_id, try_rev = push()
+        except MachTooOldError as e:
+            # The sync is based on a gecko revision that predates the mach features we
+            # rely on, so rebase onto the tip of the landing branch and try again
+            landing_branch = sync.gecko_landing_branch()
+            logger.info(f"{e}; rebasing onto {landing_branch}")
+
+            sync.gecko_rebase(landing_branch, abort_on_fail=True)
+
+            try:
+                job_id, try_rev = push()
+            except MachTooOldError as e:
+                msg = f"{e}, even after rebasing onto {landing_branch}"
+                logger.error(msg)
+                raise AbortError(msg)
 
         data = {
             "try-rev": try_rev,

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -3,7 +3,6 @@ import base64
 import os
 import shutil
 import subprocess
-import time
 import traceback
 import uuid
 from collections import defaultdict
@@ -128,32 +127,27 @@ class TryCommit:
                  Lando hasn't landed the commits yet.
         """
         job_id = self._push()
-        return job_id, self.read_try_rev(job_id, 60)
+        return job_id, self.read_try_rev(job_id)
 
     def _push(self) -> int:
         raise NotImplementedError
 
-    def read_try_rev(self, job_id: int, timeout: int) -> str | None:
-        """Wait for Lando to apply the patches we pushed and return the revision
+    def read_try_rev(self, job_id: int) -> str | None:
+        """Check if Lando applied the patches we pushed and return the revision
         it created on try.
 
         :return: The revision on try, or None if the job hasn't landed yet
         """
-        deadline = time.monotonic() + timeout
-        while True:
-            job = env.lando.landing_job(job_id)
-            try_rev = try_rev_from_job(job_id, job)
-            if try_rev is not None:
-                return try_rev
-            status = job.get("status")
-            if time.monotonic() > deadline:
-                logger.info(
-                    f"Lando job {job_id} hasn't landed the try push yet; last status was "
-                    f"{status}. Waiting for the decision task instead. See {job.get('url')}"
-                )
-                return None
-            logger.info(f"Waiting for Lando job {job_id} to land the try push, status {status}")
-            time.sleep(10)
+        job = env.lando.landing_job(job_id)
+        try_rev = try_rev_from_job(job_id, job)
+        if try_rev is not None:
+            return try_rev
+        status = job.get("status")
+        logger.info(
+            f"Lando job {job_id} hasn't landed the try push yet; last status was "
+            f"{status}. Waiting for the decision task instead. See {job.get('url')}"
+        )
+        return None
 
 
 class TryFuzzyCommit(TryCommit):

--- a/sync/trypush.py
+++ b/sync/trypush.py
@@ -506,6 +506,7 @@ class TryPush(base.ProcessData):
         self["try-rev"] = value
         idx.insert(idx.make_key(value), self.process_name)
 
+    @mut()
     def poll_try_rev(self) -> str | None:
         """Ask Lando once for the revision it created on try, if we don't have it yet.
 
@@ -523,14 +524,11 @@ class TryPush(base.ProcessData):
         try:
             try_rev = try_rev_from_job(job_id, env.lando.landing_job(job_id))
         except AbortError as e:
-            with SyncLock.for_process(self.process_name) as lock:
-                assert isinstance(lock, SyncLock)
-                with self.as_mut(lock):
-                    self.status = "complete"
-                    self.infra_fail = True
-                    bug = self.get("bug")
-                    if bug is not None:
-                        env.bz.comment(bug, "Try push failed to land: %s" % e.message)
+            self.status = "complete"
+            self.infra_fail = True
+            bug = self.get("bug")
+            if bug is not None:
+                env.bz.comment(bug, "Try push failed to land: %s" % e.message)
             return None
         except Exception:
             # Don't allow a problem with one try push to stop us handling the others
@@ -546,11 +544,8 @@ class TryPush(base.ProcessData):
             )
             return None
 
-        with SyncLock.for_process(self.process_name) as lock:
-            assert isinstance(lock, SyncLock)
-            with self.as_mut(lock):
-                logger.info("Try push %s landed on try as %s" % (self.process_name, try_rev))
-                self.try_rev = try_rev
+        logger.info("Try push %s landed on try as %s" % (self.process_name, try_rev))
+        self.try_rev = try_rev
         return try_rev
 
     @property

--- a/sync/update.py
+++ b/sync/update.py
@@ -292,12 +292,19 @@ def update_taskgroup_ids(git_gecko: Repo, git_wpt: Repo, try_push: TryPush | Non
     for try_push_item in try_pushes:
         if not try_push_item.taskgroup_id:
             logger.info("Setting taskgroup id for try push %s" % try_push_item)
-            if try_push_item.try_rev is None:
+            try_rev = try_push_item.poll_try_rev()
+            if try_rev is None:
                 logger.warning(
                     "Try push %s has no associated revision" % try_push_item.process_name
                 )
                 continue
-            taskgroup_id, state, runs = tc.get_taskgroup_id("try", try_push_item.try_rev)
+            try:
+                taskgroup_id, state, runs = tc.get_taskgroup_id("try", try_rev)
+            except ValueError:
+                logger.warning(
+                    f"Try push {try_push_item.process_name} has no decision task for revision {try_rev} yet"
+                )
+                continue
             logger.info("Got taskgroup id %s" % taskgroup_id)
             if state in ("completed", "failed", "exception"):
                 msg = {

--- a/sync/update.py
+++ b/sync/update.py
@@ -292,7 +292,10 @@ def update_taskgroup_ids(git_gecko: Repo, git_wpt: Repo, try_push: TryPush | Non
     for try_push_item in try_pushes:
         if not try_push_item.taskgroup_id:
             logger.info("Setting taskgroup id for try push %s" % try_push_item)
-            try_rev = try_push_item.poll_try_rev()
+            with SyncLock.for_process(try_push_item.process_name) as lock:
+                assert isinstance(lock, SyncLock)
+                with try_push_item.as_mut(lock):
+                    try_rev = try_push_item.poll_try_rev()
             if try_rev is None:
                 logger.warning(
                     "Try push %s has no associated revision" % try_push_item.process_name

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,18 +33,7 @@ from sync.lock import SyncLock
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-mach_try_output = b"""warning: paths to individual tests may not work, re-writing to \
-testing/web-platform/tests/example. Pass --allow-testfile-path to override
-Commit message:
-Fuzzy query=web-platform-tests !macosx !shippable !asan !tsan\
-&paths=testing/web-platform/tests/example
-
-mach try command: `./mach try fuzzy -q "web-platform-tests !macosx !shippable !asan !tsan" \
---artifact --no-push`
-
-Pushed via `mach try fuzzy`
-Calculated try_task_config.json:
-{
+try_task_config = """{
     "parameters": {
         "optimize_target_tasks": false,
         "try_task_config": {
@@ -61,6 +50,20 @@ Calculated try_task_config.json:
     "version": 2
 }
 """
+
+
+def mach_try(mach, *args, **kwargs):
+    """Mock `mach try`, which with --write-task-config writes try_task_config.json
+    to the root of the source tree instead of pushing to try"""
+    if "--write-task-config" not in args:
+        return b""
+    path = os.path.join(mach.path, "try_task_config.json")
+    with open(path, "w") as f:
+        f.write(try_task_config)
+    return b"""warning: paths to individual tests may not work, re-writing to \
+testing/web-platform/tests/example. Pass --allow-testfile-path to override
+Wrote %s
+""" % path.encode("utf8")
 
 
 def create_file_data(file_data, repo_workdir, repo_prefix=None):
@@ -541,7 +544,7 @@ def mock_mach():
     from sync import projectutil
 
     cls = projectutil.create_mock("mach")
-    cls.set_data("try", mach_try_output)
+    cls.set_data("try", mach_try)
     projectutil.Mach = cls
     return cls
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -563,7 +563,7 @@ def mock_try_push(git_gecko):
 
     def push(self):
         log.append(f"Pushing to try with message:\n{self.worktree.head.commit.message}")
-        return repos.cinnabar(git_gecko).git2hg(self.worktree.commit("HEAD~").hexsha)
+        return None, repos.cinnabar(git_gecko).git2hg(self.worktree.commit("HEAD~").hexsha)
 
     trypush.TryCommit.push = push
 
@@ -772,7 +772,8 @@ def MockTryCls():
             pass
 
         def push(self):
-            return "".join(hex(random.randint(0, 15))[2:] for _ in range(40))
+            try_rev = "".join(hex(random.randint(0, 15))[2:] for _ in range(40))
+            return 1, try_rev
 
     return MockTryPush
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,6 +33,35 @@ from sync.lock import SyncLock
 
 here = os.path.abspath(os.path.dirname(__file__))
 
+mach_try_output = b"""warning: paths to individual tests may not work, re-writing to \
+testing/web-platform/tests/example. Pass --allow-testfile-path to override
+Commit message:
+Fuzzy query=web-platform-tests !macosx !shippable !asan !tsan\
+&paths=testing/web-platform/tests/example
+
+mach try command: `./mach try fuzzy -q "web-platform-tests !macosx !shippable !asan !tsan" \
+--artifact --no-push`
+
+Pushed via `mach try fuzzy`
+Calculated try_task_config.json:
+{
+    "parameters": {
+        "optimize_target_tasks": false,
+        "try_task_config": {
+            "env": {
+                "TRY_SELECTOR": "fuzzy"
+            },
+            "tasks": [
+                "test-linux2404-64/debug-web-platform-tests-1",
+                "test-linux2404-64/opt-web-platform-tests-1"
+            ],
+            "use-artifact-builds": true
+        }
+    },
+    "version": 2
+}
+"""
+
 
 def create_file_data(file_data, repo_workdir, repo_prefix=None):
     add_paths = []
@@ -512,6 +541,7 @@ def mock_mach():
     from sync import projectutil
 
     cls = projectutil.create_mock("mach")
+    cls.set_data("try", mach_try_output)
     projectutil.Mach = cls
     return cls
 
@@ -680,7 +710,7 @@ def try_push(
 
     trypush.Mach = mock_mach
     with patch("sync.tree.is_open", Mock(return_value=True)):
-        with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+        with patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read:
             mock_read.return_value = "0000000000000000"
             downstream.new_wpt_pr(git_gecko, git_wpt, pr)
             sync = set_pr_status(pr.number, "success")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -57,9 +57,18 @@ def mach_try(mach, *args, **kwargs):
     to the root of the source tree instead of pushing to try"""
     if "--write-task-config" not in args:
         return b""
+
+    task_config = json.loads(try_task_config)
+    task_env = task_config["parameters"]["try_task_config"]["env"]
+    for idx, arg in enumerate(args):
+        if arg == "--env":
+            name, value = args[idx + 1].split("=", 1)
+            task_env[name] = value
+
     path = os.path.join(mach.path, "try_task_config.json")
     with open(path, "w") as f:
-        f.write(try_task_config)
+        json.dump(task_config, f, indent=4, sort_keys=True)
+        f.write("\n")
     return b"""warning: paths to individual tests may not work, re-writing to \
 testing/web-platform/tests/example. Pass --allow-testfile-path to override
 Wrote %s

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -52,9 +52,24 @@ try_task_config = """{
 """
 
 
+try_fuzzy_help = b"""usage: mach [global arguments] try fuzzy [command arguments]
+
+Command Arguments:
+  --full                Use the full task graph
+  --artifact            Force artifact builds
+  --no-artifact         Disable artifact builds
+  --env ENV             Set an environment variable in the task
+  --write-task-config   Write try_task_config.json to the root of the source
+                        tree instead of pushing to try
+"""
+
+
 def mach_try(mach, *args, **kwargs):
     """Mock `mach try`, which with --write-task-config writes try_task_config.json
     to the root of the source tree instead of pushing to try"""
+    if "--help" in args:
+        return try_fuzzy_help
+
     if "--write-task-config" not in args:
         return b""
 
@@ -556,6 +571,15 @@ def mock_mach():
     cls.set_data("try", mach_try)
     projectutil.Mach = cls
     return cls
+
+
+@pytest.fixture
+def mock_mach_no_write_task_config():
+    """Mock mach for a gecko revision that predates `mach try --write-task-config`,
+    so `mach try fuzzy --help` doesn't list the flag"""
+    from sync import projectutil
+
+    return projectutil.create_mock("mach")
 
 
 @pytest.fixture(scope="function")

--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -144,7 +144,7 @@ def test_wpt_pr_approved(
         assert sync.latest_try_push is None
 
         # If we 'merge' the PR, then we will see a stability try push
-        with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+        with patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read:
             mock_read.return_value = "0000000000000000"
             handlers.handle_pr(
                 git_gecko,

--- a/test/test_downstream.py
+++ b/test/test_downstream.py
@@ -525,6 +525,57 @@ def test_next_try_push_infra_fail_try_rebase_failed(
                 assert sync.next_action == downstream.DownstreamAction.manual_fix
 
 
+def test_try_push_rebases_old_mach(
+    env,
+    git_gecko,
+    git_wpt,
+    pull_request,
+    set_pr_status,
+    hg_gecko_try,
+    mock_mach,
+    mock_mach_no_write_task_config,
+    upstream_gecko_commit,
+):
+    pr = pull_request([(b"Test commit", {"README": b"Example change\n"})], "Test PR")
+
+    with patch("sync.tree.is_open", Mock(return_value=True)):
+        downstream.new_wpt_pr(git_gecko, git_wpt, pr)
+        sync = set_pr_status(pr.number, "success")
+        env.gh_wpt.get_pull(sync.pr).merged = True
+
+        # Add a commit to central so that rebasing the sync changes its base
+        rev = upstream_gecko_commit(
+            test_changes={"OTHER_CHANGES": b"TEST"},
+            message=b"Other changes",
+            bookmarks="mozilla/central",
+        )
+        downstream.update_repositories(git_gecko, git_wpt, wait_gecko_commit=rev)
+        env.lando.hg_to_git[rev] = "test_revision"
+        upstream.gecko_push(git_gecko, git_wpt, "mozilla-central", rev, raise_on_error=True)
+
+        central = git_gecko.rev_parse(downstream.DownstreamSync.gecko_landing_branch())
+
+        with SyncLock.for_process(sync.process_name) as lock:
+            with sync.as_mut(lock):
+                sync.data["affected-tests"] = {"testharness": ["example"]}
+                assert not git_gecko.is_ancestor(central, sync.gecko_commits.head.commit)
+
+                # The first attempt to push gets a mach that predates
+                # --write-task-config; the attempt after the rebase doesn't
+                mach_clss = iter([mock_mach_no_write_task_config, mock_mach])
+                with (
+                    patch("sync.trypush.Mach", lambda path: next(mach_clss)(path)),
+                    patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read,
+                ):
+                    mock_read.return_value = "0000000000000000"
+                    try_push = sync.next_try_push()
+
+                assert try_push is not None
+                # The sync was rebased onto central and the push retried with both machs
+                assert git_gecko.is_ancestor(central, sync.gecko_commits.head.commit)
+                assert next(mach_clss, None) is None
+
+
 def test_dependent_commit(
     env, git_gecko, git_wpt, pull_request, upstream_wpt_commit, pull_request_commit
 ):

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -91,9 +91,12 @@ def test_land_try(
         "-q",
         "web-platform-tests mac !debug shippable",
         "--disable-target-task-filter",
+        "--env",
+        ANY,
         "--artifact",
         "--write-task-config",
     )
+    assert mach_command["args"][-3].startswith("WPTSYNC_TRY_PUSH_TOKEN=landing/")
 
 
 def test_land_commit(

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -92,7 +92,7 @@ def test_land_try(
         "web-platform-tests mac !debug shippable",
         "--disable-target-task-filter",
         "--artifact",
-        "--no-push",
+        "--write-task-config",
     )
 
 

--- a/test/test_landing.py
+++ b/test/test_landing.py
@@ -55,7 +55,7 @@ def test_land_try(
         with sync.as_mut(downstream_lock):
             sync.data["force-metadata-ready"] = True
 
-    with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+    with patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read:
         mock_read.return_value = "0000000000000000"
         landing_sync = landing.update_landing(git_gecko, git_wpt)
 
@@ -92,7 +92,7 @@ def test_land_try(
         "web-platform-tests mac !debug shippable",
         "--disable-target-task-filter",
         "--artifact",
-        "--push-to-vcs",
+        "--no-push",
     )
 
 
@@ -123,7 +123,7 @@ def test_land_commit(
         with downstream_sync.as_mut(downstream_lock):
             downstream_sync.data["force-metadata-ready"] = True
 
-    with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+    with patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read:
         mock_read.return_value = "0000000000000000"
         sync = landing.update_landing(git_gecko, git_wpt)
 
@@ -140,7 +140,7 @@ def test_land_commit(
                     property(Mock(return_value=mock_tasks(completed=["foo"]))),
                 ):
                     with patch.object(
-                        trypush.TryCommit, "read_treeherder", autospec=True
+                        trypush.TryCommit, "read_try_rev", autospec=True
                     ) as mock_read:
                         mock_read.return_value = "0000000000000001"
                         landing.try_push_complete(git_gecko, git_wpt, try_push, sync)
@@ -401,7 +401,7 @@ def test_landing_reapply(
     pushed, _, _ = upstream.gecko_push(git_gecko, git_wpt, "autoland", rev, raise_on_error=True)
 
     # Now start a landing
-    with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+    with patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read:
         mock_read.return_value = "0000000000000000"
         sync = landing.update_landing(git_gecko, git_wpt)
 
@@ -419,7 +419,7 @@ def test_landing_reapply(
                     property(Mock(return_value=mock_tasks(completed=["foo"]))),
                 ):
                     with patch.object(
-                        trypush.TryCommit, "read_treeherder", autospec=True
+                        trypush.TryCommit, "read_try_rev", autospec=True
                     ) as mock_read:
                         mock_read.return_value = "0000000000000001"
                         with patch.object(landing, "push_with_lando", Mock(side_effect=mock_push)):
@@ -479,7 +479,7 @@ def test_landing_pr_on_central(
     # Repeat the changes in m-c
     upstream_gecko_commit(test_changes=test_changes, bug=1234, message=b"Change README")
 
-    with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+    with patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read:
         mock_read.return_value = "0000000000000000"
         sync = landing.update_landing(git_gecko, git_wpt)
 
@@ -523,7 +523,7 @@ def test_landing_metadata(
 
     landing.wpt_push(git_gecko, git_wpt, [head_rev], create_missing=False)
 
-    with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+    with patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read:
         mock_read.return_value = "0000000000000000"
         landing_sync = landing.update_landing(git_gecko, git_wpt)
 
@@ -622,7 +622,7 @@ def test_relanding_unchanged_upstreamed_pr(
     m = Mock(side_effect=mock_create, wraps=sync_commit.Commit.create)
     with (
         patch("sync.commit.Commit.create", m),
-        patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read,
+        patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read,
     ):
         mock_read.return_value = "0000000000000000"
         landing_sync = landing.update_landing(git_gecko, git_wpt, include_incomplete=True)
@@ -680,7 +680,7 @@ def test_relanding_changed_upstreamed_pr(
         for _ in git_wpt.references[sync.branch_name].log():
             git_wpt.git.reflog("delete", f"{sync.branch_name}@{{0}}")
 
-    with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+    with patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read:
         mock_read.return_value = "0000000000000000"
         landing_sync = landing.update_landing(git_gecko, git_wpt, include_incomplete=True)
     commits = landing_sync.gecko_commits._commits
@@ -734,7 +734,7 @@ def test_landing_push_failed(
         with downstream_sync.as_mut(downstream_lock):
             downstream_sync.data["force-metadata-ready"] = True
 
-    with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+    with patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read:
         mock_read.return_value = "0000000000000000"
         sync = landing.update_landing(git_gecko, git_wpt)
 
@@ -751,7 +751,7 @@ def test_landing_push_failed(
                     property(Mock(return_value=mock_tasks(completed=["foo"]))),
                 ):
                     with patch.object(
-                        trypush.TryCommit, "read_treeherder", autospec=True
+                        trypush.TryCommit, "read_try_rev", autospec=True
                     ) as mock_read:
                         mock_read.return_value = "0000000000000001"
                         landing.try_push_complete(git_gecko, git_wpt, try_push, sync)
@@ -822,7 +822,7 @@ def test_upstream_commit_missing_pr_number(
             sync.data["force-metadata-ready"] = True
 
     landing_sync = None
-    with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+    with patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read:
         mock_read.return_value = "0000000000000000"
         with pytest.raises(AbortError):
             landing_sync = landing.update_landing(git_gecko, git_wpt)
@@ -835,7 +835,7 @@ def test_upstream_commit_missing_pr_number(
         wpt_commit = sync_commit.WptCommit(git_wpt, commit_item)
         wpt_commit.notes["wpt_pr"] = pr["number"]
 
-    with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+    with patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read:
         mock_read.return_value = "0000000000000000"
         landing_sync = landing.update_landing(git_gecko, git_wpt)
 
@@ -902,7 +902,7 @@ def test_upstream_commit_missing_pr_number_with_has_no_pr(
             sync_2.data["force-metadata-ready"] = True
 
     landing_sync = None
-    with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+    with patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read:
         mock_read.return_value = "0000000000000000"
         with pytest.raises(AbortError):
             landing_sync = landing.update_landing(git_gecko, git_wpt)
@@ -915,7 +915,7 @@ def test_upstream_commit_missing_pr_number_with_has_no_pr(
         wpt_commit = sync_commit.WptCommit(git_wpt, commit_item)
         wpt_commit.notes["wpt_pr"] = 0
 
-    with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+    with patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read:
         mock_read.return_value = "0000000000000000"
         landing_sync = landing.update_landing(git_gecko, git_wpt)
 
@@ -959,7 +959,7 @@ def test_update_landing_interrupted_before_patches(
     assert landing_sync.landing_commit is None
 
     # Invoke update_landing and confirm that the patches are applied
-    with patch.object(trypush.TryCommit, "read_treeherder", autospec=True) as mock_read:
+    with patch.object(trypush.TryCommit, "read_try_rev", autospec=True) as mock_read:
         mock_read.return_value = "0000000000000000"
         result = landing.update_landing(git_gecko, git_wpt, new_wpt_head=head_rev)
 

--- a/test/test_try.py
+++ b/test/test_try.py
@@ -1,7 +1,46 @@
+import base64
+import json
+import re
 from unittest.mock import Mock, patch
 
-from sync import tc
+from sync import tc, trypush
 from sync.lock import SyncLock
+from conftest import mach_try_output
+
+
+def test_read_try_task_config(env, git_gecko):
+    try_commit = trypush.TryFuzzyCommit(git_gecko, git_gecko, None, 0, hacks=False)
+    message, try_task_config = try_commit.read_try_task_config(
+        mach_try_output.decode("utf8", "replace")
+    )
+
+    assert message.startswith("Fuzzy query=web-platform-tests")
+    assert message.endswith("Pushed via `mach try fuzzy`")
+    assert json.loads(try_task_config)["parameters"]["try_task_config"]["tasks"] == [
+        "test-linux2404-64/debug-web-platform-tests-1",
+        "test-linux2404-64/opt-web-platform-tests-1",
+    ]
+
+
+def test_read_try_rev(env, git_gecko):
+    try_commit = trypush.TryFuzzyCommit(git_gecko, git_gecko, None, 0, hacks=False)
+    job_id = env.lando.try_push(["patch"], "0" * 40)
+
+    assert try_commit.read_try_rev(job_id) == "%040x" % job_id
+
+
+def test_try_push_patches(env, try_push):
+    assert len(env.lando.try_pushes) == 1
+    lando_push = env.lando.try_pushes[0]
+
+    assert lando_push["repo_name"] == "try"
+    assert lando_push["patch_format"] == "git-format-patch"
+    assert lando_push["base_commit_vcs"] == "hg"
+    assert re.match("^[0-9a-f]{40}$", lando_push["base_commit"])
+
+    patches = [base64.b64decode(item).decode("utf8") for item in lando_push["patches"]]
+    assert patches
+    assert "try_task_config.json" in patches[-1]
 
 
 def test_try_task_states(mock_tasks, try_push):

--- a/test/test_try.py
+++ b/test/test_try.py
@@ -41,6 +41,9 @@ def test_try_push_patches(env, try_push):
     patches = [base64.b64decode(item).decode("utf8") for item in lando_push["patches"]]
     assert patches
     assert "try_task_config.json" in patches[-1]
+    # The try commit is the last one in the push, so its message is the one that gets
+    # passed to the decision task
+    assert f"wptsync-try-push: {try_push.token}" in patches[-1]
 
 
 def test_try_task_states(mock_tasks, try_push):

--- a/test/test_try.py
+++ b/test/test_try.py
@@ -6,19 +6,6 @@ from sync import tc, trypush
 from sync.lock import SyncLock
 
 
-def test_commit_message(env, git_gecko):
-    try_commit = trypush.TryFuzzyCommit(
-        git_gecko, git_gecko, None, 0, hacks=False, token="downstream/1234/abcdef"
-    )
-    message = try_commit.commit_message(["testing/web-platform/tests/example"])
-
-    assert message == (
-        "Fuzzy query=web-platform-tests !macosx !shippable !asan !tsan"
-        "&paths=testing/web-platform/tests/example\n\n"
-        "wptsync-try-push: downstream/1234/abcdef"
-    )
-
-
 def test_read_try_rev(env, git_gecko):
     try_commit = trypush.TryFuzzyCommit(git_gecko, git_gecko, None, 0, hacks=False)
     job_id = env.lando.try_push(["patch"], "0" * 40)
@@ -40,9 +27,27 @@ def test_try_push_patches(env, try_push):
     # The try commit contains the try_task_config.json written by mach try
     assert "try_task_config.json" in patches[-1]
     assert "test-linux2404-64/opt-web-platform-tests-1" in patches[-1]
-    # The try commit is the last one in the push, so its message is the one that gets
-    # passed to the decision task
-    assert f"wptsync-try-push: {try_push.token}" in patches[-1]
+
+
+def test_try_push_for_task(git_gecko, try_push):
+    task = {"payload": {"env": {"WPTSYNC_TRY_PUSH_TOKEN": try_push.token}}}
+
+    assert trypush.TryPush.for_task(git_gecko, task) == try_push
+
+
+def test_try_push_for_task_selects_exact_push(git_gecko, git_wpt, try_push, MockTryCls):
+    sync = try_push.sync(git_gecko, git_wpt)
+    assert sync is not None
+    with SyncLock.for_process(sync.process_name) as lock:
+        with sync.as_mut(lock):
+            second_try_push = trypush.TryPush.create(
+                lock, sync, hacks=False, try_cls=MockTryCls, check_open=False
+            )
+
+    task = {"payload": {"env": {"WPTSYNC_TRY_PUSH_TOKEN": second_try_push.token}}}
+
+    assert second_try_push.token != try_push.token
+    assert trypush.TryPush.for_task(git_gecko, task) == second_try_push
 
 
 def test_try_task_states(mock_tasks, try_push):

--- a/test/test_try.py
+++ b/test/test_try.py
@@ -1,25 +1,22 @@
 import base64
-import json
 import re
 from unittest.mock import Mock, patch
 
 from sync import tc, trypush
 from sync.lock import SyncLock
-from conftest import mach_try_output
 
 
-def test_read_try_task_config(env, git_gecko):
-    try_commit = trypush.TryFuzzyCommit(git_gecko, git_gecko, None, 0, hacks=False)
-    message, try_task_config = try_commit.read_try_task_config(
-        mach_try_output.decode("utf8", "replace")
+def test_commit_message(env, git_gecko):
+    try_commit = trypush.TryFuzzyCommit(
+        git_gecko, git_gecko, None, 0, hacks=False, token="downstream/1234/abcdef"
     )
+    message = try_commit.commit_message(["testing/web-platform/tests/example"])
 
-    assert message.startswith("Fuzzy query=web-platform-tests")
-    assert message.endswith("Pushed via `mach try fuzzy`")
-    assert json.loads(try_task_config)["parameters"]["try_task_config"]["tasks"] == [
-        "test-linux2404-64/debug-web-platform-tests-1",
-        "test-linux2404-64/opt-web-platform-tests-1",
-    ]
+    assert message == (
+        "Fuzzy query=web-platform-tests !macosx !shippable !asan !tsan"
+        "&paths=testing/web-platform/tests/example\n\n"
+        "wptsync-try-push: downstream/1234/abcdef"
+    )
 
 
 def test_read_try_rev(env, git_gecko):
@@ -40,7 +37,9 @@ def test_try_push_patches(env, try_push):
 
     patches = [base64.b64decode(item).decode("utf8") for item in lando_push["patches"]]
     assert patches
+    # The try commit contains the try_task_config.json written by mach try
     assert "try_task_config.json" in patches[-1]
+    assert "test-linux2404-64/opt-web-platform-tests-1" in patches[-1]
     # The try commit is the last one in the push, so its message is the one that gets
     # passed to the decision task
     assert f"wptsync-try-push: {try_push.token}" in patches[-1]

--- a/test/test_try.py
+++ b/test/test_try.py
@@ -10,7 +10,7 @@ def test_read_try_rev(env, git_gecko):
     try_commit = trypush.TryFuzzyCommit(git_gecko, git_gecko, None, 0, hacks=False)
     job_id = env.lando.try_push(["patch"], "0" * 40)
 
-    assert try_commit.read_try_rev(job_id, 10) == "%040x" % job_id
+    assert try_commit.read_try_rev(job_id) == "%040x" % job_id
 
 
 def test_try_push_patches(env, try_push):

--- a/test/test_try.py
+++ b/test/test_try.py
@@ -10,7 +10,7 @@ def test_read_try_rev(env, git_gecko):
     try_commit = trypush.TryFuzzyCommit(git_gecko, git_gecko, None, 0, hacks=False)
     job_id = env.lando.try_push(["patch"], "0" * 40)
 
-    assert try_commit.read_try_rev(job_id) == "%040x" % job_id
+    assert try_commit.read_try_rev(job_id, 10) == "%040x" % job_id
 
 
 def test_try_push_patches(env, try_push):


### PR DESCRIPTION
~~Update the logic for pushing to try to:~~
~~- run `mach try fuzzy --no-push`;~~
~~- create a commit with the the data from the mach execution;~~
~~- push this commit together with the others to try via Lando API;~~
~~- poll the Lando job status endpoint until the commits have landed to get hg commit hash;~~
~~- clean up the try commit.~~

New workflow:
- generate a token:  `/downstream/<sync id>/<try push uuid>`
- run `mach try fuzzy --write-task-config --env WPTSYNC_TRY_PUSH_TOKEN=/downstream/<sync id>/<try push uuid>`;
- create a commit;
- push this commit together with the others to try via Lando API;
- poll the Lando job status endpoint for 60s to make sure the commits have landed;
- if it takes longer, wait for a pulse event, use the task id to get task info, and get the token from the task info to find the right sync and try push and update it's status;
- clean up the try commit;
- if we missed the event for landing, use `wptsync pr` or `wptsync retrigger` to query the lando job status endpoint.